### PR TITLE
Redesign AETHER MAS schema for domain-agnostic configuration

### DIFF
--- a/bili/aether/README.md
+++ b/bili/aether/README.md
@@ -1,130 +1,155 @@
 # AETHER: Agent Ecosystems for Testing, Hardening, Evaluation, and Research
 
-AETHER is a multi-agent system (MAS) security testing framework built as an extension to bili-core. It enables researchers to declaratively configure multi-agent systems and test security vulnerabilities specific to LLM-based agent architectures.
+AETHER is a domain-agnostic multi-agent system (MAS) framework built as an extension to bili-core. It enables declarative configuration of multi-agent systems for any domain - research, content moderation, code review, customer support, and more.
 
-## Overview
+## Design Philosophy
 
-AETHER extends bili-core's single-agent conversational AI capabilities to support multi-agent orchestration with a focus on security testing. It inherits all bili-core features (LLM providers, tools, authentication, state persistence) while adding capabilities for:
+AETHER uses a **domain-agnostic** design where agent roles and capabilities are **free-form strings**, not restrictive enums. This means:
 
-- Declarative multi-agent system configuration
-- Agent-to-agent communication protocols
-- Security attack vector testing and metrics
-- Transparent agent communication logging
-- Checkpoint persistence vulnerability analysis
+- **Any role**: Define agents with any role you need (`researcher`, `security_engineer`, `content_reviewer`, etc.)
+- **Any capabilities**: Specify any capabilities as strings (`web_search`, `code_analysis`, `policy_lookup`, etc.)
+- **Presets for convenience**: Use built-in presets for common patterns without being restricted to them
+- **Full flexibility**: The framework doesn't impose domain-specific constraints
+
+## Quick Start
+
+### Create an Agent (Domain-Agnostic)
+
+```python
+from bili.aether.schema import AgentSpec
+
+# Any role and capabilities - not restricted to enums
+agent = AgentSpec(
+    agent_id="my_researcher",
+    role="senior_researcher",  # Free-form string
+    objective="Research and analyze AI developments",
+    capabilities=["web_search", "document_analysis"],  # Free-form strings
+    tools=["serp_api_tool"],
+)
+```
+
+### Use Presets for Common Patterns
+
+```python
+from bili.aether.schema import create_agent_from_preset, list_presets
+
+# See available presets
+print(list_presets())
+# ['content_reviewer', 'researcher', 'code_reviewer', 'supervisor', ...]
+
+# Create from preset with optional overrides
+agent = create_agent_from_preset(
+    preset_name="researcher",
+    agent_id="ai_researcher",
+    objective="Research quantum computing advances",
+    temperature=0.6,  # Override preset default
+)
+```
+
+### Register Custom Presets
+
+```python
+from bili.aether.schema import register_preset, create_agent_from_preset
+
+# Register your own preset
+register_preset("my_custom_agent", {
+    "role": "domain_expert",
+    "capabilities": ["specialized_analysis", "reporting"],
+    "temperature": 0.3,
+})
+
+# Use it
+agent = create_agent_from_preset(
+    preset_name="my_custom_agent",
+    agent_id="expert_1",
+    objective="Provide domain expertise",
+)
+```
+
+## Example Workflows
+
+AETHER includes example YAML configurations for multiple domains:
+
+### Content Moderation
+- `simple_chain.yaml` - Sequential review pipeline
+- `hierarchical_voting.yaml` - Tiered debate and voting
+- `supervisor_moderation.yaml` - Supervisor-routed specialists
+- `consensus_network.yaml` - Peer deliberation
+- `custom_escalation.yaml` - Human-in-the-loop
+
+### Research (Domain-Agnostic)
+- `research_analysis.yaml` - Research → Fact-check → Analyze → Synthesize
+
+### Software Engineering (Domain-Agnostic)
+- `code_review.yaml` - Lead engineer routes to security/performance/style reviewers
 
 ## Architecture
 
 ```
 bili/aether/
-├── __init__.py           # Package initialization
+├── __init__.py           # Package exports
 ├── README.md             # This file
-├── schema/               # MAS configuration data models
-├── validation/           # MAS configuration validation
-├── compiler/             # AETHER → LangGraph translation
-├── communication/        # Agent messaging protocol
-├── execution/            # MAS runtime controller
-└── attacks/              # Security testing framework
+├── schema/               # MAS configuration schemas
+│   ├── agent_spec.py     # Domain-agnostic AgentSpec
+│   ├── agent_presets.py  # Preset registry system
+│   ├── mas_config.py     # MASConfig, Channel, WorkflowEdge
+│   └── enums.py          # Structural enums only (WorkflowType, etc.)
+├── config/               # YAML loading and examples
+│   ├── loader.py         # load_mas_from_yaml, load_mas_from_dict
+│   └── examples/         # Example YAML configurations
+└── tests/                # Test suite
 ```
 
 ## Integration with bili-core
 
-AETHER agents are bili-core agents with additional capabilities:
+AETHER agents inherit all bili-core capabilities:
 
 ### Inherited from bili-core:
-
 - LLM model selection and configuration
 - System prompt customization
 - Tool access (FAISS, Weather APIs, SerpAPI, etc.)
 - State persistence (MongoDB/PostgreSQL checkpointing)
-- Conversation state management
-- Authentication (Firebase, In-Memory)
 - Memory management strategies
+- Authentication (Firebase, In-Memory)
 
 ### Added by AETHER:
-
-- Agent objectives within MAS context
-- Output format specification (not just chat)
+- Multi-agent orchestration patterns
 - Agent-to-agent communication channels
-- Security attack injection points
-- Communication transparency logging
-- Multi-agent orchestration
+- Workflow type support (sequential, hierarchical, supervisor, consensus)
+- Domain-agnostic agent configuration
+- Preset system for common patterns
 
-## Example Usage (Post Task 5)
+## Workflow Types
 
-```python
-from bili.aether.schema import AgentSpec, AgentRole
-from bili.aether.compiler import compile_mas_to_langgraph
+AETHER supports multiple workflow patterns:
 
-# Define a simple 2-agent MAS
-agents = [
-    AgentSpec(
-        agent_id="reviewer",
-        role=AgentRole.REVIEWER,
-        objective="Review content for policy violations",
-        llm_model="claude-sonnet-4",
-        tools=["faiss_search"],
-    ),
-    AgentSpec(
-        agent_id="policy_expert",
-        role=AgentRole.POLICY,
-        objective="Provide policy guidance to reviewer",
-        llm_model="gpt-4",
-        tools=[],
-    ),
-]
+| Type | Description | Use Case |
+|------|-------------|----------|
+| `sequential` | Chain of agents (A → B → C) | Step-by-step processing |
+| `hierarchical` | Tiered voting with debate | Decision making with multiple perspectives |
+| `supervisor` | Hub-and-spoke routing | Dynamic task delegation |
+| `consensus` | Peer deliberation network | Collaborative decision making |
+| `parallel` | Simultaneous execution | Independent parallel tasks |
+| `custom` | User-defined edges | Complex custom workflows |
 
-# Compile to executable LangGraph
-graph = compile_mas_to_langgraph(agents, channels=[...])
-
-# Execute MAS
-result = graph.invoke({"input": "User query here"})
-```
-
-## Research Focus
-
-AETHER is designed to support cybersecurity research on multi-agent LLM systems, specifically:
-
-1. **Prompt Injection Attacks**: Single and multi-agent injection scenarios
-2. **Memory Poisoning**: Persistent malicious state across agent interactions
-3. **Bias Inheritance**: Propagation of biased outputs through agent chains
-4. **Agent Impersonation**: Identity spoofing in multi-agent communications
-5. **Checkpoint Persistence**: Attack payload survival through state checkpointing
-6. **Cross-Model Transferability**: Attack effectiveness across different LLM providers
-
-## Development Guidelines
-
-### Code Style
-
-- Follow bili-core's existing code style (Black formatting, pylint compliance)
-- Use type hints for all function signatures
-- Document all public APIs with docstrings
-- Write unit tests for all new functionality
-
-### Integration Points
-
-When developing AETHER modules, leverage existing bili-core infrastructure:
-
-```python
-# Use bili-core's LLM loaders
-from bili.loaders.langchain_loader import load_langgraph_agent
-
-# Use bili-core's checkpointers
-from bili.checkpointers.mongodb_checkpoint import MongoDBCheckpointer
-
-# Use bili-core's tool configuration
-from bili.tools import faiss_memory_indexing, api_serp
-```
+## Development
 
 ### Testing
 
-- Place tests in `tests/aether/` (parallel to module structure)
-- Use pytest for all testing
-- Aim for >80% code coverage
-- Test against multiple LLM providers when possible
+```bash
+# Run AETHER tests in isolation (avoids heavy bili-core dependencies)
+python bili/aether/tests/run_tests.py -v
+```
+
+### Code Style
+
+- Follow bili-core's existing style (Black formatting, pylint compliance)
+- Use type hints for all function signatures
+- Document all public APIs with docstrings
 
 ## Contributing
 
-AETHER is part of ongoing cybersecurity research at MSU Denver. For questions or contributions, please refer to the main bili-core repository guidelines.
+AETHER is part of ongoing research at MSU Denver. For questions or contributions, please refer to the main bili-core repository guidelines.
 
 ## License
 
@@ -132,6 +157,6 @@ MIT License - See LICENSE file in the repository root.
 
 ---
 
-**AETHER Version:** 0.0.1  
-**Last Updated:** January 26, 2026  
+**AETHER Version:** 0.1.0
+**Last Updated:** February 2, 2026
 **bili-core Version Required:** ≥3.0.0

--- a/bili/aether/__init__.py
+++ b/bili/aether/__init__.py
@@ -1,32 +1,33 @@
 """
 AETHER: Agent Ecosystems for Testing, Hardening, Evaluation, and Research
 
-AETHER is a multi-agent system (MAS) security testing framework built as an
-extension to bili-core. It enables declarative configuration of multi-agent
-systems for testing security vulnerabilities in LLM-based agent architectures.
+AETHER is a multi-agent system (MAS) framework built as an extension to
+bili-core. It enables declarative configuration of multi-agent systems
+for any domain - research, content moderation, code review, and more.
+
+Design Philosophy:
+- Domain-agnostic: Agent roles and capabilities are free-form strings
+- Preset system: Common patterns available without restrictions
+- Extensible: Register custom presets at runtime
+- bili-core integration: Inherit LLM, tool, and state management features
 
 Core Capabilities:
 - Multi-agent system configuration and orchestration
 - Agent-to-agent communication protocols
-- Security attack vector testing (prompt injection, memory poisoning, etc.)
+- Multiple workflow patterns (sequential, hierarchical, supervisor, consensus)
 - Transparent agent communication logging
-- Integration with bili-core's LLM, tool, and state management features
-
-AETHER extends bili-core's single-agent RAG workflows to support complex
-multi-agent security testing scenarios while inheriting all bili-core
-capabilities (authentication, checkpointing, tool access, LLM configuration).
+- Full bili-core integration (auth, checkpoints, tools, LLMs)
 
 Author: MSU Denver Cybersecurity Research
 License: MIT
 """
 
-__version__ = "0.0.6"
+__version__ = "0.1.0"
 __author__ = "MSU Denver Cybersecurity Research, MonRos3"
 
 from .config import load_mas_from_dict, load_mas_from_yaml
 from .schema import (
-    AgentCapability,
-    AgentRole,
+    AGENT_PRESETS,
     AgentSpec,
     Channel,
     CommunicationProtocol,
@@ -34,6 +35,10 @@ from .schema import (
     OutputFormat,
     WorkflowEdge,
     WorkflowType,
+    create_agent_from_preset,
+    get_preset,
+    list_presets,
+    register_preset,
 )
 
 __all__ = [
@@ -44,12 +49,16 @@ __all__ = [
     "MASConfig",
     "Channel",
     "WorkflowEdge",
-    # Enums
-    "AgentRole",
-    "AgentCapability",
+    # Structural enums
     "OutputFormat",
     "WorkflowType",
     "CommunicationProtocol",
+    # Preset system
+    "AGENT_PRESETS",
+    "create_agent_from_preset",
+    "get_preset",
+    "list_presets",
+    "register_preset",
     # Config loaders
     "load_mas_from_yaml",
     "load_mas_from_dict",

--- a/bili/aether/config/examples/code_review.yaml
+++ b/bili/aether/config/examples/code_review.yaml
@@ -1,0 +1,121 @@
+# =============================================================================
+# Code Review Workflow (Domain-Agnostic Example)
+# =============================================================================
+#
+# This example demonstrates AETHER's domain-agnostic design with a
+# software engineering use case - code review.
+#
+# Pattern: Supervisor routes code to specialized reviewers
+#
+# Use case: A lead engineer receives code for review and routes it to
+# specialist reviewers (security, performance, style) who provide feedback,
+# which is then synthesized into a final review.
+# =============================================================================
+
+mas_id: code_review
+name: Code Review Pipeline
+description: >
+  A supervisor-based code review workflow where a lead engineer routes
+  code to specialist reviewers (security, performance, style) and
+  synthesizes their feedback into a final review.
+version: "1.0.0"
+
+workflow_type: supervisor
+entry_point: lead_engineer
+
+agents:
+  - agent_id: lead_engineer
+    role: lead_engineer
+    objective: >
+      Review incoming code submissions and route them to appropriate
+      specialist reviewers based on the type of changes. Synthesize
+      reviewer feedback into a final code review decision.
+    temperature: 0.2
+    is_supervisor: true
+    capabilities:
+      - code_analysis
+      - task_routing
+      - feedback_synthesis
+    output_format: json
+
+  - agent_id: security_reviewer
+    role: security_engineer
+    objective: >
+      Review code for security vulnerabilities including injection attacks,
+      authentication issues, data exposure, and OWASP Top 10 concerns.
+      Provide detailed security recommendations.
+    temperature: 0.1
+    capabilities:
+      - vulnerability_detection
+      - security_analysis
+      - threat_modeling
+    output_format: json
+
+  - agent_id: performance_reviewer
+    role: performance_engineer
+    objective: >
+      Analyze code for performance issues including algorithmic complexity,
+      memory usage, database query efficiency, and potential bottlenecks.
+      Suggest optimizations where appropriate.
+    temperature: 0.2
+    capabilities:
+      - performance_analysis
+      - complexity_analysis
+      - optimization_suggestions
+    output_format: json
+
+  - agent_id: style_reviewer
+    role: code_quality_engineer
+    objective: >
+      Review code for style consistency, readability, maintainability,
+      and adherence to coding standards. Check documentation and naming
+      conventions.
+    temperature: 0.3
+    capabilities:
+      - style_analysis
+      - readability_assessment
+      - documentation_review
+    output_format: json
+
+channels:
+  - channel_id: lead_to_security
+    protocol: direct
+    source: lead_engineer
+    target: security_reviewer
+    description: Code routed to security reviewer
+
+  - channel_id: lead_to_performance
+    protocol: direct
+    source: lead_engineer
+    target: performance_reviewer
+    description: Code routed to performance reviewer
+
+  - channel_id: lead_to_style
+    protocol: direct
+    source: lead_engineer
+    target: style_reviewer
+    description: Code routed to style reviewer
+
+  - channel_id: security_to_lead
+    protocol: direct
+    source: security_reviewer
+    target: lead_engineer
+    description: Security review feedback returned
+
+  - channel_id: performance_to_lead
+    protocol: direct
+    source: performance_reviewer
+    target: lead_engineer
+    description: Performance review feedback returned
+
+  - channel_id: style_to_lead
+    protocol: direct
+    source: style_reviewer
+    target: lead_engineer
+    description: Style review feedback returned
+
+tags:
+  - code-review
+  - software-engineering
+  - supervisor
+  - domain-agnostic

--- a/bili/aether/config/examples/hierarchical_voting.yaml
+++ b/bili/aether/config/examples/hierarchical_voting.yaml
@@ -99,8 +99,7 @@ agents:
   # =========================================================================
 
   - agent_id: content_agent
-    role: custom
-    custom_role_name: Content Agent
+    role: content_aggregator
     objective: >
       Receive the arguments from the allow and block content agents
       and determine what verdict to pass to the vote agent based on
@@ -114,8 +113,7 @@ agents:
     output_format: json
 
   - agent_id: policy_agent
-    role: custom
-    custom_role_name: Policy Agent
+    role: policy_aggregator
     objective: >
       Receive the arguments from the allow and block policy agents
       and determine what verdict to pass to the vote agent based on

--- a/bili/aether/config/examples/research_analysis.yaml
+++ b/bili/aether/config/examples/research_analysis.yaml
@@ -1,0 +1,104 @@
+# =============================================================================
+# Research Analysis Workflow (Domain-Agnostic Example)
+# =============================================================================
+#
+# This example demonstrates AETHER's domain-agnostic design by showing
+# a research workflow that has nothing to do with content moderation.
+#
+# Pattern: researcher → fact_checker → analyst → synthesizer
+#
+# Use case: Analyze a research topic by gathering information, verifying
+# facts, performing analysis, and synthesizing a final report.
+# =============================================================================
+
+mas_id: research_analysis
+name: Research Analysis Pipeline
+description: >
+  A four-stage research pipeline demonstrating AETHER's domain-agnostic
+  design. Agents have custom roles like researcher, fact_checker, analyst,
+  and synthesizer - not limited to content moderation roles.
+version: "1.0.0"
+
+workflow_type: sequential
+
+agents:
+  - agent_id: researcher
+    role: researcher
+    objective: >
+      Search for and gather information on the given research topic.
+      Compile relevant sources, data points, and findings for further
+      analysis by downstream agents.
+    temperature: 0.5
+    capabilities:
+      - web_search
+      - document_analysis
+      - source_gathering
+    tools:
+      - serp_api_tool
+    output_format: json
+
+  - agent_id: fact_checker
+    role: fact_checker
+    objective: >
+      Verify the claims and data gathered by the researcher. Cross-reference
+      sources, identify potential inaccuracies, and flag claims that need
+      additional verification.
+    temperature: 0.2
+    capabilities:
+      - source_verification
+      - claim_analysis
+      - web_search
+    tools:
+      - serp_api_tool
+    output_format: json
+
+  - agent_id: analyst
+    role: analyst
+    objective: >
+      Analyze the verified research findings. Identify patterns, trends,
+      and insights. Provide quantitative and qualitative analysis of the
+      data gathered by previous agents.
+    temperature: 0.3
+    capabilities:
+      - data_analysis
+      - pattern_recognition
+      - statistical_reasoning
+    output_format: json
+
+  - agent_id: synthesizer
+    role: synthesizer
+    objective: >
+      Synthesize all research, fact-checking, and analysis into a coherent
+      final report. Summarize key findings, highlight important insights,
+      and provide recommendations based on the analysis.
+    temperature: 0.4
+    capabilities:
+      - report_writing
+      - summarization
+      - insight_generation
+    output_format: text
+
+channels:
+  - channel_id: researcher_to_factchecker
+    protocol: direct
+    source: researcher
+    target: fact_checker
+    description: Raw research findings sent for fact-checking
+
+  - channel_id: factchecker_to_analyst
+    protocol: direct
+    source: fact_checker
+    target: analyst
+    description: Verified findings sent for analysis
+
+  - channel_id: analyst_to_synthesizer
+    protocol: direct
+    source: analyst
+    target: synthesizer
+    description: Analysis results sent for final synthesis
+
+tags:
+  - research
+  - analysis
+  - sequential
+  - domain-agnostic

--- a/bili/aether/schema/__init__.py
+++ b/bili/aether/schema/__init__.py
@@ -4,36 +4,53 @@ AETHER Schema Module
 Pydantic models for defining multi-agent system configurations,
 agent specifications, and communication channel definitions.
 
+Design Philosophy:
+- Agent roles and capabilities are free-form strings (not enums)
+- Use presets for convenience without restrictions
+- Structural enums (WorkflowType, OutputFormat, etc.) are still used
+
 Modules:
-- agent_spec.py: Agent configuration schema
+- agent_spec.py: Domain-agnostic agent configuration schema
+- agent_presets.py: Registry-based preset system for common patterns
 - mas_config.py: Multi-agent system configuration schema
-- enums.py: Shared enumerations
+- enums.py: Structural enumerations (workflow types, protocols, etc.)
 """
 
 # Agent specification
 from .agent_spec import AgentSpec
 
-# Enums
+# Agent presets
+from .agent_presets import (
+    AGENT_PRESETS,
+    create_agent_from_preset,
+    get_preset,
+    list_presets,
+    register_preset,
+)
+
+# Structural enums only (no domain-specific enums)
 from .enums import (
-    AgentCapability,
-    AgentRole,
     CommunicationProtocol,
     OutputFormat,
     WorkflowType,
 )
 
-# MAS configuration (Task 3, but available now)
+# MAS configuration
 from .mas_config import Channel, MASConfig, WorkflowEdge
 
 __all__ = [
-    # Enums
-    "AgentRole",
-    "AgentCapability",
+    # Structural enums
     "OutputFormat",
     "WorkflowType",
     "CommunicationProtocol",
     # Agent
     "AgentSpec",
+    # Presets
+    "AGENT_PRESETS",
+    "create_agent_from_preset",
+    "get_preset",
+    "list_presets",
+    "register_preset",
     # MAS
     "MASConfig",
     "Channel",

--- a/bili/aether/schema/agent_presets.py
+++ b/bili/aether/schema/agent_presets.py
@@ -1,0 +1,254 @@
+"""
+Agent preset system for AETHER.
+
+Provides pre-defined configurations for common agent patterns.
+Presets offer convenience without restrictions - users can always
+define custom agents with any role and capabilities.
+"""
+
+from typing import Any, Dict, Optional
+
+from .agent_spec import AgentSpec
+
+
+# =============================================================================
+# PRESET REGISTRY
+# =============================================================================
+
+AGENT_PRESETS: Dict[str, Dict[str, Any]] = {
+    # -------------------------------------------------------------------------
+    # Content Moderation Presets
+    # -------------------------------------------------------------------------
+    "content_reviewer": {
+        "role": "content_reviewer",
+        "capabilities": ["text_analysis", "policy_enforcement"],
+        "temperature": 0.3,
+    },
+    "policy_expert": {
+        "role": "policy_expert",
+        "capabilities": ["policy_lookup", "rule_interpretation"],
+        "temperature": 0.2,
+    },
+    "moderator_judge": {
+        "role": "judge",
+        "capabilities": ["decision_making", "evidence_synthesis"],
+        "temperature": 0.1,
+    },
+    "appeals_specialist": {
+        "role": "appeals_specialist",
+        "capabilities": ["context_analysis", "precedent_lookup"],
+        "temperature": 0.3,
+    },
+    # -------------------------------------------------------------------------
+    # Research & Analysis Presets
+    # -------------------------------------------------------------------------
+    "researcher": {
+        "role": "researcher",
+        "capabilities": ["web_search", "document_analysis", "summarization"],
+        "tools": ["serp_api_tool"],
+        "temperature": 0.5,
+    },
+    "analyst": {
+        "role": "analyst",
+        "capabilities": ["data_analysis", "pattern_recognition", "reporting"],
+        "temperature": 0.3,
+    },
+    "fact_checker": {
+        "role": "fact_checker",
+        "capabilities": ["web_search", "source_verification", "claim_analysis"],
+        "tools": ["serp_api_tool"],
+        "temperature": 0.2,
+    },
+    # -------------------------------------------------------------------------
+    # Code & Technical Presets
+    # -------------------------------------------------------------------------
+    "code_reviewer": {
+        "role": "code_reviewer",
+        "capabilities": ["static_analysis", "best_practices", "security_scanning"],
+        "temperature": 0.2,
+    },
+    "security_auditor": {
+        "role": "security_auditor",
+        "capabilities": ["vulnerability_detection", "threat_modeling"],
+        "temperature": 0.1,
+    },
+    "documentation_writer": {
+        "role": "documentation_writer",
+        "capabilities": ["technical_writing", "code_explanation"],
+        "temperature": 0.4,
+    },
+    # -------------------------------------------------------------------------
+    # Customer Support Presets
+    # -------------------------------------------------------------------------
+    "support_agent": {
+        "role": "support_agent",
+        "capabilities": ["ticket_handling", "knowledge_base_search"],
+        "tools": ["faiss_retriever"],
+        "temperature": 0.4,
+    },
+    "escalation_specialist": {
+        "role": "escalation_specialist",
+        "capabilities": ["complex_issue_resolution", "customer_advocacy"],
+        "temperature": 0.3,
+    },
+    # -------------------------------------------------------------------------
+    # Workflow Pattern Presets
+    # -------------------------------------------------------------------------
+    "supervisor": {
+        "role": "supervisor",
+        "capabilities": ["task_routing", "agent_coordination", "quality_control"],
+        "is_supervisor": True,
+        "temperature": 0.2,
+    },
+    "consensus_voter": {
+        "role": "voter",
+        "capabilities": ["evaluation", "voting"],
+        "output_format": "json",
+        "temperature": 0.3,
+    },
+    "debate_advocate": {
+        "role": "advocate",
+        "capabilities": ["argumentation", "evidence_presentation"],
+        "temperature": 0.5,
+    },
+}
+
+
+# =============================================================================
+# PRESET FUNCTIONS
+# =============================================================================
+
+
+def register_preset(name: str, preset: Dict[str, Any]) -> None:
+    """
+    Register a custom preset at runtime.
+
+    Args:
+        name: Unique preset name
+        preset: Dict with AgentSpec fields to use as defaults
+
+    Examples:
+        >>> register_preset("my_agent", {
+        ...     "role": "custom_role",
+        ...     "capabilities": ["cap1", "cap2"],
+        ...     "temperature": 0.5,
+        ... })
+    """
+    AGENT_PRESETS[name] = preset
+
+
+def get_preset(name: str) -> Optional[Dict[str, Any]]:
+    """
+    Get a preset by name.
+
+    Args:
+        name: Preset name
+
+    Returns:
+        Preset dict or None if not found
+    """
+    return AGENT_PRESETS.get(name)
+
+
+def list_presets() -> list:
+    """
+    List all available preset names.
+
+    Returns:
+        List of preset names
+    """
+    return list(AGENT_PRESETS.keys())
+
+
+def create_agent_from_preset(
+    preset_name: str,
+    agent_id: str,
+    objective: str,
+    **overrides,
+) -> AgentSpec:
+    """
+    Create an AgentSpec from a preset with optional overrides.
+
+    Args:
+        preset_name: Name of preset to use
+        agent_id: Unique agent ID (required)
+        objective: Agent objective (required)
+        **overrides: Any AgentSpec fields to override
+
+    Returns:
+        Configured AgentSpec instance
+
+    Raises:
+        ValueError: If preset not found
+
+    Examples:
+        >>> # Create researcher from preset
+        >>> agent = create_agent_from_preset(
+        ...     preset_name="researcher",
+        ...     agent_id="my_researcher",
+        ...     objective="Research quantum computing advances"
+        ... )
+
+        >>> # Create with overrides
+        >>> agent = create_agent_from_preset(
+        ...     preset_name="code_reviewer",
+        ...     agent_id="senior_reviewer",
+        ...     objective="Review Python code for security",
+        ...     temperature=0.1,
+        ...     capabilities=["python_analysis", "security_focus"]
+        ... )
+    """
+    preset = get_preset(preset_name)
+    if preset is None:
+        raise ValueError(
+            f"Unknown preset: {preset_name}. "
+            f"Available: {list_presets()}"
+        )
+
+    # Merge preset with overrides
+    config = {
+        **preset,
+        "agent_id": agent_id,
+        "objective": objective,
+        **overrides,
+    }
+
+    return AgentSpec(**config)
+
+
+# =============================================================================
+# EXAMPLE USAGE
+# =============================================================================
+
+if __name__ == "__main__":
+    print("Available presets:", list_presets())
+
+    # Create agent from preset
+    researcher = create_agent_from_preset(
+        preset_name="researcher",
+        agent_id="tech_researcher",
+        objective="Research and summarize AI developments",
+    )
+    print(f"\nResearcher: {researcher}")
+    print(f"  Role: {researcher.role}")
+    print(f"  Capabilities: {researcher.capabilities}")
+    print(f"  Temperature: {researcher.temperature}")
+
+    # Create with overrides
+    custom_reviewer = create_agent_from_preset(
+        preset_name="code_reviewer",
+        agent_id="python_expert",
+        objective="Review Python code for best practices",
+        temperature=0.1,
+        capabilities=["python_analysis", "pep8_compliance", "type_checking"],
+    )
+    print(f"\nCustom Reviewer: {custom_reviewer}")
+    print(f"  Capabilities: {custom_reviewer.capabilities}")
+
+    # Register custom preset
+    register_preset("my_custom_agent", {
+        "role": "custom_role",
+        "capabilities": ["custom_cap"],
+        "temperature": 0.4,
+    })
+    print(f"\nAfter registering custom preset: {list_presets()}")

--- a/bili/aether/schema/enums.py
+++ b/bili/aether/schema/enums.py
@@ -1,52 +1,12 @@
 """
 Enumerations for AETHER schema.
 
-This module defines all enum types used across agent and MAS configurations.
+This module defines structural enum types used across MAS configurations.
+Note: Agent roles and capabilities are intentionally NOT enums - they are
+free-form strings to support any domain without code changes.
 """
 
 from enum import Enum
-
-
-class AgentRole(str, Enum):
-    """
-    Agent roles for content moderation MAS.
-
-    Includes bili-core standard roles and new roles for your 5 MAS patterns.
-    """
-
-    # bili-core standard roles (Task 7 integration)
-    CONTENT_REVIEWER = "content_reviewer"
-    POLICY_EXPERT = "policy_expert"
-    JUDGE = "judge"
-    APPEALS_SPECIALIST = "appeals_specialist"
-    COMMUNITY_MANAGER = "community_manager"
-
-    # NEW: Adversarial/debate roles (MAS #2 - Hierarchical)
-    ALLOW_ADVOCATE = "allow_advocate"
-    BLOCK_ADVOCATE = "block_advocate"
-
-    # Catch-all for custom roles
-    CUSTOM = "custom"
-
-
-class AgentCapability(str, Enum):
-    """
-    Agent capabilities (features an agent can use).
-
-    These correspond to bili-core features and LangGraph capabilities.
-    """
-
-    # bili-core integration
-    RAG_RETRIEVAL = "rag_retrieval"
-    POLICY_LOOKUP = "policy_lookup"
-    MEMORY_ACCESS = "memory_access"
-
-    # LangGraph features
-    CHECKPOINT_PERSISTENCE = "checkpoint_persistence"
-    TOOL_CALLING = "tool_calling"
-
-    # Communication
-    INTER_AGENT_COMMUNICATION = "inter_agent_communication"
 
 
 class OutputFormat(str, Enum):
@@ -65,12 +25,14 @@ class WorkflowType(str, Enum):
     """
     MAS workflow execution patterns.
 
-    Maps to your 5 MAS configurations:
-    - SEQUENTIAL: MAS #1 (Chain)
-    - HIERARCHICAL: MAS #2 (Tree/voting)
-    - SUPERVISOR: MAS #3 (Hub-and-spoke)
-    - CONSENSUS: MAS #4 (Network/deliberation)
-    - DELIBERATIVE: MAS #5 (Custom with escalation)
+    Maps to common multi-agent patterns:
+    - SEQUENTIAL: Chain pattern (A -> B -> C)
+    - HIERARCHICAL: Tree/voting pattern with tiers
+    - SUPERVISOR: Hub-and-spoke pattern
+    - CONSENSUS: Network/deliberation pattern
+    - DELIBERATIVE: Custom with escalation
+    - PARALLEL: All agents execute simultaneously
+    - CUSTOM: User-defined workflow with explicit edges
     """
 
     SEQUENTIAL = "sequential"
@@ -89,11 +51,9 @@ class CommunicationProtocol(str, Enum):
     Defines how agents exchange messages.
     """
 
-    DIRECT = "direct"  # Point-to-point: A → B
-    BROADCAST = "broadcast"  # One-to-many: A → All
-    REQUEST_RESPONSE = "request_response"  # Bidirectional: A ↔ B
+    DIRECT = "direct"  # Point-to-point: A -> B
+    BROADCAST = "broadcast"  # One-to-many: A -> All
+    REQUEST_RESPONSE = "request_response"  # Bidirectional: A <-> B
     PUBSUB = "pubsub"  # Publish-subscribe pattern
-
-    # NEW: For your MAS patterns
-    COMPETITIVE = "competitive"  # MAS #2: Adversarial debate
-    CONSENSUS = "consensus"  # MAS #4: Peer deliberation
+    COMPETITIVE = "competitive"  # Adversarial debate pattern
+    CONSENSUS = "consensus"  # Peer deliberation pattern

--- a/bili/aether/tests/test_loader.py
+++ b/bili/aether/tests/test_loader.py
@@ -60,10 +60,9 @@ def test_load_hierarchical_yaml():
     assert tier_1[0].agent_id == "vote_agent"
     assert tier_1[0].voting_weight == 2.0
 
-    # Tier 2 agents use custom roles
+    # Tier 2 agents are aggregators
     for agent in tier_2:
-        assert agent.role.value == "custom"
-        assert agent.custom_role_name is not None
+        assert "aggregator" in agent.role
 
 
 def test_load_supervisor_yaml():
@@ -84,7 +83,7 @@ def test_load_supervisor_yaml():
     # Verify appeals_specialist is present
     appeals = config.get_agent("appeals_specialist")
     assert appeals is not None
-    assert appeals.role.value == "appeals_specialist"
+    assert appeals.role == "appeals_specialist"
 
 
 def test_load_consensus_yaml():

--- a/bili/aether/tests/test_presets.py
+++ b/bili/aether/tests/test_presets.py
@@ -1,0 +1,131 @@
+"""Tests for the agent preset system."""
+
+import pytest
+
+from bili.aether.schema import (
+    AGENT_PRESETS,
+    create_agent_from_preset,
+    get_preset,
+    list_presets,
+    register_preset,
+)
+
+
+def test_list_presets():
+    """Test listing available presets."""
+    presets = list_presets()
+    assert isinstance(presets, list)
+    assert len(presets) > 0
+    assert "researcher" in presets
+    assert "content_reviewer" in presets
+    assert "supervisor" in presets
+
+
+def test_get_preset():
+    """Test getting a preset by name."""
+    preset = get_preset("researcher")
+    assert preset is not None
+    assert preset["role"] == "researcher"
+    assert "web_search" in preset["capabilities"]
+
+
+def test_get_nonexistent_preset():
+    """Test getting a preset that doesn't exist."""
+    preset = get_preset("nonexistent_preset")
+    assert preset is None
+
+
+def test_create_agent_from_preset():
+    """Test creating an agent from a preset."""
+    agent = create_agent_from_preset(
+        preset_name="researcher",
+        agent_id="my_researcher",
+        objective="Research AI developments",
+    )
+
+    assert agent.agent_id == "my_researcher"
+    assert agent.role == "researcher"
+    assert agent.objective == "Research AI developments"
+    assert "web_search" in agent.capabilities
+
+
+def test_create_agent_with_overrides():
+    """Test creating agent from preset with overrides."""
+    agent = create_agent_from_preset(
+        preset_name="code_reviewer",
+        agent_id="security_expert",
+        objective="Review Python code for security",
+        temperature=0.1,
+        capabilities=["python_security", "owasp_detection"],
+    )
+
+    assert agent.agent_id == "security_expert"
+    assert agent.role == "code_reviewer"
+    assert agent.temperature == 0.1
+    # Overrides replace preset capabilities
+    assert "python_security" in agent.capabilities
+    assert "owasp_detection" in agent.capabilities
+
+
+def test_create_agent_unknown_preset():
+    """Test that unknown preset raises ValueError."""
+    with pytest.raises(ValueError, match="Unknown preset"):
+        create_agent_from_preset(
+            preset_name="unknown_preset",
+            agent_id="test",
+            objective="This should fail",
+        )
+
+
+def test_register_preset():
+    """Test registering a custom preset."""
+    register_preset("my_custom_preset", {
+        "role": "custom_role",
+        "capabilities": ["custom_cap"],
+        "temperature": 0.4,
+    })
+
+    assert "my_custom_preset" in list_presets()
+    preset = get_preset("my_custom_preset")
+    assert preset["role"] == "custom_role"
+
+
+def test_create_agent_from_custom_preset():
+    """Test creating agent from a registered custom preset."""
+    # Register first
+    register_preset("test_custom", {
+        "role": "test_role",
+        "capabilities": ["test_cap"],
+        "temperature": 0.5,
+    })
+
+    # Create agent
+    agent = create_agent_from_preset(
+        preset_name="test_custom",
+        agent_id="test_agent",
+        objective="Testing custom preset functionality",
+    )
+
+    assert agent.role == "test_role"
+    assert agent.temperature == 0.5
+    assert "test_cap" in agent.capabilities
+
+
+def test_preset_registry_not_empty():
+    """Test that AGENT_PRESETS registry has entries."""
+    assert len(AGENT_PRESETS) > 0
+    assert "researcher" in AGENT_PRESETS
+    assert "supervisor" in AGENT_PRESETS
+
+
+def test_all_presets_have_role():
+    """Test that all presets have a role defined."""
+    for name, preset in AGENT_PRESETS.items():
+        assert "role" in preset, f"Preset '{name}' missing 'role'"
+
+
+def test_supervisor_preset_has_flag():
+    """Test supervisor preset has is_supervisor flag."""
+    preset = get_preset("supervisor")
+    assert preset is not None
+    assert preset.get("is_supervisor") is True


### PR DESCRIPTION
This refactors the AETHER schema to be fully domain-agnostic:

Schema Changes:
- Remove AgentRole and AgentCapability enums (domain-specific)
- Make agent `role` a free-form string instead of enum
- Make agent `capabilities` a list of free-form strings
- Keep structural enums only (WorkflowType, OutputFormat, CommunicationProtocol)
- Remove custom_role_name field (no longer needed)

New Preset System (agent_presets.py):
- Registry-based preset system for common agent patterns
- Built-in presets: researcher, code_reviewer, supervisor, etc.
- register_preset() for runtime custom presets
- create_agent_from_preset() with optional overrides
- Presets provide convenience without restrictions

New Domain Examples:
- research_analysis.yaml - Research pipeline (researcher → fact_checker → analyst → synthesizer)
- code_review.yaml - Code review with specialist reviewers

Updated Tests:
- test_agent_spec.py updated for string-based roles/capabilities
- test_presets.py added for preset system
- test_loader.py updated for new YAML format

This design allows AETHER to support any domain (research, code review, customer support, etc.) without code changes, while providing convenient presets for common patterns.

Slack thread: https://compscimsu.slack.com/archives/C07LKD5KLP3/p1769977620.315069

https://claude.ai/code/session_01FPoBuKN2J5wzgPHJJPTVRp

### This PR introduces the following changes 
- Detail 
- Detail
- Detail 
- Add more details as needed

### Steps to Review
1. Checkout the `insert-branch-name-here` branch on your local machine 
2. More steps 
3. Add more steps as needed 



