### PR TITLE
Execution time wrapper node

### DIFF
--- a/bili/loaders/langchain_loader.py
+++ b/bili/loaders/langchain_loader.py
@@ -114,14 +114,17 @@ def wrap_node(node_func: Callable, node_name: str) -> Callable:
 
     :param node_func: The node function to wrap.
     :param node_name: The name of the node for logging purposes.
-    :return: A wrapped function that logs execution time.
+    :return: A wrapped function that logs execution time, or the node itself if it's a CompiledStateGraph.
     """
+    # Skip wrapping for CompiledStateGraph - let LangGraph handle it directly
+    if isinstance(node_func, CompiledStateGraph):
+        return node_func
+
     def wrapper(*args, **kwargs):
         start_time = time.time()
         result = node_func(*args, **kwargs)
-        end_time = time.time()
-        execution_time = end_time - start_time
-        LOGGER.info(f"Node '{node_name}' executed in {execution_time:.4f} seconds")
+        execution_time = (time.time() - start_time) * 1000
+        LOGGER.info(f"Node '{node_name}' executed in {execution_time:.2f} ms")
         return result
     return wrapper
 

--- a/bili/loaders/langchain_loader.py
+++ b/bili/loaders/langchain_loader.py
@@ -52,6 +52,7 @@ agent_graph = build_agent_graph(
 
 import difflib
 import logging
+import time
 from typing import Callable
 
 import langchain
@@ -105,6 +106,24 @@ DEFAULT_GRAPH_DEFINITION = [
     "trim_summarize",
     "normalize_state",
 ]
+
+
+def wrap_node(node_func: Callable, node_name: str) -> Callable:
+    """
+    Wraps a node function to log its execution time.
+
+    :param node_func: The node function to wrap.
+    :param node_name: The name of the node for logging purposes.
+    :return: A wrapped function that logs execution time.
+    """
+    def wrapper(*args, **kwargs):
+        start_time = time.time()
+        result = node_func(*args, **kwargs)
+        end_time = time.time()
+        execution_time = end_time - start_time
+        LOGGER.info(f"Node '{node_name}' executed in {execution_time:.4f} seconds")
+        return result
+    return wrapper
 
 
 def build_agent_graph(
@@ -170,6 +189,7 @@ def build_agent_graph(
             )
         builder = node_registry[node_name]
         nodes[node_name] = builder(**node_kwargs)
+        nodes[node_name] = wrap_node(nodes[node_name], node_name)
         graph.add_node(node_name, nodes[node_name])
 
     # Add edges between nodes in the graph

--- a/bili/loaders/langchain_loader.py
+++ b/bili/loaders/langchain_loader.py
@@ -114,15 +114,15 @@ def wrap_node(node_func: Callable, node_name: str) -> Callable:
 
     :param node_func: The node function to wrap.
     :param node_name: The name of the node for logging purposes.
-    :return: A wrapped function that logs execution time, or the node itself if it's a CompiledStateGraph.
+    :return: A wrapped function that logs execution time.
     """
-    # Skip wrapping for CompiledStateGraph - let LangGraph handle it directly
-    if isinstance(node_func, CompiledStateGraph):
-        return node_func
-
     def wrapper(*args, **kwargs):
         start_time = time.time()
-        result = node_func(*args, **kwargs)
+        # CompiledStateGraph objects need to use .invoke() method
+        if isinstance(node_func, CompiledStateGraph):
+            result = node_func.invoke(*args, **kwargs)
+        else:
+            result = node_func(*args, **kwargs)
         execution_time = (time.time() - start_time) * 1000
         LOGGER.info(f"Node '{node_name}' executed in {execution_time:.2f} ms")
         return result

--- a/bili/nodes/react_agent_node.py
+++ b/bili/nodes/react_agent_node.py
@@ -96,11 +96,16 @@ def build_react_agent_node(
     if tools is not None:
         # If tools are supported, create a REACT agent with the provided tools
         LOGGER.debug("Creating REACT agent with tools: %s", tools)
-        agent = create_react_agent(
+        compiled_agent = create_react_agent(
             model=llm_model,
             state_schema=state,
             tools=tools,
         )
+
+        # Wrap the compiled agent in a callable function so it can be used as a node
+        # (CompiledStateGraph can't be added directly as a node)
+        def agent(state: State):
+            return compiled_agent.invoke(state)
     else:
         LOGGER.debug(
             "TOOLS not supported for this LLM. Creating a simple graph node to invoke the LLM"

--- a/bili/nodes/react_agent_node.py
+++ b/bili/nodes/react_agent_node.py
@@ -96,16 +96,11 @@ def build_react_agent_node(
     if tools is not None:
         # If tools are supported, create a REACT agent with the provided tools
         LOGGER.debug("Creating REACT agent with tools: %s", tools)
-        compiled_agent = create_react_agent(
+        agent = create_react_agent(
             model=llm_model,
             state_schema=state,
             tools=tools,
         )
-
-        # Wrap the compiled agent in a callable function so it can be used as a node
-        # (CompiledStateGraph can't be added directly as a node)
-        def agent(state: State):
-            return compiled_agent.invoke(state)
     else:
         LOGGER.debug(
             "TOOLS not supported for this LLM. Creating a simple graph node to invoke the LLM"


### PR DESCRIPTION
Added a timing wrapper around each node when its being built. This will log the execution time of each node in ms. 
For example: 
- Node 'react_agent' executed in 764.50 ms


