### PR TITLE
34 implement static agent communication protocol [Task 6]

### DIFF
--- a/bili/aether/compiler/compiled_mas.py
+++ b/bili/aether/compiler/compiled_mas.py
@@ -23,6 +23,7 @@ class CompiledMAS:
     state_schema: Type
     agent_nodes: Dict[str, Callable]
     checkpoint_config: Dict[str, Any] = field(default_factory=dict)
+    channel_manager: Any = field(default=None)  # Optional ChannelManager
 
     def compile_graph(self, checkpointer=None):
         """Compile the StateGraph into an executable CompiledStateGraph.

--- a/bili/aether/compiler/graph_builder.py
+++ b/bili/aether/compiler/graph_builder.py
@@ -77,13 +77,23 @@ class GraphBuilder:  # pylint: disable=too-few-public-methods
             len(self._agent_nodes),
         )
 
-        # 6. Return CompiledMAS
+        # 6. Initialise ChannelManager if channels are configured
+        channel_manager = None
+        if self._config.channels:
+            from bili.aether.runtime.channel_manager import (  # pylint: disable=import-outside-toplevel
+                ChannelManager,
+            )
+
+            channel_manager = ChannelManager.initialize_from_config(self._config)
+
+        # 7. Return CompiledMAS
         return CompiledMAS(
             config=self._config,
             graph=self._graph,
             state_schema=self._state_schema,
             agent_nodes=dict(self._agent_nodes),
             checkpoint_config=self._config.checkpoint_config,
+            channel_manager=channel_manager,
         )
 
     # ------------------------------------------------------------------

--- a/bili/aether/compiler/state_generator.py
+++ b/bili/aether/compiler/state_generator.py
@@ -58,6 +58,12 @@ def generate_state_schema(config: MASConfig) -> Type:
     if wtype == WorkflowType.CUSTOM and config.human_in_loop:
         annotations["needs_human_review"] = bool
 
+    # Communication fields (present when channels are configured)
+    if config.channels:
+        annotations["channel_messages"] = Dict[str, Any]
+        annotations["pending_messages"] = Dict[str, list]
+        annotations["communication_log"] = list
+
     # Build a valid Python identifier from the mas_id
     safe_name = re.sub(r"[^a-zA-Z0-9_]", "_", config.mas_id)
     class_name = f"{safe_name}_State"

--- a/bili/aether/runtime/__init__.py
+++ b/bili/aether/runtime/__init__.py
@@ -1,0 +1,48 @@
+"""AETHER runtime — agent communication protocol.
+
+Provides structured inter-agent messaging through declared channels,
+with JSONL logging and LangGraph state integration.
+
+Key classes:
+    ``Message``              — Pydantic model for a single message.
+    ``MessageType``          — Enum (DIRECT, BROADCAST, REQUEST, RESPONSE).
+    ``MessageHistory``       — Ordered message collection with query helpers.
+    ``CommunicationLogger``  — JSONL file writer for message audit trails.
+    ``CommunicationChannel`` — ABC for channel implementations.
+    ``DirectChannel``        — Point-to-point messaging.
+    ``BroadcastChannel``     — One-to-many messaging.
+    ``RequestResponseChannel`` — Bidirectional request/response.
+    ``ChannelManager``       — Top-level orchestrator for all channels.
+"""
+
+from bili.aether.runtime.channel_manager import ChannelManager
+from bili.aether.runtime.channels import (
+    BroadcastChannel,
+    CommunicationChannel,
+    DirectChannel,
+    RequestResponseChannel,
+    create_channel,
+)
+from bili.aether.runtime.communication_state import (
+    format_messages_for_context,
+    get_pending_messages,
+    send_message_in_state,
+)
+from bili.aether.runtime.logger import CommunicationLogger
+from bili.aether.runtime.messages import Message, MessageHistory, MessageType
+
+__all__ = [
+    "BroadcastChannel",
+    "ChannelManager",
+    "CommunicationChannel",
+    "CommunicationLogger",
+    "DirectChannel",
+    "Message",
+    "MessageHistory",
+    "MessageType",
+    "RequestResponseChannel",
+    "create_channel",
+    "format_messages_for_context",
+    "get_pending_messages",
+    "send_message_in_state",
+]

--- a/bili/aether/runtime/channel_manager.py
+++ b/bili/aether/runtime/channel_manager.py
@@ -1,0 +1,169 @@
+"""Channel manager — creates and routes messages across all channels in a MAS.
+
+Provides a single entry point for agent nodes to send and receive
+messages without knowing the underlying channel topology.
+"""
+
+import logging
+import os
+import uuid
+from typing import Any, Dict, List, Optional
+
+from bili.aether.runtime.channels import CommunicationChannel, create_channel
+from bili.aether.runtime.logger import CommunicationLogger
+from bili.aether.runtime.messages import Message, MessageHistory
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ChannelManager:
+    """Manages all communication channels for a compiled MAS.
+
+    Responsibilities:
+        * Create channel instances from ``MASConfig.channels``.
+        * Route ``send_message`` calls to the correct channel.
+        * Aggregate pending messages for an agent across all channels.
+        * Log every message via ``CommunicationLogger``.
+
+    Usage::
+
+        mgr = ChannelManager.initialize_from_config(mas_config)
+        mgr.send_message("reviewer_to_judge", "reviewer", "Looks good.")
+        pending = mgr.get_messages_for_agent("judge")
+        mgr.close()
+    """
+
+    def __init__(
+        self,
+        channels: Optional[Dict[str, CommunicationChannel]] = None,
+        logger: Optional[CommunicationLogger] = None,
+        agent_ids: Optional[List[str]] = None,
+    ) -> None:
+        self._channels: Dict[str, CommunicationChannel] = channels or {}
+        self._logger = logger
+        self._agent_ids = agent_ids or []
+        self._global_history = MessageHistory()
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def initialize_from_config(
+        cls,
+        config: Any,
+        log_dir: Optional[str] = None,
+    ) -> "ChannelManager":
+        """Build a ``ChannelManager`` from a ``MASConfig``.
+
+        Args:
+            config: A validated ``MASConfig`` instance.
+            log_dir: Directory for the JSONL log file. Defaults to cwd.
+
+        Returns:
+            A fully initialised ``ChannelManager``.
+        """
+        agent_ids = [a.agent_id for a in config.agents]
+        channels: Dict[str, CommunicationChannel] = {}
+
+        for chan_cfg in config.channels:
+            channels[chan_cfg.channel_id] = create_channel(chan_cfg, agent_ids)
+
+        # Set up logger
+        log_dir = log_dir or os.getcwd()
+        log_filename = f"communication_{config.mas_id}_{uuid.uuid4().hex[:8]}.jsonl"
+        log_path = os.path.join(log_dir, log_filename)
+        logger = CommunicationLogger(log_path)
+
+        LOGGER.info(
+            "ChannelManager initialised for '%s' with %d channels, logging to %s",
+            config.mas_id,
+            len(channels),
+            log_path,
+        )
+
+        return cls(channels=channels, logger=logger, agent_ids=agent_ids)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def send_message(
+        self,
+        channel_id: str,
+        sender: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Message:
+        """Send a message on the specified channel.
+
+        Args:
+            channel_id: Target channel ID.
+            sender: Agent ID of the sender.
+            content: Message body.
+            metadata: Optional metadata dict.
+
+        Returns:
+            The created ``Message``.
+
+        Raises:
+            KeyError: If *channel_id* is not registered.
+        """
+        channel = self._get_channel(channel_id)
+        msg = channel.send(sender, content, metadata)
+        self._global_history.add_message(msg)
+
+        if self._logger is not None:
+            self._logger.log_message(msg)
+
+        LOGGER.debug(
+            "Message %s sent on channel '%s': %s -> %s",
+            msg.message_id,
+            channel_id,
+            sender,
+            msg.receiver,
+        )
+        return msg
+
+    def get_messages_for_agent(self, agent_id: str) -> List[Message]:
+        """Collect unread messages for *agent_id* across all channels."""
+        pending: List[Message] = []
+        for channel in self._channels.values():
+            pending.extend(channel.receive(agent_id))
+        return pending
+
+    def get_channel(self, channel_id: str) -> CommunicationChannel:
+        """Look up a channel by ID.
+
+        Raises:
+            KeyError: If *channel_id* is not registered.
+        """
+        return self._get_channel(channel_id)
+
+    @property
+    def channel_ids(self) -> List[str]:
+        """Return all registered channel IDs."""
+        return list(self._channels.keys())
+
+    @property
+    def global_history(self) -> MessageHistory:
+        """Return the global (cross-channel) message history."""
+        return self._global_history
+
+    def close(self) -> None:
+        """Flush and close the communication logger."""
+        if self._logger is not None:
+            self._logger.close()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _get_channel(self, channel_id: str) -> CommunicationChannel:
+        """Look up a channel, raising ``KeyError`` if not found."""
+        if channel_id not in self._channels:
+            raise KeyError(
+                f"Channel '{channel_id}' not found. "
+                f"Available: {list(self._channels.keys())}"
+            )
+        return self._channels[channel_id]

--- a/bili/aether/runtime/channels.py
+++ b/bili/aether/runtime/channels.py
@@ -1,0 +1,286 @@
+"""Communication channel implementations.
+
+Provides ``DirectChannel``, ``BroadcastChannel``, and
+``RequestResponseChannel`` — each backed by the ``Channel`` schema
+model from ``bili.aether.schema``.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+from bili.aether.runtime.messages import Message, MessageHistory, MessageType
+from bili.aether.schema import CommunicationProtocol
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CommunicationChannel(ABC):
+    """Abstract base for all channel types.
+
+    Subclasses implement ``send`` and ``receive`` with protocol-specific
+    validation and delivery semantics.
+
+    Args:
+        channel_config: The ``Channel`` schema model describing this channel.
+        agent_ids: All agent IDs in the MAS (used by broadcast).
+    """
+
+    def __init__(
+        self, channel_config: Any, agent_ids: Optional[List[str]] = None
+    ) -> None:
+        self.channel_config = channel_config
+        self.history = MessageHistory()
+        self._agent_ids = agent_ids or []
+        self._delivered: Dict[str, List[str]] = (
+            {}
+        )  # agent_id -> list of message_ids already read
+
+    @property
+    def channel_id(self) -> str:
+        """Shortcut to the underlying config's channel_id."""
+        return self.channel_config.channel_id
+
+    # ------------------------------------------------------------------
+    # Abstract interface
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def send(
+        self,
+        sender: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Message:
+        """Send a message on this channel. Returns the created ``Message``."""
+
+    def receive(self, agent_id: str) -> List[Message]:
+        """Return unread messages for *agent_id* on this channel."""
+        all_msgs = self.history.get_messages_for(agent_id)
+        already = set(self._delivered.get(agent_id, []))
+        new_msgs = [m for m in all_msgs if m.message_id not in already]
+        # Mark as delivered
+        self._delivered.setdefault(agent_id, []).extend(m.message_id for m in new_msgs)
+        return new_msgs
+
+    # ------------------------------------------------------------------
+    # Validation helpers
+    # ------------------------------------------------------------------
+
+    def _validate_sender(self, sender: str) -> None:
+        """Raise ``ValueError`` if *sender* is not allowed on this channel."""
+        source = self.channel_config.source
+        if source == "any":
+            return
+        if self.channel_config.bidirectional:
+            if sender not in (source, self.channel_config.target):
+                raise ValueError(
+                    f"Sender '{sender}' not allowed on bidirectional channel "
+                    f"'{self.channel_id}' (source={source}, target={self.channel_config.target})"
+                )
+            return
+        if sender != source:
+            raise ValueError(
+                f"Sender '{sender}' != expected source '{source}' "
+                f"on channel '{self.channel_id}'"
+            )
+
+
+# ======================================================================
+# Concrete channel types
+# ======================================================================
+
+
+class DirectChannel(CommunicationChannel):
+    """Point-to-point channel: source -> target.
+
+    If ``bidirectional`` is set, either end may send.
+    """
+
+    def send(
+        self,
+        sender: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Message:
+        self._validate_sender(sender)
+
+        # Determine receiver: if bidirectional, receiver is the *other* end
+        cfg = self.channel_config
+        if cfg.bidirectional:
+            receiver = cfg.target if sender == cfg.source else cfg.source
+        else:
+            receiver = cfg.target
+
+        msg = Message(
+            sender=sender,
+            receiver=receiver,
+            channel=self.channel_id,
+            content=content,
+            message_type=MessageType.DIRECT,
+            metadata=metadata or {},
+        )
+        self.history.add_message(msg)
+        return msg
+
+
+class BroadcastChannel(CommunicationChannel):
+    """One-to-many channel: source -> all agents (except sender)."""
+
+    def send(
+        self,
+        sender: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Message:
+        self._validate_sender(sender)
+
+        msg = Message(
+            sender=sender,
+            receiver="__all__",
+            channel=self.channel_id,
+            content=content,
+            message_type=MessageType.BROADCAST,
+            metadata=metadata or {},
+        )
+        self.history.add_message(msg)
+        return msg
+
+    def receive(self, agent_id: str) -> List[Message]:
+        """Broadcasts are delivered to everyone except the sender."""
+        all_msgs = [
+            m
+            for m in self.history.messages
+            if m.sender != agent_id  # exclude own broadcasts
+        ]
+        already = set(self._delivered.get(agent_id, []))
+        new_msgs = [m for m in all_msgs if m.message_id not in already]
+        self._delivered.setdefault(agent_id, []).extend(m.message_id for m in new_msgs)
+        return new_msgs
+
+
+class RequestResponseChannel(CommunicationChannel):
+    """Bidirectional request/response channel with correlation tracking.
+
+    Always operates between ``source`` and ``target`` in both directions.
+    """
+
+    def __init__(
+        self, channel_config: Any, agent_ids: Optional[List[str]] = None
+    ) -> None:
+        super().__init__(channel_config, agent_ids)
+        self._pending_requests: Dict[str, Message] = {}  # message_id -> request Message
+
+    def send(
+        self,
+        sender: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Message:
+        """Send a request (alias for ``send_request``)."""
+        return self.send_request(sender, content, metadata)
+
+    def send_request(
+        self,
+        sender: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Message:
+        """Send a request message. Returns the request ``Message``."""
+        self._validate_sender_reqresp(sender)
+        cfg = self.channel_config
+        receiver = cfg.target if sender == cfg.source else cfg.source
+
+        msg = Message(
+            sender=sender,
+            receiver=receiver,
+            channel=self.channel_id,
+            content=content,
+            message_type=MessageType.REQUEST,
+            metadata=metadata or {},
+        )
+        self._pending_requests[msg.message_id] = msg
+        self.history.add_message(msg)
+        return msg
+
+    def send_response(
+        self,
+        sender: str,
+        request_id: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Message:
+        """Send a response to a previous request.
+
+        Args:
+            sender: The responding agent ID.
+            request_id: ``message_id`` of the original request.
+            content: Response body.
+            metadata: Optional metadata.
+
+        Raises:
+            ValueError: If *request_id* is not a pending request.
+        """
+        if request_id not in self._pending_requests:
+            raise ValueError(
+                f"No pending request '{request_id}' on channel '{self.channel_id}'"
+            )
+
+        original = self._pending_requests.pop(request_id)
+        receiver = original.sender  # respond back to requester
+
+        msg = Message(
+            sender=sender,
+            receiver=receiver,
+            channel=self.channel_id,
+            content=content,
+            message_type=MessageType.RESPONSE,
+            metadata=metadata or {},
+            in_reply_to=request_id,
+        )
+        self.history.add_message(msg)
+        return msg
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _validate_sender_reqresp(self, sender: str) -> None:
+        """Either endpoint may send on a request/response channel."""
+        cfg = self.channel_config
+        if sender not in (cfg.source, cfg.target):
+            raise ValueError(
+                f"Sender '{sender}' not allowed on request/response channel "
+                f"'{self.channel_id}' (source={cfg.source}, target={cfg.target})"
+            )
+
+
+# ======================================================================
+# Factory
+# ======================================================================
+
+_CHANNEL_TYPE_MAP = {
+    CommunicationProtocol.DIRECT: DirectChannel,
+    CommunicationProtocol.BROADCAST: BroadcastChannel,
+    CommunicationProtocol.REQUEST_RESPONSE: RequestResponseChannel,
+}
+
+
+def create_channel(
+    channel_config: Any,
+    agent_ids: Optional[List[str]] = None,
+) -> CommunicationChannel:
+    """Create the appropriate channel subclass for a ``Channel`` config.
+
+    Falls back to ``DirectChannel`` for unimplemented protocol types
+    (PUBSUB, COMPETITIVE, CONSENSUS).
+    """
+    cls = _CHANNEL_TYPE_MAP.get(channel_config.protocol, DirectChannel)
+    if channel_config.protocol not in _CHANNEL_TYPE_MAP:
+        LOGGER.warning(
+            "Protocol '%s' not yet implemented; falling back to DirectChannel "
+            "for channel '%s'",
+            channel_config.protocol.value,
+            channel_config.channel_id,
+        )
+    return cls(channel_config, agent_ids)

--- a/bili/aether/runtime/communication_state.py
+++ b/bili/aether/runtime/communication_state.py
@@ -1,0 +1,131 @@
+"""State integration helpers for agent communication.
+
+Provides pure-function helpers that agent nodes call to interact with
+the communication layer through LangGraph state, without needing a
+direct reference to the ``ChannelManager``.
+
+State fields used:
+    ``channel_messages``  — ``Dict[str, list]``  channel_id -> serialised messages
+    ``pending_messages``  — ``Dict[str, list]``  agent_id  -> serialised messages
+    ``communication_log`` — ``list``             flat list of all message dicts
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from bili.aether.runtime.messages import Message, MessageType
+
+LOGGER = logging.getLogger(__name__)
+
+
+def send_message_in_state(
+    state: dict,
+    channel_id: str,
+    sender: str,
+    content: str,
+    receiver: str = "__all__",
+    message_type: MessageType = MessageType.DIRECT,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> dict:
+    """Create a message and return updated communication state fields.
+
+    This is a *pure* helper — it does not mutate *state* in place.
+    The caller merges the returned dict into the LangGraph state update.
+
+    Args:
+        state: Current LangGraph state dict.
+        channel_id: Channel to send on.
+        sender: Sending agent ID.
+        content: Message body.
+        receiver: Receiving agent ID or ``__all__``.
+        message_type: Message category.
+        metadata: Optional metadata.
+
+    Returns:
+        Dict with updated ``channel_messages``, ``pending_messages``,
+        and ``communication_log`` fields.
+    """
+    msg = Message(
+        sender=sender,
+        receiver=receiver,
+        channel=channel_id,
+        content=content,
+        message_type=message_type,
+        metadata=metadata or {},
+    )
+    msg_dict = msg.to_log_dict()
+
+    channel_messages = _update_channel_messages(state, channel_id, msg_dict)
+    pending = _update_pending_messages(state, sender, receiver, msg_dict)
+    comm_log = list(state.get("communication_log") or [])
+    comm_log.append(msg_dict)
+
+    return {
+        "channel_messages": channel_messages,
+        "pending_messages": pending,
+        "communication_log": comm_log,
+    }
+
+
+def _update_channel_messages(
+    state: dict, channel_id: str, msg_dict: dict
+) -> Dict[str, list]:
+    """Append *msg_dict* to the channel_messages entry for *channel_id*."""
+    channel_messages = dict(state.get("channel_messages") or {})
+    channel_msgs = list(channel_messages.get(channel_id, []))
+    channel_msgs.append(msg_dict)
+    channel_messages[channel_id] = channel_msgs
+    return channel_messages
+
+
+def _update_pending_messages(
+    state: dict, sender: str, receiver: str, msg_dict: dict
+) -> Dict[str, list]:
+    """Append *msg_dict* to the pending_messages for the appropriate agent(s)."""
+    pending = dict(state.get("pending_messages") or {})
+    if receiver == "__all__":
+        agent_outputs = state.get("agent_outputs") or {}
+        for aid in agent_outputs:
+            if aid != sender:
+                agent_pending = list(pending.get(aid, []))
+                agent_pending.append(msg_dict)
+                pending[aid] = agent_pending
+    else:
+        agent_pending = list(pending.get(receiver, []))
+        agent_pending.append(msg_dict)
+        pending[receiver] = agent_pending
+    return pending
+
+
+def get_pending_messages(state: dict, agent_id: str) -> List[Dict[str, Any]]:
+    """Return pending message dicts for *agent_id* and clear them from state.
+
+    Returns:
+        A list of message dicts (may be empty).
+    """
+    pending = state.get("pending_messages") or {}
+    return list(pending.get(agent_id, []))
+
+
+def format_messages_for_context(messages: List[Dict[str, Any]]) -> str:
+    """Format message dicts as human-readable text for LLM context injection.
+
+    Example output::
+
+        [From reviewer via reviewer_to_judge]: Content analysis looks good.
+        [From policy_expert via policy_channel]: No policy violations found.
+
+    Returns:
+        A newline-separated string, or empty string if no messages.
+    """
+    if not messages:
+        return ""
+
+    lines = []
+    for msg in messages:
+        sender = msg.get("sender", "unknown")
+        channel = msg.get("channel", "unknown")
+        content = msg.get("content", "")
+        lines.append(f"[From {sender} via {channel}]: {content}")
+
+    return "\n".join(lines)

--- a/bili/aether/runtime/logger.py
+++ b/bili/aether/runtime/logger.py
@@ -1,0 +1,81 @@
+"""JSONL communication logger for inter-agent messages.
+
+Writes one JSON object per line to a log file, enabling easy post-hoc
+analysis of agent communication patterns.
+"""
+
+import json
+import logging
+from typing import IO, Optional
+
+from bili.aether.runtime.messages import Message
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CommunicationLogger:
+    """Appends ``Message`` objects as JSONL to a file.
+
+    Supports the context-manager protocol so it can be used as::
+
+        with CommunicationLogger("run.jsonl") as logger:
+            logger.log_message(msg)
+
+    Attributes:
+        log_path: Filesystem path to the JSONL output file.
+    """
+
+    def __init__(self, log_path: str) -> None:
+        self.log_path = log_path
+        self._file_handle: Optional[IO[str]] = None
+
+    # ------------------------------------------------------------------
+    # Context manager
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "CommunicationLogger":
+        self._open()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # type: ignore[no-untyped-def]
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def log_message(self, message: Message) -> None:
+        """Write a single message as a JSONL line."""
+        if self._file_handle is None:
+            self._open()
+        line = json.dumps(message.to_log_dict(), default=str)
+        self._file_handle.write(line + "\n")  # type: ignore[union-attr]
+
+    def flush(self) -> None:
+        """Flush the underlying file buffer."""
+        if self._file_handle is not None:
+            self._file_handle.flush()
+
+    def close(self) -> None:
+        """Flush and close the log file."""
+        if self._file_handle is not None:
+            try:
+                self._file_handle.flush()
+                self._file_handle.close()
+            except OSError:
+                LOGGER.warning("Failed to close communication log: %s", self.log_path)
+            finally:
+                self._file_handle = None
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _open(self) -> None:
+        """Open the log file for appending (creates if missing)."""
+        if self._file_handle is None:
+            self._file_handle = (
+                open(  # noqa: SIM115  pylint: disable=consider-using-with
+                    self.log_path, "a", encoding="utf-8"
+                )
+            )

--- a/bili/aether/runtime/messages.py
+++ b/bili/aether/runtime/messages.py
@@ -1,0 +1,104 @@
+"""Structured message schema for inter-agent communication.
+
+Defines the ``Message`` model (Pydantic), ``MessageType`` enum, and
+``MessageHistory`` container used by channels and the communication logger.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class MessageType(str, Enum):
+    """Types of inter-agent messages."""
+
+    DIRECT = "direct"
+    BROADCAST = "broadcast"
+    REQUEST = "request"
+    RESPONSE = "response"
+
+
+class Message(BaseModel):
+    """A single inter-agent message.
+
+    Attributes:
+        message_id: Unique identifier (auto-generated UUID4).
+        timestamp: ISO-8601 UTC timestamp (auto-generated).
+        sender: Agent ID of the sender.
+        receiver: Agent ID of the receiver, or ``__all__`` for broadcasts.
+        channel: Channel ID this message was sent on.
+        content: Message body text.
+        message_type: Categorisation of the message.
+        metadata: Arbitrary key-value metadata.
+        in_reply_to: Optional message_id this is responding to.
+    """
+
+    message_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: str = Field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    sender: str
+    receiver: str
+    channel: str
+    content: str
+    message_type: MessageType = MessageType.DIRECT
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    in_reply_to: Optional[str] = None
+
+    def to_log_dict(self) -> Dict[str, Any]:
+        """Return a flat dict suitable for JSONL logging."""
+        return {
+            "message_id": self.message_id,
+            "timestamp": self.timestamp,
+            "sender": self.sender,
+            "receiver": self.receiver,
+            "channel": self.channel,
+            "content": self.content,
+            "message_type": self.message_type.value,
+            "metadata": self.metadata,
+            "in_reply_to": self.in_reply_to,
+        }
+
+
+class MessageHistory:
+    """Ordered collection of ``Message`` objects with query helpers.
+
+    Thread-safe for single-writer scenarios (one graph execution).
+    """
+
+    def __init__(self) -> None:
+        self._messages: List[Message] = []
+
+    @property
+    def messages(self) -> List[Message]:
+        """Return a shallow copy of the message list."""
+        return list(self._messages)
+
+    def add_message(self, message: Message) -> None:
+        """Append a message to the history."""
+        self._messages.append(message)
+
+    def get_messages_for(self, agent_id: str) -> List[Message]:
+        """Return messages where *agent_id* is the receiver or receiver is ``__all__``."""
+        return [m for m in self._messages if m.receiver in (agent_id, "__all__")]
+
+    def get_messages_from(self, agent_id: str) -> List[Message]:
+        """Return messages sent by *agent_id*."""
+        return [m for m in self._messages if m.sender == agent_id]
+
+    def get_messages_on_channel(self, channel_id: str) -> List[Message]:
+        """Return messages sent on a specific channel."""
+        return [m for m in self._messages if m.channel == channel_id]
+
+    def to_dicts(self) -> List[Dict[str, Any]]:
+        """Serialise all messages to a list of dicts."""
+        return [m.to_log_dict() for m in self._messages]
+
+    def __len__(self) -> int:
+        return len(self._messages)
+
+    def __bool__(self) -> bool:
+        return bool(self._messages)

--- a/bili/aether/tests/test_communication.py
+++ b/bili/aether/tests/test_communication.py
@@ -1,0 +1,469 @@
+"""Tests for the AETHER agent communication protocol (Task 6).
+
+Covers:
+    - Message and MessageHistory
+    - CommunicationLogger (JSONL output)
+    - Channel types (Direct, Broadcast, RequestResponse)
+    - ChannelManager
+    - Communication state helpers
+    - Integration with the compiler (state schema generation)
+"""
+
+# pylint: disable=missing-function-docstring
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from bili.aether.runtime.channel_manager import ChannelManager
+from bili.aether.runtime.channels import (
+    BroadcastChannel,
+    DirectChannel,
+    RequestResponseChannel,
+    create_channel,
+)
+from bili.aether.runtime.communication_state import (
+    format_messages_for_context,
+    get_pending_messages,
+    send_message_in_state,
+)
+from bili.aether.runtime.logger import CommunicationLogger
+from bili.aether.runtime.messages import Message, MessageHistory, MessageType
+from bili.aether.schema import AgentSpec, CommunicationProtocol, MASConfig
+from bili.aether.schema.mas_config import Channel
+
+# ======================================================================
+# Helpers
+# ======================================================================
+
+
+def _make_channel_config(
+    channel_id: str = "ch1",
+    protocol: CommunicationProtocol = CommunicationProtocol.DIRECT,
+    source: str = "agent_a",
+    target: str = "agent_b",
+    bidirectional: bool = False,
+) -> Channel:
+    """Create a minimal Channel config for testing."""
+    return Channel(
+        channel_id=channel_id,
+        protocol=protocol,
+        source=source,
+        target=target,
+        bidirectional=bidirectional,
+    )
+
+
+def _make_simple_mas(channels=None) -> MASConfig:
+    """Build a minimal 2-agent MASConfig with optional channels."""
+    agents = [
+        AgentSpec(agent_id="agent_a", role="writer", objective="Write content"),
+        AgentSpec(agent_id="agent_b", role="reviewer", objective="Review content"),
+    ]
+    return MASConfig(
+        mas_id="test_comm",
+        name="Communication Test MAS",
+        agents=agents,
+        channels=channels or [],
+        workflow_type="sequential",
+    )
+
+
+# ======================================================================
+# Message tests
+# ======================================================================
+
+
+class TestMessage:
+    """Tests for the Message Pydantic model."""
+
+    def test_message_creation_with_defaults(self):
+        msg = Message(
+            sender="agent_a",
+            receiver="agent_b",
+            channel="ch1",
+            content="Hello",
+        )
+        assert msg.sender == "agent_a"
+        assert msg.receiver == "agent_b"
+        assert msg.message_id  # UUID auto-generated
+        assert msg.timestamp  # timestamp auto-generated
+        assert msg.message_type == MessageType.DIRECT
+
+    def test_message_to_log_dict(self):
+        msg = Message(
+            sender="agent_a",
+            receiver="agent_b",
+            channel="ch1",
+            content="Hello",
+            message_type=MessageType.BROADCAST,
+            metadata={"key": "value"},
+        )
+        d = msg.to_log_dict()
+        assert d["sender"] == "agent_a"
+        assert d["message_type"] == "broadcast"
+        assert d["metadata"] == {"key": "value"}
+        assert "message_id" in d
+        assert "timestamp" in d
+
+    def test_message_uuid_uniqueness(self):
+        msgs = [
+            Message(sender="a", receiver="b", channel="c", content="x")
+            for _ in range(10)
+        ]
+        ids = {m.message_id for m in msgs}
+        assert len(ids) == 10
+
+
+# ======================================================================
+# MessageHistory tests
+# ======================================================================
+
+
+class TestMessageHistory:
+    """Tests for MessageHistory container."""
+
+    def test_add_and_query_by_agent(self):
+        history = MessageHistory()
+        msg1 = Message(sender="a", receiver="b", channel="ch", content="hi")
+        msg2 = Message(sender="b", receiver="a", channel="ch", content="hello")
+        history.add_message(msg1)
+        history.add_message(msg2)
+
+        assert len(history) == 2
+        assert len(history.get_messages_for("b")) == 1
+        assert history.get_messages_for("b")[0].content == "hi"
+
+    def test_query_by_channel(self):
+        history = MessageHistory()
+        history.add_message(
+            Message(sender="a", receiver="b", channel="ch1", content="one")
+        )
+        history.add_message(
+            Message(sender="a", receiver="b", channel="ch2", content="two")
+        )
+        assert len(history.get_messages_on_channel("ch1")) == 1
+        assert history.get_messages_on_channel("ch1")[0].content == "one"
+
+    def test_to_dicts(self):
+        history = MessageHistory()
+        history.add_message(
+            Message(sender="a", receiver="b", channel="ch", content="data")
+        )
+        dicts = history.to_dicts()
+        assert len(dicts) == 1
+        assert dicts[0]["content"] == "data"
+
+    def test_get_messages_from(self):
+        history = MessageHistory()
+        history.add_message(
+            Message(sender="a", receiver="b", channel="ch", content="from_a")
+        )
+        history.add_message(
+            Message(sender="b", receiver="a", channel="ch", content="from_b")
+        )
+        from_a = history.get_messages_from("a")
+        assert len(from_a) == 1
+        assert from_a[0].content == "from_a"
+
+
+# ======================================================================
+# CommunicationLogger tests
+# ======================================================================
+
+
+class TestCommunicationLogger:
+    """Tests for JSONL logging."""
+
+    def test_log_message_writes_jsonl(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False
+        ) as tmp:
+            log_path = tmp.name
+
+        try:
+            with CommunicationLogger(log_path) as logger:
+                msg = Message(sender="a", receiver="b", channel="ch1", content="logged")
+                logger.log_message(msg)
+
+            with open(log_path, encoding="utf-8") as fh:
+                lines = fh.readlines()
+            assert len(lines) == 1
+            data = json.loads(lines[0])
+            assert data["sender"] == "a"
+            assert data["content"] == "logged"
+        finally:
+            os.unlink(log_path)
+
+    def test_context_manager_closes_file(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False
+        ) as tmp:
+            log_path = tmp.name
+
+        try:
+            logger = CommunicationLogger(log_path)
+            with logger:
+                logger.log_message(
+                    Message(sender="a", receiver="b", channel="c", content="x")
+                )
+            # After __exit__, file handle should be None
+            assert logger._file_handle is None  # pylint: disable=protected-access
+        finally:
+            os.unlink(log_path)
+
+
+# ======================================================================
+# Channel tests
+# ======================================================================
+
+
+class TestDirectChannel:
+    """Tests for DirectChannel."""
+
+    def test_send_and_receive(self):
+        cfg = _make_channel_config()
+        ch = DirectChannel(cfg)
+
+        msg = ch.send("agent_a", "test content")
+        assert msg.receiver == "agent_b"
+        assert msg.message_type == MessageType.DIRECT
+
+        received = ch.receive("agent_b")
+        assert len(received) == 1
+        assert received[0].content == "test content"
+
+        # Second receive returns nothing (already delivered)
+        assert len(ch.receive("agent_b")) == 0
+
+    def test_bidirectional_send(self):
+        cfg = _make_channel_config(bidirectional=True)
+        ch = DirectChannel(cfg)
+
+        msg1 = ch.send("agent_a", "from a")
+        assert msg1.receiver == "agent_b"
+
+        msg2 = ch.send("agent_b", "from b")
+        assert msg2.receiver == "agent_a"
+
+    def test_invalid_sender_raises(self):
+        cfg = _make_channel_config()
+        ch = DirectChannel(cfg)
+        with pytest.raises(ValueError, match="Sender 'agent_c'"):
+            ch.send("agent_c", "not allowed")
+
+
+class TestBroadcastChannel:  # pylint: disable=too-few-public-methods
+    """Tests for BroadcastChannel."""
+
+    def test_broadcast_delivery(self):
+        cfg = _make_channel_config(
+            protocol=CommunicationProtocol.BROADCAST,
+            target="all",
+        )
+        ch = BroadcastChannel(cfg, agent_ids=["agent_a", "agent_b", "agent_c"])
+
+        ch.send("agent_a", "announcement")
+
+        # agent_b and agent_c should receive; agent_a (sender) should not
+        assert len(ch.receive("agent_b")) == 1
+        assert len(ch.receive("agent_c")) == 1
+        assert len(ch.receive("agent_a")) == 0
+
+
+class TestRequestResponseChannel:
+    """Tests for RequestResponseChannel."""
+
+    def test_request_response_flow(self):
+        cfg = _make_channel_config(
+            protocol=CommunicationProtocol.REQUEST_RESPONSE,
+        )
+        ch = RequestResponseChannel(cfg)
+
+        request = ch.send_request("agent_a", "What is the policy?")
+        assert request.message_type == MessageType.REQUEST
+
+        response = ch.send_response("agent_b", request.message_id, "Policy is X.")
+        assert response.message_type == MessageType.RESPONSE
+        assert response.in_reply_to == request.message_id
+
+    def test_response_to_unknown_request_raises(self):
+        cfg = _make_channel_config(
+            protocol=CommunicationProtocol.REQUEST_RESPONSE,
+        )
+        ch = RequestResponseChannel(cfg)
+        with pytest.raises(ValueError, match="No pending request"):
+            ch.send_response("agent_b", "fake_id", "response")
+
+
+# ======================================================================
+# create_channel factory tests
+# ======================================================================
+
+
+class TestCreateChannel:
+    """Tests for the channel factory function."""
+
+    def test_creates_direct_channel(self):
+        cfg = _make_channel_config(protocol=CommunicationProtocol.DIRECT)
+        ch = create_channel(cfg)
+        assert isinstance(ch, DirectChannel)
+
+    def test_creates_broadcast_channel(self):
+        cfg = _make_channel_config(
+            protocol=CommunicationProtocol.BROADCAST, target="all"
+        )
+        ch = create_channel(cfg)
+        assert isinstance(ch, BroadcastChannel)
+
+    def test_creates_request_response_channel(self):
+        cfg = _make_channel_config(protocol=CommunicationProtocol.REQUEST_RESPONSE)
+        ch = create_channel(cfg)
+        assert isinstance(ch, RequestResponseChannel)
+
+    def test_fallback_for_unimplemented_protocol(self):
+        cfg = _make_channel_config(protocol=CommunicationProtocol.PUBSUB)
+        ch = create_channel(cfg)
+        # Falls back to DirectChannel
+        assert isinstance(ch, DirectChannel)
+
+
+# ======================================================================
+# ChannelManager tests
+# ======================================================================
+
+
+class TestChannelManager:
+    """Tests for ChannelManager."""
+
+    def test_initialize_from_config(self):
+        channels = [
+            _make_channel_config("direct_ch", CommunicationProtocol.DIRECT),
+            _make_channel_config(
+                "broadcast_ch", CommunicationProtocol.BROADCAST, target="all"
+            ),
+        ]
+        config = _make_simple_mas(channels)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            mgr = ChannelManager.initialize_from_config(config, log_dir=tmp_dir)
+            assert len(mgr.channel_ids) == 2
+            assert "direct_ch" in mgr.channel_ids
+            assert "broadcast_ch" in mgr.channel_ids
+            mgr.close()
+
+    def test_send_and_receive(self):
+        channels = [_make_channel_config("ch1", CommunicationProtocol.DIRECT)]
+        config = _make_simple_mas(channels)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            mgr = ChannelManager.initialize_from_config(config, log_dir=tmp_dir)
+            mgr.send_message("ch1", "agent_a", "hello agent_b")
+
+            pending = mgr.get_messages_for_agent("agent_b")
+            assert len(pending) == 1
+            assert pending[0].content == "hello agent_b"
+
+            # Global history should also have the message
+            assert len(mgr.global_history) == 1
+            mgr.close()
+
+    def test_unknown_channel_raises(self):
+        mgr = ChannelManager()
+        with pytest.raises(KeyError, match="Channel 'missing'"):
+            mgr.send_message("missing", "a", "content")
+
+
+# ======================================================================
+# Communication state helpers tests
+# ======================================================================
+
+
+class TestCommunicationStateHelpers:
+    """Tests for send_message_in_state, get_pending_messages, format_messages_for_context."""
+
+    def test_send_message_in_state(self):
+        state = {
+            "channel_messages": {},
+            "pending_messages": {},
+            "communication_log": [],
+            "agent_outputs": {"agent_a": {}, "agent_b": {}},
+        }
+
+        update = send_message_in_state(
+            state,
+            channel_id="ch1",
+            sender="agent_a",
+            content="hello",
+            receiver="agent_b",
+        )
+
+        assert "ch1" in update["channel_messages"]
+        assert len(update["channel_messages"]["ch1"]) == 1
+        assert len(update["pending_messages"]["agent_b"]) == 1
+        assert len(update["communication_log"]) == 1
+
+    def test_get_pending_messages(self):
+        state = {
+            "pending_messages": {
+                "agent_b": [{"sender": "a", "content": "hi"}],
+            }
+        }
+        msgs = get_pending_messages(state, "agent_b")
+        assert len(msgs) == 1
+        assert msgs[0]["content"] == "hi"
+
+    def test_get_pending_messages_empty(self):
+        assert not get_pending_messages({}, "agent_x")
+
+    def test_format_messages_for_context(self):
+        msgs = [
+            {"sender": "reviewer", "channel": "review_ch", "content": "Looks good"},
+            {"sender": "expert", "channel": "expert_ch", "content": "No issues"},
+        ]
+        text = format_messages_for_context(msgs)
+        assert "[From reviewer via review_ch]: Looks good" in text
+        assert "[From expert via expert_ch]: No issues" in text
+
+    def test_format_messages_empty(self):
+        assert format_messages_for_context([]) == ""
+
+
+# ======================================================================
+# Integration: state schema with communication fields
+# ======================================================================
+
+
+class TestStateSchemaIntegration:
+    """Test that communication fields appear in generated state schemas."""
+
+    def test_state_schema_includes_communication_fields(self):
+        channels = [_make_channel_config()]
+        config = _make_simple_mas(channels)
+
+        from bili.aether.compiler.state_generator import (  # pylint: disable=import-outside-toplevel
+            generate_state_schema,
+        )
+
+        schema = generate_state_schema(config)
+        annotations = schema.__annotations__
+
+        assert "channel_messages" in annotations
+        assert "pending_messages" in annotations
+        assert "communication_log" in annotations
+
+    def test_state_schema_without_channels(self):
+        config = _make_simple_mas(channels=[])
+
+        from bili.aether.compiler.state_generator import (  # pylint: disable=import-outside-toplevel
+            generate_state_schema,
+        )
+
+        schema = generate_state_schema(config)
+        annotations = schema.__annotations__
+
+        assert "channel_messages" not in annotations
+        assert "pending_messages" not in annotations
+        assert "communication_log" not in annotations


### PR DESCRIPTION
### This PR introduces the following changes

* Implement the AETHER agent communication protocol with three channel types: `DirectChannel` (point-to-point), `BroadcastChannel` (one-to-many), and `RequestResponseChannel` (bidirectional with correlation tracking)
* Add JSONL communication logging — every inter-agent message is appended to an audit file with message ID, timestamp, sender, receiver, channel, content, and metadata
* Integrate communication into the LangGraph state schema — when `channels` are configured, `channel_messages`, `pending_messages`, and `communication_log` fields are automatically added
* Inject pending messages into agent system prompts before each LLM call so agents are aware of inter-agent context
* Add `ChannelManager` orchestration layer that initializes channels from MASConfig and routes messages to the correct channel
* Create pure-function state helpers [`send_message_in_state`, `get_pending_messages`, `format_messages_for_context`] for state-based communication without direct `ChannelManager` references
* Add 29 new tests covering messages, channels, logging, state helpers, and compiler integration [133 total]
* Update AETHER README with communication protocol documentation, updated architecture tree, and state schema table

### Steps to Review

1. From a terminal/command prompt in the project root directory, run `git fetch`
2. Checkout the `35-v2-integrate-bili-core-features-into-aether-agents` branch on your local machine
3.  Run `git pull` to ensure you have the latest changes
4. Start the container `./scripts/development/start-container`
5. In another terminal window, attach the container `./scripts/development/attach-container`
6. From inside the container, install minimal dependencies: `pip install pydantic pytest pyyaml`
7. Update `pytest` with the following command: `pip install pytest --upgrade`
2. Review the new `bili/aether/runtime/` package [6 files]: `messages.py`, `logger.py`, `channels.py`, `channel_manager.py`, `communication_state.py`, `__init__.py`
3. Review modifications to compiler files: `state_generator.py`, `agent_generator.py`, `graph_builder.py`, `compiled_mas.py`
4. Run the isolated test suite: `python bili/aether/run_tests.py` — verify all 133 tests pass
5. Run pylint: `pylint bili/aether/ --fail-under=9` — verify score ≥ 9/10
6. Review the updated `bili/aether/README.md` for the new "Agent Communication Protocol [Runtime]" section