### PR TITLE
Missing keys in template strings support 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def read_http_git_requirements():
 
 setup(
     name="bili-core",
-    version="2.8.4",
+    version="2.8.5",
     packages=find_packages(),  # Automatically detect all packages
     install_requires=read_requirements(),  # Load only standard dependencies
     cmdclass={


### PR DESCRIPTION
Fixed an issue where template strings with missing keys would throw an error. 
This is done by a custom formatter that will only replace keys that exist and skip over all other keys.



