### PR TITLE
Allow brackets in system prompt

### DIFF
--- a/bili/nodes/add_persona_and_summary.py
+++ b/bili/nodes/add_persona_and_summary.py
@@ -112,6 +112,17 @@ def build_add_persona_and_summary_node(persona: str, **kwargs):
             of the persona and conversation summary.
         :rtype: dict
         """
+        # Define custom dict class to override missing
+        # This will allow {} to exist in system prompts and only update keys
+        # found in the template_dict
+        class FormatDict(dict):
+            """
+            Support class for allowing a template string as a system prompt.
+            """
+            def __missing__(self, key):
+                LOGGER.warning("Key not found. Substituting with {%s}", key)
+                return "{" + key + "}" 
+
         # Retrieve the current list of messages from state for processing
         all_messages = state["messages"]
         LOGGER.trace(
@@ -132,7 +143,7 @@ def build_add_persona_and_summary_node(persona: str, **kwargs):
         # Check if template data should be seeded and seed it
         if template_dict is not None:
             # Use ** to unpack the dictionary for .format()
-            message_content = message_content.format(**template_dict)
+            message_content = message_content.format(**FormatDict(template_dict))
 
         if "summary" in state and state["summary"]:
             message_content += (

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def read_http_git_requirements():
 
 setup(
     name="bili-core",
-    version="2.8.2",
+    version="2.8.4",
     packages=find_packages(),  # Automatically detect all packages
     install_requires=read_requirements(),  # Load only standard dependencies
     cmdclass={


### PR DESCRIPTION
This fix allows brackets to exist in system prompts. If the bracket is a variable in the template dictionary it will be populated with the new value. otherwise the brackets will continue to exist as part of the system prompt.


