### PR TITLE
33 v2 build aether to langgraph compiler [Task 5]

### DIFF
--- a/bili/aether/__init__.py
+++ b/bili/aether/__init__.py
@@ -25,6 +25,7 @@ License: MIT
 __version__ = "0.0.7"
 __author__ = "MSU Denver Cybersecurity Research, MonRos3"
 
+from .compiler import CompiledMAS, compile_mas
 from .config import load_mas_from_dict, load_mas_from_yaml
 from .schema import (
     AGENT_PRESETS,
@@ -67,4 +68,7 @@ __all__ = [
     "MASValidator",
     "ValidationResult",
     "validate_mas",
+    # Compiler
+    "CompiledMAS",
+    "compile_mas",
 ]

--- a/bili/aether/compiler/__init__.py
+++ b/bili/aether/compiler/__init__.py
@@ -1,0 +1,64 @@
+"""AETHER-to-LangGraph compiler.
+
+Converts a validated ``MASConfig`` into an executable LangGraph
+``StateGraph`` with LLM-backed agent nodes.
+
+When ``AgentSpec.model_name`` is set, agents make real LLM calls via
+``bili.loaders.llm_loader``.  When ``model_name`` is ``None``, agents
+use a lightweight stub that emits placeholder messages.
+
+Usage::
+
+    from bili.aether.compiler import compile_mas
+    from bili.aether.config.loader import load_mas_from_yaml
+
+    config = load_mas_from_yaml("simple_chain.yaml")
+    compiled = compile_mas(config)
+    graph = compiled.compile_graph()
+"""
+
+from bili.aether.schema import MASConfig
+from bili.aether.validation import validate_mas
+
+from .agent_generator import generate_agent_node, wrap_agent_node
+from .compiled_mas import CompiledMAS
+from .graph_builder import GraphBuilder
+from .llm_resolver import create_llm, resolve_model, resolve_provider, resolve_tools
+from .state_generator import generate_state_schema
+
+__all__ = [
+    "CompiledMAS",
+    "GraphBuilder",
+    "compile_mas",
+    "create_llm",
+    "generate_agent_node",
+    "generate_state_schema",
+    "resolve_model",
+    "resolve_provider",
+    "resolve_tools",
+    "wrap_agent_node",
+]
+
+
+def compile_mas(config: MASConfig) -> CompiledMAS:
+    """Validate and compile a ``MASConfig`` into a ``CompiledMAS``.
+
+    Runs the static validation engine first.  If validation produces
+    **errors** (not warnings), raises ``ValueError`` with the full
+    validation report.
+
+    Args:
+        config: A ``MASConfig`` instance.
+
+    Returns:
+        A :class:`CompiledMAS` containing the uncompiled ``StateGraph``,
+        state schema, and agent node callables.
+
+    Raises:
+        ValueError: If validation fails with errors.
+    """
+    result = validate_mas(config)
+    if not result.valid:
+        raise ValueError(f"MAS validation failed:\n{result}")
+
+    return GraphBuilder(config).build()

--- a/bili/aether/compiler/agent_generator.py
+++ b/bili/aether/compiler/agent_generator.py
@@ -1,0 +1,304 @@
+"""Agent node generation — creates LLM-backed or stub callables from AgentSpec definitions.
+
+When an ``AgentSpec`` has ``model_name`` set, the generated node makes
+real LLM calls using bili-core's ``llm_loader``.  If the agent also has
+``tools`` configured, the node is built with ``langchain.agents.create_agent``
+— the same pattern used by ``bili/nodes/react_agent_node.py``.
+"""
+
+import json
+import logging
+import time
+from typing import Callable
+
+from bili.aether.schema import AgentSpec, OutputFormat
+
+LOGGER = logging.getLogger(__name__)
+
+
+def generate_agent_node(agent: AgentSpec) -> Callable[[dict], dict]:
+    """Create a node callable for the given agent.
+
+    If ``agent.model_name`` is set, returns a node that makes real LLM
+    calls via ``bili.loaders.llm_loader``.  If the agent also has
+    ``tools``, uses ``create_agent()`` for tool-enabled execution.
+    Otherwise returns a stub node that emits a placeholder ``AIMessage``
+    so the graph can execute end-to-end without API keys.
+
+    Args:
+        agent: The ``AgentSpec`` for this agent.
+
+    Returns:
+        A callable ``(state: dict) -> dict`` suitable for
+        ``StateGraph.add_node``.
+    """
+    if agent.model_name:
+        return _generate_llm_agent_node(agent)
+    return _generate_stub_agent_node(agent)
+
+
+# =========================================================================
+# Real LLM node
+# =========================================================================
+
+
+def _generate_llm_agent_node(agent: AgentSpec) -> Callable[[dict], dict]:
+    """Create a node callable that invokes a real LLM.
+
+    The LLM instance is created eagerly (at compile time) via
+    :func:`~bili.aether.compiler.llm_resolver.create_llm` so that
+    provider-resolution errors surface immediately rather than at
+    graph-execution time.
+
+    If the agent has ``tools`` configured, resolves them via
+    :func:`~bili.aether.compiler.llm_resolver.resolve_tools` and uses
+    ``langchain.agents.create_agent`` — the same pattern as
+    ``bili/nodes/react_agent_node.py``.
+    """
+    # pylint: disable=import-outside-toplevel
+    from bili.aether.compiler.llm_resolver import create_llm, resolve_tools
+
+    llm = create_llm(agent)
+    tools = resolve_tools(agent)
+
+    if tools:
+        return _generate_tool_agent_node(agent, llm, tools)
+    return _generate_direct_llm_node(agent, llm)
+
+
+def _generate_tool_agent_node(
+    agent: AgentSpec, llm: object, tools: list
+) -> Callable[[dict], dict]:
+    """Create a node using ``create_agent()`` for tool-enabled agents.
+
+    Mirrors the tool-enabled path in ``bili/nodes/react_agent_node.py``.
+    """
+    from langchain.agents import (  # pylint: disable=import-error,import-outside-toplevel
+        create_agent,
+    )
+
+    react_agent = create_agent(model=llm, tools=tools)
+
+    def _agent_node(state: dict) -> dict:
+        start_time = time.time()
+
+        from langchain_core.messages import (  # pylint: disable=import-error,import-outside-toplevel
+            HumanMessage,
+            SystemMessage,
+        )
+
+        # Inject system prompt into messages if not already present
+        system_prompt = agent.system_prompt or agent.objective
+        messages = list(state.get("messages", []))
+
+        has_system = any(isinstance(m, SystemMessage) for m in messages)
+        if not has_system:
+            messages.insert(0, SystemMessage(content=system_prompt))
+
+        if not any(isinstance(m, HumanMessage) for m in messages):
+            messages.append(HumanMessage(content="Begin your task."))
+
+        # Invoke the react agent — it handles tool calls internally
+        result = react_agent.invoke({"messages": messages})
+
+        execution_ms = (time.time() - start_time) * 1000
+        LOGGER.info(
+            "Agent node '%s' executed in %.2f ms (tool-agent)",
+            agent.agent_id,
+            execution_ms,
+        )
+
+        # Extract the final response content
+        response_messages = result.get("messages", [])
+        content = ""
+        if response_messages:
+            content = response_messages[-1].content or ""
+
+        output = _build_output(agent, content)
+        agent_outputs = dict(state.get("agent_outputs") or {})
+        agent_outputs[agent.agent_id] = output
+
+        from langchain_core.messages import (  # pylint: disable=import-error,import-outside-toplevel
+            AIMessage,
+        )
+
+        return {
+            "messages": [AIMessage(content=content, name=agent.agent_id)],
+            "current_agent": agent.agent_id,
+            "agent_outputs": agent_outputs,
+        }
+
+    _agent_node.agent_spec = agent  # type: ignore[attr-defined]
+    _agent_node.__name__ = f"agent_{agent.agent_id}"
+    _agent_node.__qualname__ = f"agent_{agent.agent_id}"
+
+    return _agent_node
+
+
+def _generate_direct_llm_node(agent: AgentSpec, llm: object) -> Callable[[dict], dict]:
+    """Create a node that calls ``llm.invoke()`` directly (no tools).
+
+    Mirrors the fallback path in ``bili/nodes/react_agent_node.py``.
+    """
+
+    def _agent_node(state: dict) -> dict:
+        start_time = time.time()
+
+        from langchain_core.messages import (  # pylint: disable=import-error,import-outside-toplevel
+            AIMessage,
+            HumanMessage,
+            SystemMessage,
+        )
+
+        # Build message list
+        system_prompt = agent.system_prompt or agent.objective
+        messages = [SystemMessage(content=system_prompt)]
+
+        # Filter state messages to compatible types, matching
+        # react_agent_node.py's fallback path
+        state_messages = state.get("messages", [])
+        if state_messages:
+            compatible = [
+                m
+                for m in state_messages
+                if isinstance(m, (AIMessage, HumanMessage, SystemMessage))
+            ]
+            messages.extend(compatible)
+        else:
+            messages.append(HumanMessage(content="Begin your task."))
+
+        # Invoke the LLM directly
+        response = llm.invoke(messages)
+        content = response.content
+
+        execution_ms = (time.time() - start_time) * 1000
+        LOGGER.info(
+            "Agent node '%s' executed in %.2f ms (LLM)",
+            agent.agent_id,
+            execution_ms,
+        )
+
+        output = _build_output(agent, content)
+        agent_outputs = dict(state.get("agent_outputs") or {})
+        agent_outputs[agent.agent_id] = output
+
+        return {
+            "messages": [AIMessage(content=content, name=agent.agent_id)],
+            "current_agent": agent.agent_id,
+            "agent_outputs": agent_outputs,
+        }
+
+    _agent_node.agent_spec = agent  # type: ignore[attr-defined]
+    _agent_node.__name__ = f"agent_{agent.agent_id}"
+    _agent_node.__qualname__ = f"agent_{agent.agent_id}"
+
+    return _agent_node
+
+
+# =========================================================================
+# Stub node (no LLM — used when model_name is not set)
+# =========================================================================
+
+
+def _generate_stub_agent_node(agent: AgentSpec) -> Callable[[dict], dict]:
+    """Create a stub node callable (no LLM calls).
+
+    The stub records itself in the state and emits an ``AIMessage`` so
+    the graph can execute end-to-end without real LLM calls.  The
+    ``AgentSpec`` is captured in the closure and attached as an attribute
+    for introspection.
+    """
+
+    def _agent_node(state: dict) -> dict:
+        start_time = time.time()
+
+        stub_output = {
+            "agent_id": agent.agent_id,
+            "role": agent.role,
+            "status": "stub",
+            "message": f"[STUB] Agent '{agent.agent_id}' ({agent.role}) executed.",
+        }
+
+        agent_outputs = dict(state.get("agent_outputs") or {})
+        agent_outputs[agent.agent_id] = stub_output
+
+        execution_ms = (time.time() - start_time) * 1000
+        LOGGER.info(
+            "Agent node '%s' executed in %.2f ms (stub)",
+            agent.agent_id,
+            execution_ms,
+        )
+
+        from langchain_core.messages import (  # pylint: disable=import-error,import-outside-toplevel
+            AIMessage,
+        )
+
+        return {
+            "messages": [
+                AIMessage(
+                    content=stub_output["message"],
+                    name=agent.agent_id,
+                )
+            ],
+            "current_agent": agent.agent_id,
+            "agent_outputs": agent_outputs,
+        }
+
+    # Attach metadata for introspection
+    _agent_node.agent_spec = agent  # type: ignore[attr-defined]
+    _agent_node.__name__ = f"agent_{agent.agent_id}"
+    _agent_node.__qualname__ = f"agent_{agent.agent_id}"
+
+    return _agent_node
+
+
+# =========================================================================
+# Performance wrapper
+# =========================================================================
+
+
+def wrap_agent_node(node_func: Callable, agent_id: str) -> Callable:
+    """Wrap an agent node with performance logging.
+
+    Mirrors the ``wrap_node`` pattern from
+    ``bili/loaders/langchain_loader.py``.
+    """
+
+    def wrapper(state: dict) -> dict:
+        start_time = time.time()
+        result = node_func(state)
+        execution_ms = (time.time() - start_time) * 1000
+        LOGGER.info("Agent '%s' executed in %.2f ms", agent_id, execution_ms)
+        return result
+
+    wrapper.__name__ = node_func.__name__
+    wrapper.__qualname__ = node_func.__qualname__
+    if hasattr(node_func, "agent_spec"):
+        wrapper.agent_spec = node_func.agent_spec  # type: ignore[attr-defined]
+
+    return wrapper
+
+
+# =========================================================================
+# Shared helpers
+# =========================================================================
+
+
+def _build_output(agent: AgentSpec, content: str) -> dict:
+    """Build the agent output dict, parsing JSON if configured."""
+    output = {
+        "agent_id": agent.agent_id,
+        "role": agent.role,
+        "status": "completed",
+        "message": content,
+    }
+
+    if agent.output_format == OutputFormat.JSON:
+        try:
+            output["parsed"] = json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            output["raw"] = content
+    else:
+        output["raw"] = content
+
+    return output

--- a/bili/aether/compiler/cli.py
+++ b/bili/aether/compiler/cli.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+"""CLI tool for testing AETHER MAS compilation.
+
+Usage (from project root)::
+
+    python bili/aether/compiler/cli.py                    # compile all examples
+    python bili/aether/compiler/cli.py path/to/mas.yaml   # compile specific file
+"""
+
+import os
+import sys
+import types
+
+
+def _ensure_bili_stub() -> None:
+    """Stub the top-level ``bili`` package if it hasn't been loaded yet.
+
+    Same approach as ``bili/aether/tests/run_tests.py`` — avoids pulling
+    in heavy dependencies (firebase_admin, torch, etc.) from ``bili/__init__.py``.
+    """
+    project_root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    )
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+
+    if "bili" not in sys.modules or not hasattr(sys.modules["bili"], "__path__"):
+        stub = types.ModuleType("bili")
+        stub.__path__ = [os.path.join(project_root, "bili")]
+        stub.__package__ = "bili"
+        sys.modules["bili"] = stub
+
+
+def main() -> None:
+    """Compile AETHER MAS configurations and report results."""
+    # pylint: disable=import-outside-toplevel
+    from bili.aether.compiler import compile_mas
+    from bili.aether.config.loader import load_mas_from_yaml
+
+    if len(sys.argv) > 1:
+        path = sys.argv[1]
+        config = load_mas_from_yaml(path)
+        result = compile_mas(config)
+        print(f"OK    {path}")
+        print(f"      {result}")
+        compiled = result.compile_graph()
+        print(f"      Compiled: {type(compiled).__name__}")
+        return
+
+    # Compile all examples
+    examples_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "config",
+        "examples",
+    )
+
+    example_files = [
+        "simple_chain.yaml",
+        "hierarchical_voting.yaml",
+        "supervisor_moderation.yaml",
+        "consensus_network.yaml",
+        "custom_escalation.yaml",
+        "research_analysis.yaml",
+        "code_review.yaml",
+    ]
+
+    failures = 0
+    for fname in example_files:
+        fpath = os.path.join(examples_dir, fname)
+        if not os.path.exists(fpath):
+            print(f"SKIP  {fname}  (file not found)")
+            continue
+        try:
+            config = load_mas_from_yaml(fpath)
+            result = compile_mas(config)
+            result.compile_graph()
+            print(f"OK    {fname}  ->  {result}")
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            print(f"FAIL  {fname}  ->  {exc}")
+            failures += 1
+
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    _ensure_bili_stub()
+    main()

--- a/bili/aether/compiler/compiled_mas.py
+++ b/bili/aether/compiler/compiled_mas.py
@@ -1,0 +1,55 @@
+"""Compiled MAS container — wraps a LangGraph StateGraph built from a MASConfig."""
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional, Type
+
+from bili.aether.schema import MASConfig
+
+
+@dataclass
+class CompiledMAS:
+    """Result of compiling a MASConfig into a LangGraph StateGraph.
+
+    Attributes:
+        config: The original MASConfig used to build the graph.
+        graph: The uncompiled StateGraph (can be inspected/modified).
+        state_schema: The generated TypedDict state class.
+        agent_nodes: Mapping of agent_id to its callable node function.
+        checkpoint_config: Checkpoint backend configuration dict.
+    """
+
+    config: MASConfig
+    graph: Any  # langgraph.graph.StateGraph (lazy import)
+    state_schema: Type
+    agent_nodes: Dict[str, Callable]
+    checkpoint_config: Dict[str, Any] = field(default_factory=dict)
+
+    def compile_graph(self, checkpointer=None):
+        """Compile the StateGraph into an executable CompiledStateGraph.
+
+        Args:
+            checkpointer: Optional checkpoint saver. If *None* and
+                ``config.checkpoint_enabled`` is True, a MemorySaver is used.
+
+        Returns:
+            A ``CompiledStateGraph`` ready for ``.invoke()`` or ``.stream()``.
+        """
+        if checkpointer is None and self.config.checkpoint_enabled:
+            from langgraph.checkpoint.memory import (  # pylint: disable=import-error,import-outside-toplevel
+                MemorySaver,
+            )
+
+            checkpointer = MemorySaver()
+
+        return self.graph.compile(checkpointer=checkpointer)
+
+    def get_agent_node(self, agent_id: str) -> Optional[Callable]:
+        """Look up the callable for a specific agent node."""
+        return self.agent_nodes.get(agent_id)
+
+    def __str__(self) -> str:
+        return (
+            f"CompiledMAS({self.config.mas_id}, "
+            f"{len(self.agent_nodes)} agents, "
+            f"workflow={self.config.workflow_type.value})"
+        )

--- a/bili/aether/compiler/graph_builder.py
+++ b/bili/aether/compiler/graph_builder.py
@@ -1,0 +1,425 @@
+"""Graph builder — converts a validated MASConfig into a LangGraph StateGraph.
+
+Supports all seven ``WorkflowType`` values defined in the AETHER schema.
+"""
+
+import logging
+from collections import defaultdict
+from typing import Any, Callable, Dict, List, Set
+
+from bili.aether.schema import MASConfig, WorkflowType
+
+from .agent_generator import generate_agent_node, wrap_agent_node
+from .compiled_mas import CompiledMAS
+from .state_generator import generate_state_schema
+
+LOGGER = logging.getLogger(__name__)
+
+
+class GraphBuilder:  # pylint: disable=too-few-public-methods
+    """Builds a LangGraph ``StateGraph`` from a validated ``MASConfig``.
+
+    Usage::
+
+        compiled = GraphBuilder(config).build()
+        graph = compiled.compile_graph()
+    """
+
+    def __init__(self, config: MASConfig) -> None:
+        self._config = config
+        self._agent_nodes: Dict[str, Callable] = {}
+        self._state_schema = None
+        self._graph: Any = None
+        self._end_node: Any = None
+        self._start_node: Any = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def build(self) -> CompiledMAS:
+        """Build the complete ``CompiledMAS`` from the stored config."""
+        from langgraph.constants import (  # pylint: disable=import-error,import-outside-toplevel
+            END,
+            START,
+        )
+        from langgraph.graph import (  # pylint: disable=import-error,import-outside-toplevel
+            StateGraph,
+        )
+
+        self._end_node = END
+        self._start_node = START
+
+        # 1. Generate state schema
+        self._state_schema = generate_state_schema(self._config)
+
+        # 2. Generate agent node callables
+        for agent in self._config.agents:
+            node_fn = generate_agent_node(agent)
+            wrapped = wrap_agent_node(node_fn, agent.agent_id)
+            self._agent_nodes[agent.agent_id] = wrapped
+
+        # 3. Create StateGraph
+        self._graph = StateGraph(self._state_schema)
+
+        # 4. Add all agent nodes
+        for agent_id, node_fn in self._agent_nodes.items():
+            self._graph.add_node(agent_id, node_fn)
+
+        # 5. Build workflow-specific edges
+        builder = self._get_workflow_builder()
+        builder()
+
+        LOGGER.info(
+            "Built %s graph for '%s' with %d agent nodes",
+            self._config.workflow_type.value,
+            self._config.mas_id,
+            len(self._agent_nodes),
+        )
+
+        # 6. Return CompiledMAS
+        return CompiledMAS(
+            config=self._config,
+            graph=self._graph,
+            state_schema=self._state_schema,
+            agent_nodes=dict(self._agent_nodes),
+            checkpoint_config=self._config.checkpoint_config,
+        )
+
+    # ------------------------------------------------------------------
+    # Workflow dispatch
+    # ------------------------------------------------------------------
+
+    def _get_workflow_builder(self) -> Callable:
+        dispatch = {
+            WorkflowType.SEQUENTIAL: self._build_sequential,
+            WorkflowType.HIERARCHICAL: self._build_hierarchical,
+            WorkflowType.SUPERVISOR: self._build_supervisor,
+            WorkflowType.CONSENSUS: self._build_consensus,
+            WorkflowType.DELIBERATIVE: self._build_deliberative,
+            WorkflowType.PARALLEL: self._build_parallel,
+            WorkflowType.CUSTOM: self._build_custom,
+        }
+        builder = dispatch.get(self._config.workflow_type)
+        if builder is None:
+            raise ValueError(f"Unsupported workflow type: {self._config.workflow_type}")
+        return builder
+
+    # ==================================================================
+    # SEQUENTIAL — linear chain
+    # ==================================================================
+
+    def _build_sequential(self) -> None:
+        """``START -> A -> B -> C -> END`` in agent-list order.
+
+        If ``workflow_edges`` are defined, uses those instead.
+        """
+        if self._config.workflow_edges:
+            self._build_from_explicit_edges()
+            return
+
+        entry = self._config.get_entry_agent()
+        agent_ids = [a.agent_id for a in self._config.agents]
+
+        # Reorder so entry agent comes first
+        if entry.agent_id in agent_ids:
+            idx = agent_ids.index(entry.agent_id)
+            ordered = agent_ids[idx:] + agent_ids[:idx]
+        else:
+            ordered = agent_ids
+
+        self._graph.add_edge(self._start_node, ordered[0])
+        for i in range(len(ordered) - 1):
+            self._graph.add_edge(ordered[i], ordered[i + 1])
+        self._graph.add_edge(ordered[-1], self._end_node)
+
+    # ==================================================================
+    # HIERARCHICAL — tier-based fan-out
+    # ==================================================================
+
+    def _build_hierarchical(self) -> None:  # pylint: disable=too-many-branches
+        """Process tiers from highest number (leaves) to tier 1 (root).
+
+        Uses channel definitions for specific inter-tier routing when
+        available; falls back to full cross-tier connectivity otherwise.
+        """
+        tiers = sorted(
+            {a.tier for a in self._config.agents if a.tier is not None},
+            reverse=True,
+        )
+        if not tiers:
+            self._build_sequential()
+            return
+
+        # Build channel-based adjacency: source -> {targets}
+        channel_targets: Dict[str, Set[str]] = defaultdict(set)
+        for ch in self._config.channels:
+            channel_targets[ch.source].add(ch.target)
+            if ch.bidirectional:
+                channel_targets[ch.target].add(ch.source)
+
+        previous_tier_ids: List[str] = []
+
+        for tier_num in tiers:
+            tier_ids = [a.agent_id for a in self._config.get_agents_by_tier(tier_num)]
+
+            if tier_num == max(tiers):
+                # Leaf tier: START fans out to all agents
+                for aid in tier_ids:
+                    self._graph.add_edge(self._start_node, aid)
+            else:
+                # Connect from previous tier
+                for prev_id in previous_tier_ids:
+                    targets = channel_targets.get(prev_id, set())
+                    connected = targets & set(tier_ids)
+                    if connected:
+                        for curr_id in connected:
+                            self._graph.add_edge(prev_id, curr_id)
+                    else:
+                        for curr_id in tier_ids:
+                            self._graph.add_edge(prev_id, curr_id)
+
+            if tier_num == 1:
+                for aid in tier_ids:
+                    self._graph.add_edge(aid, self._end_node)
+
+            previous_tier_ids = tier_ids
+
+    # ==================================================================
+    # SUPERVISOR — hub-and-spoke
+    # ==================================================================
+
+    def _build_supervisor(self) -> None:
+        """Supervisor receives input, conditionally routes to workers,
+        workers return to supervisor, supervisor can route to END.
+        """
+        entry = self._config.get_entry_agent()
+        supervisor_id = entry.agent_id
+
+        worker_ids = [
+            a.agent_id for a in self._config.agents if a.agent_id != supervisor_id
+        ]
+
+        self._graph.add_edge(self._start_node, supervisor_id)
+
+        # Supervisor -> conditional routing to workers or END
+        path_map = {wid: wid for wid in worker_ids}
+        path_map["END"] = self._end_node
+
+        def supervisor_router(state: dict) -> str:
+            next_agent = state.get("next_agent", "END")
+            if next_agent in path_map:
+                return next_agent
+            return "END"
+
+        self._graph.add_conditional_edges(
+            supervisor_id,
+            supervisor_router,
+            path_map,
+        )
+
+        for wid in worker_ids:
+            self._graph.add_edge(wid, supervisor_id)
+
+    # ==================================================================
+    # CONSENSUS — round-based deliberation
+    # ==================================================================
+
+    def _build_consensus(self) -> None:
+        """All agents deliberate in rounds until consensus or max rounds.
+
+        Topology::
+
+            START -> __round_start__ -> [all agents] -> __consensus_checker__
+                         ^  (continue)                        |
+                         +------------------------------------+
+                                                     (end) -> END
+        """
+        agent_ids = [a.agent_id for a in self._config.agents]
+        max_rounds = self._config.max_consensus_rounds
+
+        def round_start(_state: dict) -> dict:
+            return {}
+
+        self._graph.add_node("__round_start__", round_start)
+
+        def consensus_checker(state: dict) -> dict:
+            current_round = (state.get("current_round") or 0) + 1
+            consensus_reached = current_round >= max_rounds
+            return {
+                "current_round": current_round,
+                "consensus_reached": consensus_reached,
+            }
+
+        self._graph.add_node("__consensus_checker__", consensus_checker)
+
+        self._graph.add_edge(self._start_node, "__round_start__")
+
+        for aid in agent_ids:
+            self._graph.add_edge("__round_start__", aid)
+
+        for aid in agent_ids:
+            self._graph.add_edge(aid, "__consensus_checker__")
+
+        def consensus_router(state: dict) -> str:
+            if state.get("consensus_reached", False):
+                return "end"
+            current_round = state.get("current_round", 0)
+            if current_round >= max_rounds:
+                return "end"
+            return "continue"
+
+        self._graph.add_conditional_edges(
+            "__consensus_checker__",
+            consensus_router,
+            {"continue": "__round_start__", "end": self._end_node},
+        )
+
+    # ==================================================================
+    # PARALLEL — fan-out / fan-in
+    # ==================================================================
+
+    def _build_parallel(self) -> None:
+        """``START -> [all agents] -> END`` (parallel execution)."""
+        for agent in self._config.agents:
+            self._graph.add_edge(self._start_node, agent.agent_id)
+            self._graph.add_edge(agent.agent_id, self._end_node)
+
+    # ==================================================================
+    # DELIBERATIVE — delegates to CUSTOM or SEQUENTIAL
+    # ==================================================================
+
+    def _build_deliberative(self) -> None:
+        """Deliberative workflows use explicit edges when available."""
+        if self._config.workflow_edges:
+            self._build_custom()
+        else:
+            self._build_sequential()
+
+    # ==================================================================
+    # CUSTOM — explicit edges from workflow_edges
+    # ==================================================================
+
+    def _build_custom(self) -> None:
+        """Build graph from explicit ``workflow_edges``.
+
+        Handles unconditional edges, conditional edges, and fan-out
+        (multiple unconditional edges from the same source).
+        """
+        entry = self._config.get_entry_agent()
+        self._graph.add_edge(self._start_node, entry.agent_id)
+
+        # Group edges by source agent
+        edges_by_source: Dict[str, list] = defaultdict(list)
+        for edge in self._config.workflow_edges:
+            edges_by_source[edge.from_agent].append(edge)
+
+        for from_agent, edges in edges_by_source.items():
+            conditional = [e for e in edges if e.condition]
+            unconditional = [e for e in edges if not e.condition]
+
+            if conditional:
+                self._add_conditional_group(from_agent, conditional, unconditional)
+            elif len(unconditional) == 1:
+                target = (
+                    self._end_node
+                    if unconditional[0].to_agent == "END"
+                    else unconditional[0].to_agent
+                )
+                self._graph.add_edge(from_agent, target)
+            else:
+                self._add_fan_out(from_agent, unconditional)
+
+    def _add_conditional_group(
+        self,
+        from_agent: str,
+        conditional: list,
+        unconditional: list,
+    ) -> None:
+        """Add conditional edges from a single source agent."""
+        path_map: Dict[str, Any] = {}
+        all_edges = conditional + unconditional
+
+        for edge in all_edges:
+            target = self._end_node if edge.to_agent == "END" else edge.to_agent
+            key = edge.label or edge.to_agent
+            path_map[key] = target
+
+        captured_edges = list(all_edges)
+
+        def _make_router(edges_list: list) -> Callable:
+            def router(state: dict) -> str:
+                for e in edges_list:
+                    if e.condition:
+                        try:
+                            if eval(  # noqa: S307  pylint: disable=eval-used
+                                e.condition,
+                                {"__builtins__": {}},
+                                {"state": _StateProxy(state)},
+                            ):
+                                return e.label or e.to_agent
+                        except Exception:  # pylint: disable=broad-exception-caught
+                            continue
+                # Fallback: first unconditional edge
+                for e in edges_list:
+                    if not e.condition:
+                        return e.label or e.to_agent
+                return edges_list[-1].label or edges_list[-1].to_agent
+
+            return router
+
+        self._graph.add_conditional_edges(
+            from_agent,
+            _make_router(captured_edges),
+            path_map,
+        )
+
+    def _add_fan_out(self, from_agent: str, edges: list) -> None:
+        """Add fan-out (multiple unconditional edges) from a single source."""
+        targets = []
+        path_map: Dict[str, Any] = {}
+        for edge in edges:
+            target = self._end_node if edge.to_agent == "END" else edge.to_agent
+            key = edge.label or edge.to_agent
+            path_map[key] = target
+            targets.append(key)
+
+        captured_targets = list(targets)
+
+        def fan_out_router(_state: dict) -> list:
+            return captured_targets
+
+        self._graph.add_conditional_edges(from_agent, fan_out_router, path_map)
+
+    # ------------------------------------------------------------------
+    # Shared helpers
+    # ------------------------------------------------------------------
+
+    def _build_from_explicit_edges(self) -> None:
+        """Build graph from explicit edges (used by sequential fallback)."""
+        entry = self._config.get_entry_agent()
+        self._graph.add_edge(self._start_node, entry.agent_id)
+
+        has_end = False
+        for edge in self._config.workflow_edges:
+            target = self._end_node if edge.to_agent == "END" else edge.to_agent
+            self._graph.add_edge(edge.from_agent, target)
+            if edge.to_agent == "END":
+                has_end = True
+
+        if not has_end:
+            last_agent = self._config.agents[-1].agent_id
+            self._graph.add_edge(last_agent, self._end_node)
+
+
+class _StateProxy:  # pylint: disable=too-few-public-methods
+    """Allows ``state.field`` attribute access for condition evaluation."""
+
+    def __init__(self, state: dict) -> None:
+        self._state = state
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self._state[name]
+        except KeyError:
+            return None

--- a/bili/aether/compiler/llm_resolver.py
+++ b/bili/aether/compiler/llm_resolver.py
@@ -1,0 +1,245 @@
+"""LLM resolution — maps AgentSpec model names to LLM provider instances.
+
+Resolves ``AgentSpec.model_name`` to a provider type and ``model_id``
+using ``bili.config.llm_config.LLM_MODELS``, then instantiates the LLM
+via ``bili.loaders.llm_loader.load_model``.
+
+bili-core distinguishes between a display *model_name* (e.g.
+``"GPT-4o"``) and the actual *model_id* sent to the provider (e.g.
+``"gpt-4o"``).  This module handles that mapping so AETHER users can
+specify either form in their ``AgentSpec.model_name`` field.
+
+All heavy imports (torch, provider SDKs) are lazy to allow the compiler
+module to load without those dependencies installed.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from bili.aether.schema import AgentSpec
+
+LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Heuristic provider detection (fallback when LLM_MODELS lookup fails)
+# ---------------------------------------------------------------------------
+
+_HEURISTIC_RULES = [
+    # (substring_or_prefix, provider_type)
+    # Order matters — more specific patterns must come before broader ones.
+    ("gpt-", "remote_openai"),
+    ("gpt4", "remote_openai"),
+    ("o1-", "remote_openai"),
+    ("o1", "remote_openai"),
+    ("o3-", "remote_openai"),
+    ("o3", "remote_openai"),
+    ("gemini", "remote_google_vertex"),
+    ("amazon.nova", "remote_aws_bedrock"),
+    ("amazon.titan", "remote_aws_bedrock"),
+    ("anthropic.claude", "remote_aws_bedrock"),  # Bedrock-hosted Claude
+    ("meta.llama", "remote_aws_bedrock"),
+    ("mistral", "remote_aws_bedrock"),
+    ("cohere.command", "remote_aws_bedrock"),
+    ("claude-", "remote_openai"),  # Direct Anthropic API (after Bedrock check)
+]
+
+
+def resolve_model(model_name: str) -> Tuple[str, str]:
+    """Resolve a model name to a ``(provider_type, model_id)`` pair.
+
+    Search order:
+        1. Exact match on ``model_id`` in ``LLM_MODELS``
+        2. Exact match on display ``model_name`` in ``LLM_MODELS``
+        3. Heuristic fallback using prefix/substring rules
+           (assumes *model_name* is already the *model_id*)
+
+    Args:
+        model_name: The model identifier from ``AgentSpec.model_name``.
+            Can be a display name (``"GPT-4o"``) or a model ID
+            (``"gpt-4o"``).
+
+    Returns:
+        A ``(provider_type, model_id)`` tuple — e.g.
+        ``("remote_openai", "gpt-4o")``.
+
+    Raises:
+        ValueError: If the model cannot be resolved to any provider.
+    """
+    # --- 1 & 2: Look up in LLM_MODELS ---
+    result = _lookup_in_llm_models(model_name)
+    if result is not None:
+        provider, model_id = result
+        LOGGER.debug(
+            "Resolved '%s' via LLM_MODELS → provider=%s, model_id=%s",
+            model_name,
+            provider,
+            model_id,
+        )
+        return provider, model_id
+
+    # --- 3: Heuristic fallback (model_name IS the model_id) ---
+    lower = model_name.lower()
+    for pattern, ptype in _HEURISTIC_RULES:
+        if pattern in lower:
+            LOGGER.debug(
+                "Resolved '%s' via heuristic ('%s') → %s (using as model_id)",
+                model_name,
+                pattern,
+                ptype,
+            )
+            return ptype, model_name
+
+    raise ValueError(
+        f"Cannot resolve model '{model_name}' to a provider. "
+        f"Set a recognised model_name or use bili.loaders.llm_loader directly."
+    )
+
+
+def resolve_provider(model_name: str) -> str:
+    """Resolve a model name to a bili-core provider type string.
+
+    Convenience wrapper around :func:`resolve_model` that returns only
+    the provider type.
+    """
+    provider, _ = resolve_model(model_name)
+    return provider
+
+
+def create_llm(agent: AgentSpec) -> Any:
+    """Create a LangChain chat model instance from an ``AgentSpec``.
+
+    Lazy-imports ``bili.loaders.llm_loader.load_model`` and
+    ``bili.config.llm_config.LLM_MODELS`` so the compiler module can be
+    loaded without heavy dependencies.
+
+    The function resolves the display ``model_name`` to the actual
+    ``model_id`` expected by the provider, then delegates to
+    ``load_model`` with the correct parameter name for each provider.
+
+    Args:
+        agent: An ``AgentSpec`` with ``model_name`` set.
+
+    Returns:
+        A LangChain-compatible chat model ready for ``.invoke()``.
+
+    Raises:
+        ValueError: If ``agent.model_name`` is ``None`` or unresolvable.
+    """
+    if not agent.model_name:
+        raise ValueError(
+            f"AgentSpec '{agent.agent_id}' has no model_name; "
+            f"cannot create LLM instance."
+        )
+
+    provider, model_id = resolve_model(agent.model_name)
+
+    # Build kwargs for load_model — each provider uses "model_name" as
+    # the kwarg, but the *value* must be the provider's model_id.
+    kwargs: Dict[str, Any] = {"model_name": model_id}
+    if agent.temperature is not None:
+        kwargs["temperature"] = agent.temperature
+    if agent.max_tokens is not None:
+        kwargs["max_tokens"] = agent.max_tokens
+
+    LOGGER.info(
+        "Creating LLM for agent '%s': provider=%s, model_id=%s",
+        agent.agent_id,
+        provider,
+        model_id,
+    )
+
+    from bili.loaders.llm_loader import (  # noqa: E402  pylint: disable=import-outside-toplevel
+        load_model,
+    )
+
+    return load_model(provider, **kwargs)
+
+
+def resolve_tools(agent: AgentSpec) -> list:
+    """Resolve an ``AgentSpec``'s tool names to tool instances.
+
+    Lazy-imports ``bili.loaders.tools_loader.initialize_tools`` and
+    ``bili.config.tool_config.TOOLS`` so the compiler module can be
+    loaded without those dependencies installed.
+
+    Args:
+        agent: An ``AgentSpec`` whose ``tools`` list may contain tool
+            names registered in bili-core's ``TOOL_REGISTRY``.
+
+    Returns:
+        A list of LangChain ``Tool`` instances (empty if no tools
+        are configured or if the tools loader is unavailable).
+    """
+    if not agent.tools:
+        return []
+
+    try:
+        from bili.config.tool_config import (  # noqa: E402  pylint: disable=import-outside-toplevel
+            TOOLS as TOOL_CONFIG,
+        )
+        from bili.loaders.tools_loader import (  # noqa: E402  pylint: disable=import-outside-toplevel
+            initialize_tools,
+        )
+    except ImportError:
+        LOGGER.warning(
+            "bili.loaders.tools_loader not available; "
+            "skipping tool resolution for agent '%s'",
+            agent.agent_id,
+        )
+        return []
+
+    # Build prompts dict from tool_config defaults
+    tool_prompts: Dict[str, str] = {}
+    for tool_name in agent.tools:
+        if tool_name in TOOL_CONFIG and "default_prompt" in TOOL_CONFIG[tool_name]:
+            tool_prompts[tool_name] = TOOL_CONFIG[tool_name]["default_prompt"]
+
+    try:
+        return initialize_tools(
+            active_tools=agent.tools,
+            tool_prompts=tool_prompts,
+        )
+    except Exception:  # pylint: disable=broad-exception-caught
+        LOGGER.warning(
+            "Failed to resolve tools %s for agent '%s'; "
+            "agent will run without tools",
+            agent.tools,
+            agent.agent_id,
+            exc_info=True,
+        )
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _lookup_in_llm_models(model_name: str) -> Optional[Tuple[str, str]]:
+    """Search ``LLM_MODELS`` for a matching model entry.
+
+    Returns ``(provider_type, model_id)`` if found, ``None`` otherwise.
+    """
+    try:
+        from bili.config.llm_config import (  # noqa: E402  pylint: disable=import-outside-toplevel
+            LLM_MODELS,
+        )
+    except ImportError:
+        LOGGER.debug("bili.config.llm_config not available; skipping LLM_MODELS lookup")
+        return None
+
+    for provider_type, provider_info in LLM_MODELS.items():
+        models: List[Dict[str, Any]] = provider_info.get("models", [])
+        for entry in models:
+            entry_model_id = entry.get("model_id", "")
+            entry_display = entry.get("model_name", "")
+
+            # Match on model_id (e.g. "gpt-4o")
+            if entry_model_id == model_name:
+                return provider_type, entry_model_id
+
+            # Match on display name (e.g. "GPT-4o")
+            if entry_display == model_name:
+                return provider_type, entry_model_id
+
+    return None

--- a/bili/aether/compiler/state_generator.py
+++ b/bili/aether/compiler/state_generator.py
@@ -1,0 +1,66 @@
+"""Dynamic state schema generation for compiled MAS graphs."""
+
+import re
+from typing import Any, Dict, List, Type
+
+from bili.aether.schema import MASConfig, WorkflowType
+
+
+def generate_state_schema(config: MASConfig) -> Type:
+    """Generate a TypedDict state schema tailored to a MAS configuration.
+
+    Base fields (always present):
+        messages — LangGraph message list with ``add_messages`` reducer.
+        current_agent — ID of the currently executing agent.
+        agent_outputs — Mapping of agent_id → latest output dict.
+        mas_id — The MAS identifier.
+
+    Workflow-specific fields are added based on ``config.workflow_type``.
+
+    Args:
+        config: A validated ``MASConfig``.
+
+    Returns:
+        A ``TypedDict`` subclass suitable as a LangGraph ``state_schema``.
+    """
+    from langgraph.graph import (  # pylint: disable=import-error,import-outside-toplevel
+        add_messages,
+    )
+    from typing_extensions import (  # pylint: disable=import-error,import-outside-toplevel
+        Annotated,
+        TypedDict,
+    )
+
+    annotations: Dict[str, Any] = {
+        "messages": Annotated[list, add_messages],
+        "current_agent": str,
+        "agent_outputs": Dict[str, Any],
+        "mas_id": str,
+    }
+
+    wtype = config.workflow_type
+
+    if wtype == WorkflowType.CONSENSUS:
+        annotations["current_round"] = int
+        annotations["votes"] = Dict[str, str]
+        annotations["consensus_reached"] = bool
+        annotations["max_rounds"] = int
+
+    if wtype == WorkflowType.HIERARCHICAL:
+        annotations["current_tier"] = int
+        annotations["tier_results"] = Dict[str, Any]
+
+    if wtype == WorkflowType.SUPERVISOR:
+        annotations["next_agent"] = str
+        annotations["pending_tasks"] = List[str]
+        annotations["completed_tasks"] = List[str]
+
+    if wtype == WorkflowType.CUSTOM and config.human_in_loop:
+        annotations["needs_human_review"] = bool
+
+    # Build a valid Python identifier from the mas_id
+    safe_name = re.sub(r"[^a-zA-Z0-9_]", "_", config.mas_id)
+    class_name = f"{safe_name}_State"
+
+    state_class: Type = TypedDict(class_name, annotations)  # type: ignore[call-overload]
+    return state_class

--- a/bili/aether/tests/test_compiler.py
+++ b/bili/aether/tests/test_compiler.py
@@ -1,0 +1,779 @@
+"""Tests for the AETHER-to-LangGraph compiler."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import (  # pylint: disable=import-error
+    AIMessage,
+    HumanMessage,
+)
+from langgraph.graph import StateGraph  # pylint: disable=import-error
+from langgraph.graph.state import CompiledStateGraph  # pylint: disable=import-error
+
+from bili.aether.compiler import CompiledMAS, compile_mas
+from bili.aether.compiler.agent_generator import generate_agent_node
+from bili.aether.compiler.state_generator import generate_state_schema
+from bili.aether.config.loader import load_mas_from_yaml
+from bili.aether.schema import (
+    AgentSpec,
+    MASConfig,
+    OutputFormat,
+    WorkflowEdge,
+    WorkflowType,
+)
+
+_EXAMPLES_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "config",
+    "examples",
+)
+
+
+# =========================================================================
+# Helper
+# =========================================================================
+
+
+def _agent(agent_id: str, **kwargs) -> AgentSpec:
+    """Shortcut to build an AgentSpec with sensible defaults."""
+    defaults = {
+        "role": "test_role",
+        "objective": f"Test objective for {agent_id}",
+    }
+    defaults.update(kwargs)
+    return AgentSpec(agent_id=agent_id, **defaults)
+
+
+# =========================================================================
+# COMPILED MAS TESTS
+# =========================================================================
+
+
+def test_compile_mas_returns_compiled_mas():
+    """compile_mas() returns a CompiledMAS with correct agent count."""
+    config = MASConfig(
+        mas_id="test_seq",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_agent("a"), _agent("b")],
+    )
+
+    result = compile_mas(config)
+
+    assert isinstance(result, CompiledMAS)
+    assert isinstance(result.graph, StateGraph)
+    assert len(result.agent_nodes) == 2
+    assert "a" in result.agent_nodes
+    assert "b" in result.agent_nodes
+
+
+def test_compile_mas_rejects_invalid_config():
+    """compile_mas() raises ValueError when validation has errors."""
+    config = MASConfig(
+        mas_id="bad",
+        name="Bad",
+        workflow_type=WorkflowType.HIERARCHICAL,
+        agents=[_agent("t2", tier=2), _agent("t3", tier=3)],
+    )
+
+    with pytest.raises(ValueError, match="validation failed"):
+        compile_mas(config)
+
+
+def test_compile_mas_allows_warnings():
+    """compile_mas() succeeds when validation has only warnings."""
+    config = MASConfig(
+        mas_id="warn",
+        name="Warn",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_agent("orphan")],
+    )
+
+    result = compile_mas(config)
+    assert isinstance(result, CompiledMAS)
+
+
+def test_compiled_mas_str():
+    """__str__ includes mas_id, agent count, and workflow type."""
+    config = MASConfig(
+        mas_id="test_str",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_agent("a"), _agent("b")],
+    )
+
+    result = compile_mas(config)
+    text = str(result)
+
+    assert "test_str" in text
+    assert "2 agents" in text
+    assert "sequential" in text
+
+
+def test_get_agent_node():
+    """get_agent_node() returns correct callable by ID."""
+    config = MASConfig(
+        mas_id="test_get",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_agent("x"), _agent("y")],
+    )
+
+    result = compile_mas(config)
+
+    assert result.get_agent_node("x") is not None
+    assert result.get_agent_node("y") is not None
+    assert result.get_agent_node("nonexistent") is None
+
+
+# =========================================================================
+# STATE SCHEMA TESTS
+# =========================================================================
+
+
+def test_state_schema_base_fields():
+    """Base state schema has messages, current_agent, agent_outputs."""
+    config = MASConfig(
+        mas_id="test_state",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_agent("a")],
+    )
+
+    schema = generate_state_schema(config)
+    annotations = schema.__annotations__
+
+    assert "messages" in annotations
+    assert "current_agent" in annotations
+    assert "agent_outputs" in annotations
+    assert "mas_id" in annotations
+
+
+def test_state_schema_consensus_fields():
+    """Consensus state has round tracking and vote fields."""
+    config = MASConfig(
+        mas_id="test_consensus",
+        name="Test",
+        workflow_type=WorkflowType.CONSENSUS,
+        consensus_threshold=0.5,
+        agents=[_agent("a"), _agent("b")],
+    )
+
+    schema = generate_state_schema(config)
+    annotations = schema.__annotations__
+
+    assert "current_round" in annotations
+    assert "votes" in annotations
+    assert "consensus_reached" in annotations
+    assert "max_rounds" in annotations
+
+
+def test_state_schema_hierarchical_fields():
+    """Hierarchical state has tier tracking fields."""
+    config = MASConfig(
+        mas_id="test_hier",
+        name="Test",
+        workflow_type=WorkflowType.HIERARCHICAL,
+        agents=[_agent("a", tier=1)],
+    )
+
+    schema = generate_state_schema(config)
+    annotations = schema.__annotations__
+
+    assert "current_tier" in annotations
+    assert "tier_results" in annotations
+
+
+def test_state_schema_supervisor_fields():
+    """Supervisor state has next_agent and task tracking fields."""
+    config = MASConfig(
+        mas_id="test_sup",
+        name="Test",
+        workflow_type=WorkflowType.SUPERVISOR,
+        agents=[_agent("sup", is_supervisor=True)],
+    )
+
+    schema = generate_state_schema(config)
+    annotations = schema.__annotations__
+
+    assert "next_agent" in annotations
+    assert "pending_tasks" in annotations
+    assert "completed_tasks" in annotations
+
+
+def test_state_schema_sanitizes_mas_id():
+    """Hyphens in mas_id are converted to underscores for the class name."""
+    config = MASConfig(
+        mas_id="my-mas-id",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_agent("a")],
+    )
+
+    schema = generate_state_schema(config)
+    assert "my_mas_id" in schema.__name__
+
+
+# =========================================================================
+# AGENT NODE TESTS
+# =========================================================================
+
+
+def test_agent_node_callable():
+    """Agent node callable returns dict with required keys."""
+    agent = _agent("test_agent")
+    node_fn = generate_agent_node(agent)
+
+    state = {"messages": [], "agent_outputs": {}}
+    result = node_fn(state)
+
+    assert isinstance(result, dict)
+    assert "messages" in result
+    assert "current_agent" in result
+    assert "agent_outputs" in result
+    assert result["current_agent"] == "test_agent"
+
+
+def test_agent_node_returns_ai_message():
+    """Agent node emits an AIMessage with name set to agent_id."""
+    agent = _agent("msg_agent")
+    node_fn = generate_agent_node(agent)
+
+    state = {"messages": [], "agent_outputs": {}}
+    result = node_fn(state)
+
+    assert len(result["messages"]) == 1
+    msg = result["messages"][0]
+    assert isinstance(msg, AIMessage)
+    assert msg.name == "msg_agent"
+
+
+def test_agent_node_has_spec_attribute():
+    """.agent_spec is accessible on the callable."""
+    agent = _agent("spec_agent")
+    node_fn = generate_agent_node(agent)
+
+    assert hasattr(node_fn, "agent_spec")
+    assert node_fn.agent_spec.agent_id == "spec_agent"
+
+
+def test_agent_node_accumulates_outputs():
+    """Agent node merges into existing agent_outputs."""
+    agent = _agent("accumulator")
+    node_fn = generate_agent_node(agent)
+
+    state = {
+        "messages": [],
+        "agent_outputs": {"other_agent": {"status": "done"}},
+    }
+    result = node_fn(state)
+
+    assert "other_agent" in result["agent_outputs"]
+    assert "accumulator" in result["agent_outputs"]
+
+
+# =========================================================================
+# GRAPH COMPILATION TESTS
+# =========================================================================
+
+
+def test_sequential_compiles():
+    """3-agent sequential graph compiles to a CompiledStateGraph."""
+    config = MASConfig(
+        mas_id="seq3",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_agent("a"), _agent("b"), _agent("c")],
+    )
+
+    compiled = compile_mas(config)
+    graph = compiled.compile_graph()
+    assert isinstance(graph, CompiledStateGraph)
+
+
+def test_supervisor_compiles():
+    """Supervisor graph with workers compiles."""
+    config = MASConfig(
+        mas_id="sup",
+        name="Test",
+        workflow_type=WorkflowType.SUPERVISOR,
+        entry_point="boss",
+        agents=[
+            _agent("boss", is_supervisor=True),
+            _agent("worker1"),
+            _agent("worker2"),
+        ],
+    )
+
+    compiled = compile_mas(config)
+    graph = compiled.compile_graph()
+    assert isinstance(graph, CompiledStateGraph)
+    assert "boss" in compiled.agent_nodes
+    assert "worker1" in compiled.agent_nodes
+
+
+def test_parallel_compiles():
+    """Parallel fan-out graph compiles."""
+    config = MASConfig(
+        mas_id="par",
+        name="Test",
+        workflow_type=WorkflowType.PARALLEL,
+        agents=[_agent("a"), _agent("b"), _agent("c")],
+    )
+
+    compiled = compile_mas(config)
+    graph = compiled.compile_graph()
+    assert isinstance(graph, CompiledStateGraph)
+
+
+def test_consensus_compiles():
+    """Consensus graph compiles and has checker node."""
+    config = MASConfig(
+        mas_id="cons",
+        name="Test",
+        workflow_type=WorkflowType.CONSENSUS,
+        consensus_threshold=0.5,
+        agents=[_agent("a"), _agent("b")],
+    )
+
+    compiled = compile_mas(config)
+    assert "__consensus_checker__" in compiled.graph.nodes
+    graph = compiled.compile_graph()
+    assert isinstance(graph, CompiledStateGraph)
+
+
+def test_hierarchical_compiles():
+    """Hierarchical graph with tiers compiles."""
+    config = MASConfig(
+        mas_id="hier",
+        name="Test",
+        workflow_type=WorkflowType.HIERARCHICAL,
+        agents=[
+            _agent("leaf1", tier=2),
+            _agent("leaf2", tier=2),
+            _agent("root", tier=1),
+        ],
+    )
+
+    compiled = compile_mas(config)
+    graph = compiled.compile_graph()
+    assert isinstance(graph, CompiledStateGraph)
+
+
+def test_custom_with_conditions_compiles():
+    """Custom graph with conditional edges compiles."""
+    config = MASConfig(
+        mas_id="cust",
+        name="Test",
+        workflow_type=WorkflowType.CUSTOM,
+        agents=[_agent("a"), _agent("b"), _agent("c")],
+        workflow_edges=[
+            WorkflowEdge(
+                from_agent="a", to_agent="b", condition="state.x == 1", label="go_b"
+            ),
+            WorkflowEdge(
+                from_agent="a", to_agent="c", condition="state.x == 2", label="go_c"
+            ),
+            WorkflowEdge(from_agent="b", to_agent="END", label="done_b"),
+            WorkflowEdge(from_agent="c", to_agent="END", label="done_c"),
+        ],
+    )
+
+    compiled = compile_mas(config)
+    graph = compiled.compile_graph()
+    assert isinstance(graph, CompiledStateGraph)
+
+
+def test_compile_graph_returns_compiled_type():
+    """compile_graph() return type is CompiledStateGraph."""
+    config = MASConfig(
+        mas_id="type_check",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_agent("a")],
+    )
+
+    compiled = compile_mas(config)
+    graph = compiled.compile_graph()
+    assert isinstance(graph, CompiledStateGraph)
+
+
+def test_checkpoint_disabled():
+    """checkpoint_enabled=False still compiles without error."""
+    config = MASConfig(
+        mas_id="no_cp",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_agent("a")],
+        checkpoint_enabled=False,
+    )
+
+    compiled = compile_mas(config)
+    graph = compiled.compile_graph()
+    assert isinstance(graph, CompiledStateGraph)
+
+
+def test_deliberative_with_edges_compiles():
+    """Deliberative workflow with edges delegates to custom builder."""
+    config = MASConfig(
+        mas_id="delib",
+        name="Test",
+        workflow_type=WorkflowType.DELIBERATIVE,
+        agents=[_agent("a"), _agent("b")],
+        workflow_edges=[
+            WorkflowEdge(from_agent="a", to_agent="b"),
+            WorkflowEdge(from_agent="b", to_agent="END"),
+        ],
+    )
+
+    compiled = compile_mas(config)
+    graph = compiled.compile_graph()
+    assert isinstance(graph, CompiledStateGraph)
+
+
+def test_deliberative_without_edges_compiles():
+    """Deliberative workflow without edges falls back to sequential."""
+    config = MASConfig(
+        mas_id="delib_seq",
+        name="Test",
+        workflow_type=WorkflowType.DELIBERATIVE,
+        agents=[_agent("a"), _agent("b")],
+    )
+
+    compiled = compile_mas(config)
+    graph = compiled.compile_graph()
+    assert isinstance(graph, CompiledStateGraph)
+
+
+# =========================================================================
+# INTEGRATION TESTS — all example YAMLs
+# =========================================================================
+
+
+@pytest.mark.parametrize(
+    "fname",
+    [
+        "simple_chain.yaml",
+        "hierarchical_voting.yaml",
+        "supervisor_moderation.yaml",
+        "consensus_network.yaml",
+        "custom_escalation.yaml",
+        "research_analysis.yaml",
+        "code_review.yaml",
+    ],
+)
+def test_example_yaml_compiles(fname):
+    """Each example YAML must compile without errors."""
+    fpath = os.path.join(_EXAMPLES_DIR, fname)
+    if not os.path.exists(fpath):
+        pytest.skip(f"{fname} not found")
+
+    config = load_mas_from_yaml(fpath)
+    result = compile_mas(config)
+
+    assert isinstance(result, CompiledMAS)
+    assert len(result.agent_nodes) == len(config.agents)
+
+    compiled = result.compile_graph()
+    assert isinstance(compiled, CompiledStateGraph)
+
+
+# =========================================================================
+# LLM AGENT NODE TESTS (mocked — no API keys required)
+# =========================================================================
+
+# Shared mock targets
+_MOCK_CREATE = "bili.aether.compiler.llm_resolver.create_llm"
+_MOCK_TOOLS = "bili.aether.compiler.llm_resolver.resolve_tools"
+
+
+def test_llm_agent_node_invokes_model():
+    """Agent node with model_name calls LLM invoke."""
+    agent = _agent("llm_agent", model_name="gpt-4o")
+
+    with patch(_MOCK_CREATE) as mock_create, patch(_MOCK_TOOLS, return_value=[]):
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = MagicMock(content="LLM response")
+        mock_create.return_value = mock_llm
+
+        node_fn = generate_agent_node(agent)
+        state = {"messages": [], "agent_outputs": {}}
+        result = node_fn(state)
+
+        mock_llm.invoke.assert_called_once()
+        assert result["current_agent"] == "llm_agent"
+        assert result["messages"][0].content == "LLM response"
+
+
+def test_agent_without_model_uses_stub():
+    """Agent without model_name falls back to stub."""
+    agent = _agent("stub_agent")  # no model_name
+    node_fn = generate_agent_node(agent)
+
+    state = {"messages": [], "agent_outputs": {}}
+    result = node_fn(state)
+    assert "[STUB]" in result["messages"][0].content
+
+
+def test_llm_agent_uses_system_prompt():
+    """Agent node passes system_prompt to LLM."""
+    agent = _agent(
+        "prompt_agent",
+        model_name="gpt-4o",
+        system_prompt="You are a helper.",
+    )
+
+    with patch(_MOCK_CREATE) as mock_create, patch(_MOCK_TOOLS, return_value=[]):
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = MagicMock(content="response")
+        mock_create.return_value = mock_llm
+
+        node_fn = generate_agent_node(agent)
+        node_fn({"messages": [], "agent_outputs": {}})
+
+        call_args = mock_llm.invoke.call_args[0][0]
+        # First message should be the SystemMessage
+        assert call_args[0].content == "You are a helper."
+
+
+def test_llm_agent_falls_back_to_objective():
+    """Agent without system_prompt uses objective as system message."""
+    agent = _agent("obj_agent", model_name="gpt-4o")
+
+    with patch(_MOCK_CREATE) as mock_create, patch(_MOCK_TOOLS, return_value=[]):
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = MagicMock(content="response")
+        mock_create.return_value = mock_llm
+
+        node_fn = generate_agent_node(agent)
+        node_fn({"messages": [], "agent_outputs": {}})
+
+        call_args = mock_llm.invoke.call_args[0][0]
+        assert call_args[0].content == "Test objective for obj_agent"
+
+
+def test_llm_agent_json_output_parsing():
+    """Agent with output_format=JSON parses response as JSON."""
+    agent = _agent(
+        "json_agent",
+        model_name="gpt-4o",
+        output_format=OutputFormat.JSON,
+    )
+
+    with patch(_MOCK_CREATE) as mock_create, patch(_MOCK_TOOLS, return_value=[]):
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = MagicMock(content='{"key": "value"}')
+        mock_create.return_value = mock_llm
+
+        node_fn = generate_agent_node(agent)
+        result = node_fn({"messages": [], "agent_outputs": {}})
+
+        assert result["agent_outputs"]["json_agent"]["parsed"] == {"key": "value"}
+        assert result["agent_outputs"]["json_agent"]["status"] == "completed"
+
+
+def test_llm_agent_json_parse_failure():
+    """Agent with output_format=JSON handles non-JSON responses gracefully."""
+    agent = _agent(
+        "bad_json",
+        model_name="gpt-4o",
+        output_format=OutputFormat.JSON,
+    )
+
+    with patch(_MOCK_CREATE) as mock_create, patch(_MOCK_TOOLS, return_value=[]):
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = MagicMock(content="not json")
+        mock_create.return_value = mock_llm
+
+        node_fn = generate_agent_node(agent)
+        result = node_fn({"messages": [], "agent_outputs": {}})
+
+        output = result["agent_outputs"]["bad_json"]
+        assert "parsed" not in output
+        assert output["raw"] == "not json"
+
+
+def test_llm_agent_has_spec_attribute():
+    """.agent_spec is accessible on LLM-backed node."""
+    agent = _agent("spec_llm", model_name="gpt-4o")
+
+    with patch(_MOCK_CREATE) as mock_create, patch(_MOCK_TOOLS, return_value=[]):
+        mock_create.return_value = MagicMock()
+        node_fn = generate_agent_node(agent)
+
+        assert hasattr(node_fn, "agent_spec")
+        assert node_fn.agent_spec.agent_id == "spec_llm"
+
+
+def test_llm_agent_forwards_state_messages():
+    """Agent node forwards existing state messages to LLM."""
+    agent = _agent("fwd_agent", model_name="gpt-4o")
+
+    with patch(_MOCK_CREATE) as mock_create, patch(_MOCK_TOOLS, return_value=[]):
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = MagicMock(content="reply")
+        mock_create.return_value = mock_llm
+
+        node_fn = generate_agent_node(agent)
+        existing_msg = HumanMessage(content="Hello agent")
+        node_fn({"messages": [existing_msg], "agent_outputs": {}})
+
+        call_args = mock_llm.invoke.call_args[0][0]
+        # SystemMessage + the existing HumanMessage
+        assert len(call_args) == 2
+        assert call_args[1].content == "Hello agent"
+
+
+# =========================================================================
+# MODEL RESOLUTION TESTS
+# =========================================================================
+
+
+def test_resolve_model_by_model_id():
+    """resolve_model finds provider by model_id match."""
+    from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+        resolve_model,
+    )
+
+    # Mock LLM_MODELS with a known entry
+    mock_models = {
+        "remote_openai": {
+            "models": [
+                {"model_name": "GPT-4o", "model_id": "gpt-4o"},
+            ]
+        }
+    }
+    with patch(
+        "bili.aether.compiler.llm_resolver.LLM_MODELS",
+        mock_models,
+        create=True,
+    ):
+        # Patch the import inside _lookup_in_llm_models
+        with patch("bili.config.llm_config.LLM_MODELS", mock_models):
+            provider, model_id = resolve_model("gpt-4o")
+            assert provider == "remote_openai"
+            assert model_id == "gpt-4o"
+
+
+def test_resolve_model_by_display_name():
+    """resolve_model maps display name to model_id."""
+    from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+        resolve_model,
+    )
+
+    mock_models = {
+        "remote_openai": {
+            "models": [
+                {"model_name": "GPT-4o", "model_id": "gpt-4o"},
+            ]
+        }
+    }
+    with patch("bili.config.llm_config.LLM_MODELS", mock_models):
+        provider, model_id = resolve_model("GPT-4o")
+        assert provider == "remote_openai"
+        assert model_id == "gpt-4o"
+
+
+def test_resolve_model_heuristic_fallback():
+    """resolve_model uses heuristic when LLM_MODELS has no match."""
+    from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+        resolve_model,
+    )
+
+    # Empty LLM_MODELS so lookup fails
+    with patch("bili.config.llm_config.LLM_MODELS", {}):
+        provider, model_id = resolve_model("gpt-4o-mini")
+        assert provider == "remote_openai"
+        # Heuristic keeps original name as model_id
+        assert model_id == "gpt-4o-mini"
+
+
+def test_resolve_model_bedrock_claude():
+    """resolve_model detects Bedrock-hosted Claude by model_id prefix."""
+    from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+        resolve_model,
+    )
+
+    with patch("bili.config.llm_config.LLM_MODELS", {}):
+        provider, _model_id = resolve_model("anthropic.claude-3-sonnet-20240229-v1:0")
+        assert provider == "remote_aws_bedrock"
+
+
+def test_resolve_model_unknown_raises():
+    """resolve_model raises ValueError for unknown model names."""
+    from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+        resolve_model,
+    )
+
+    with patch("bili.config.llm_config.LLM_MODELS", {}):
+        with pytest.raises(ValueError, match="Cannot resolve model"):
+            resolve_model("totally-unknown-model-xyz")
+
+
+# =========================================================================
+# TOOL-ENABLED AGENT TESTS
+# =========================================================================
+
+
+def test_tool_agent_uses_create_agent():
+    """Agent with tools uses create_agent() for tool-enabled execution."""
+    import sys  # pylint: disable=import-outside-toplevel
+    import types  # pylint: disable=import-outside-toplevel
+
+    agent = _agent("tool_agent", model_name="gpt-4o", tools=["mock_tool"])
+
+    mock_tool = MagicMock()
+    mock_react_agent = MagicMock()
+    mock_react_agent.invoke.return_value = {
+        "messages": [AIMessage(content="tool result", name="tool_agent")]
+    }
+
+    # Stub langchain.agents if not installed
+    mock_create_agent_fn = MagicMock(return_value=mock_react_agent)
+    langchain_stub = types.ModuleType("langchain")
+    agents_stub = types.ModuleType("langchain.agents")
+    agents_stub.create_agent = mock_create_agent_fn
+    langchain_stub.agents = agents_stub
+
+    with (
+        patch(_MOCK_CREATE) as mock_create,
+        patch(_MOCK_TOOLS, return_value=[mock_tool]),
+        patch.dict(
+            sys.modules,
+            {
+                "langchain": langchain_stub,
+                "langchain.agents": agents_stub,
+            },
+        ),
+    ):
+        mock_create.return_value = MagicMock()
+
+        node_fn = generate_agent_node(agent)
+
+        # Verify create_agent was called with the LLM and tools
+        mock_create_agent_fn.assert_called_once()
+        call_kwargs = mock_create_agent_fn.call_args
+        assert call_kwargs.kwargs["tools"] == [mock_tool]
+
+        # Invoke and check output
+        result = node_fn({"messages": [], "agent_outputs": {}})
+        assert result["current_agent"] == "tool_agent"
+        assert result["messages"][0].content == "tool result"
+
+
+def test_agent_with_empty_tools_uses_direct_llm():
+    """Agent whose tools resolve to empty list uses direct LLM invoke."""
+    agent = _agent("no_tools", model_name="gpt-4o", tools=["nonexistent"])
+
+    with patch(_MOCK_CREATE) as mock_create, patch(_MOCK_TOOLS, return_value=[]):
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = MagicMock(content="direct response")
+        mock_create.return_value = mock_llm
+
+        node_fn = generate_agent_node(agent)
+        result = node_fn({"messages": [], "agent_outputs": {}})
+
+        # Should use direct LLM, not create_agent
+        mock_llm.invoke.assert_called_once()
+        assert result["messages"][0].content == "direct response"


### PR DESCRIPTION
### This PR introduces the following changes
* Replace stub-only agent nodes with real LLM-backed nodes that invoke models via bili-core's `llm_loader` infrastructure
* Add `llm_resolver.py` module for model name → provider resolution using `LLM_MODELS` lookup and heuristic fallback
* Support three agent node modes: tool-enabled LLM (via `create_agent()`), direct LLM (via `llm.invoke()`), and stub fallback (when `model_name` is None)
* Resolve `AgentSpec.tools` to tool instances via bili-core's `initialize_tools()` with graceful fallback
* Handle bili-core's `model_name` vs `model_id` distinction so AETHER users can specify either display names or provider IDs
* Add 15 new mocked tests covering LLM invocation, model resolution, tool-enabled agents, and JSON output parsing (104 total)
* Update README to document the three agent node modes and add compiler/validation directories to the architecture tree

### Steps to Review
1. From a terminal/command prompt in the project root directory, run `git fetch`
2. Checkout the `33-build-aether-to-langgraph-compiler` branch on your local machine
3.  Run `git pull` to ensure you have the latest changes
4. Start the container `./scripts/development/start-container`
5. In another terminal window, attach the container `./scripts/development/attach-container`
6. From inside the container, install minimal dependencies: `pip install pydantic pytest pyyaml`
7. Update `pytest` with the following command: `pip install pytest --upgrade`
8. Review `bili/aether/compiler/llm_resolver.py` for model resolution logic and heuristic provider detection rules
9. Review `bili/aether/compiler/agent_generator.py` for the three-path node generation (`_generate_tool_agent_node`, `_generate_direct_llm_node`, `_generate_stub_agent_node`)
10. Run tests: `.venv/bin/python bili/aether/tests/run_tests.py -v` — all 104 tests should pass without API keys
11. Run CLI: `.venv/bin/python bili/aether/compiler/cli.py` — all 7 example YAMLs should compile successfully (using stub mode since they don't set `model_name`)
12. Verify that existing bili-core functionality is unaffected — all AETHER imports are lazy to avoid pulling in provider SDKs at module level

### Note on lazy imports
Imports from `bili.*` modules (`llm_loader`, `llm_config`, `tool_config`, `tools_loader`) are intentionally lazy (inside function bodies) because `bili/__init__.py` triggers heavy dependencies like `firebase_admin` and `torch` at import time. The test runner and CLI both stub the `bili` package to avoid this chain. Imports from `langchain_core` and `langgraph` — which are lightweight — could be moved to top-level in a future cleanup pass. Until then, have added inline pylint: disable comments for intentional lazy imports (import-outside-toplevel).



