### PR TITLE
Updated vertex to allow specific response types

### DIFF
--- a/bili/config/llm_config.py
+++ b/bili/config/llm_config.py
@@ -516,6 +516,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 40,
+                "response_mime_type": "string",
+                "response_schema": {"type": "string"},
             },
             {
                 "model_name": "Gemini 2.5 Flash",
@@ -529,10 +531,12 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 40,
+                "response_mime_type": "string",
+                "response_schema": {"type": "string"},
             },
             {
                 "model_name": "Gemini 2.5 Flash Lite",
-                "model_id": "gemini-2.5-flash-lite-preview-06-17",
+                "model_id": "gemini-2.5-flash-lite",
                 "custom_model_path": False,
                 "max_input_tokens": 1000000,
                 "max_output_tokens": 65536,
@@ -542,6 +546,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 40,
+                "response_mime_type": "string",
+                "response_schema": {"type": "string"},
             },
             {
                 "model_name": "Gemini 2.0 Flash",

--- a/bili/loaders/llm_loader.py
+++ b/bili/loaders/llm_loader.py
@@ -358,7 +358,7 @@ def load_llamacpp_model(
 #    without Customer's prior permission or instruction."
 @conditional_cache_resource()
 def load_remote_gcp_vertex_model(
-    model_name, max_tokens=None, temperature=None, top_p=None, top_k=None, seed=None
+    model_name, max_tokens=None, temperature=None, top_p=None, top_k=None, seed=None, response_schema=None, response_mime_type=None
 ):
     """
     Loads a remote GCP Vertex AI model with the specified configuration parameters.
@@ -399,6 +399,10 @@ def load_remote_gcp_vertex_model(
         llm_config["top_k"] = top_k
     if seed:
         llm_config["seed"] = seed
+    if response_mime_type:
+        llm_config["response_mime_type"] = response_mime_type
+    if response_schema:
+        llm_config["response_schema"] = response_schema
 
     llm = ChatVertexAI(**llm_config)
 

--- a/bili/streamlit_ui/ui/chat_interface.py
+++ b/bili/streamlit_ui/ui/chat_interface.py
@@ -57,7 +57,7 @@ Example:
     # Run the application page
     run_app_page()
 """
-
+import json
 import streamlit as st
 from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.checkpoint.memory import MemorySaver
@@ -444,7 +444,7 @@ def display_model_configuration():
                 )
             if "memory_limit_trim_value" in st.session_state:
                 st.markdown(
-                    f"**Chat History 'trim_k' Value:** {st.session_state.get('memory_limit_trim_value')}"
+                    f"""**Chat History 'trim_k' Value:** {st.session_state.get('memory_limit_trim_value')}"""
                 )
 
         if st.session_state.get("supports_tools", True):
@@ -476,6 +476,30 @@ def load_system_components(checkpointer):
     :return: None
     """
     # Load the model that will be used for the conversation chain
+    model_kwargs = st.session_state.get("model_kwargs", {})
+
+    # Add Vertex AI specific parameters if using Google Vertex
+    if st.session_state["model_type"] == "remote_google_vertex":
+        # Handle custom response schema
+        if st.session_state.get("response_mime_type") == "application/json":
+            custom_schema = st.session_state.get("custom_response_schema")
+            if custom_schema:
+                try:
+                    parsed_schema = json.loads(custom_schema)
+                    model_kwargs["response_schema"] = parsed_schema
+                except json.JSONDecodeError:
+                    # Use default string schema if custom schema is invalid
+                    model_kwargs["response_schema"] = {"type": "string"}
+            else:
+                model_kwargs["response_schema"] = {"type": "string"}
+
+        # Handle MIME type
+        response_mime_type = st.session_state.get("response_mime_type", "text/plain")
+        if response_mime_type == "text/plain":
+            model_kwargs["response_mime_type"] = "text/plain"
+        elif response_mime_type == "application/json":
+            model_kwargs["response_mime_type"] = "application/json"
+
     model = load_model(
         model_type=st.session_state["model_type"],
         model_name=st.session_state["model_id"],
@@ -484,7 +508,7 @@ def load_system_components(checkpointer):
         top_p=st.session_state.get("top_p", None),
         top_k=st.session_state.get("top_k", None),
         seed=st.session_state.get("seed_value", None),
-        **st.session_state.get("model_kwargs", {}),
+        **model_kwargs,
     )
     st.session_state["model_config"] = model
 


### PR DESCRIPTION
- Updated google vertex LLM configurations to include response mime type and response schema.
- Updated the GCP vertex loader to allow response schema and response mime type.
- Added vertex specific handler to support the new response mime types and response schema.
- Added configuration UI in streamlit. The UI allows the user to upload custom json for the schema and provides examples.