### PR TITLE
Exclude per user state human message from summarization

### DIFF
--- a/bili/nodes/trim_and_summarize.py
+++ b/bili/nodes/trim_and_summarize.py
@@ -154,9 +154,10 @@ def build_trim_and_summarize_node(
         user_profile_message = None 
         user_profile_message_id = None
         for message in all_messages:
-            if isinstance(message, HumanMessage) and message.content.startswith('USER PROFILE:'):
-                user_profile_message = message
-                user_profile_message_id = user_profile_message.id
+            if isinstance(message, HumanMessage):
+                if message.content.startswith('USER PROFILE:'):
+                    user_profile_message = message
+                    user_profile_message_id = user_profile_message.id
                 break
         # 1) Start by trimming messages, if needed, using either message or token count to trim by
         arguments = {

--- a/bili/nodes/trim_and_summarize.py
+++ b/bili/nodes/trim_and_summarize.py
@@ -157,7 +157,7 @@ def build_trim_and_summarize_node(
             if isinstance(message, HumanMessage) and message.content.startswith('USER PROFILE:'):
                 user_profile_message = message
                 user_profile_message_id = user_profile_message.id
-
+                break
         # 1) Start by trimming messages, if needed, using either message or token count to trim by
         arguments = {
             "max_tokens": k,

--- a/bili/nodes/trim_and_summarize.py
+++ b/bili/nodes/trim_and_summarize.py
@@ -151,6 +151,13 @@ def build_trim_and_summarize_node(
         )
         last_ai_message_id = last_ai_message.id if last_ai_message else None
 
+        user_profile_message = None 
+        user_profile_message_id = None
+        for message in all_messages:
+            if isinstance(message, HumanMessage) and message.content.startswith('USER PROFILE:'):
+                user_profile_message = message
+                user_profile_message_id = user_profile_message.id
+
         # 1) Start by trimming messages, if needed, using either message or token count to trim by
         arguments = {
             "max_tokens": k,
@@ -198,6 +205,7 @@ def build_trim_and_summarize_node(
         # they should never be removed. Also, exclude the last human and AI messages so
         # that even if we exceed the message or token limit, we don't remove the last interaction
         # with the user. This allows the conversation to continue from the last asked question.
+        # Also, Exclude the user profile message being loaded in by per_user_state.py
         removed_messages = [
             m
             for m in all_messages
@@ -205,6 +213,7 @@ def build_trim_and_summarize_node(
             and not isinstance(m, SystemMessage)
             and not m.id == last_human_message_id
             and not m.id == last_ai_message_id
+            and not m.id == user_profile_message_id
         ]
         LOGGER.trace(f"Removed messages after trimming: {removed_messages}")
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def read_http_git_requirements():
 
 setup(
     name="bili-core",
-    version="2.8.0",
+    version="2.8.1",
     packages=find_packages(),  # Automatically detect all packages
     install_requires=read_requirements(),  # Load only standard dependencies
     cmdclass={


### PR DESCRIPTION
Added check to exclude the user_profile_message being created by per_user_state. This prevents the LLM from summarizing the user profile data resulting in a conflict of dynamic data.


