### PR TITLE
35 implement bili-core inheritance integration with role registry [Task 7]

### DIFF
--- a/bili/aether/compiler/state_generator.py
+++ b/bili/aether/compiler/state_generator.py
@@ -64,6 +64,16 @@ def generate_state_schema(config: MASConfig) -> Type:
         annotations["pending_messages"] = Dict[str, list]
         annotations["communication_log"] = list
 
+    # Inheritance state fields (when agents use bili-core inheritance)
+    try:
+        from bili.aether.integration.state_integration import (  # pylint: disable=import-outside-toplevel
+            get_inheritance_state_fields,
+        )
+
+        annotations.update(get_inheritance_state_fields(config.agents))
+    except ImportError:
+        pass  # integration package not available
+
     # Build a valid Python identifier from the mas_id
     safe_name = re.sub(r"[^a-zA-Z0-9_]", "_", config.mas_id)
     class_name = f"{safe_name}_State"

--- a/bili/aether/config/examples/inherited_research.yaml
+++ b/bili/aether/config/examples/inherited_research.yaml
@@ -1,0 +1,62 @@
+# =============================================================================
+# Research Pipeline with bili-core Inheritance
+# =============================================================================
+#
+# Demonstrates using inherit_from_bili_core to get default system prompts,
+# tools, and temperature from the role registry.
+#
+# Agents only need: agent_id, role, and objective. Everything else is
+# inherited from bili-core's role defaults.
+#
+# To use real LLMs, add model_name to each agent (e.g. model_name: gpt-4o).
+# Without model_name, agents run in stub mode for testing.
+# =============================================================================
+
+mas_id: inherited_research
+name: Research Pipeline (with bili-core Inheritance)
+description: >
+  Minimal agent definitions that inherit system prompts, tools, and
+  temperature from bili-core's role registry.
+version: "1.0.0"
+
+workflow_type: sequential
+
+agents:
+  - agent_id: researcher
+    role: researcher
+    objective: >
+      Search for information on the assigned topic and compile findings.
+    inherit_from_bili_core: true
+    # Inherits: system_prompt, tools=[serp_api_tool], temperature=0.5
+    # Add model_name: gpt-4o for real LLM execution
+
+  - agent_id: fact_checker
+    role: fact_checker
+    objective: >
+      Verify the claims gathered by the researcher.
+    inherit_from_bili_core: true
+    # Inherits: system_prompt, tools=[serp_api_tool], temperature=0.2
+
+  - agent_id: analyst
+    role: analyst
+    objective: >
+      Analyse verified findings and identify patterns.
+    inherit_from_bili_core: true
+    inherit_tools: false
+    # Inherits: system_prompt, temperature=0.3 (but NOT tools)
+
+  - agent_id: writer
+    role: documentation_writer
+    objective: >
+      Write a comprehensive report from the analysis.
+    inherit_from_bili_core: true
+    system_prompt: >
+      You are a report writer. Synthesise all findings into a clear,
+      well-structured report with executive summary and recommendations.
+    # Custom system_prompt overrides registry default
+    # Inherits: temperature=0.4
+
+tags:
+  - research
+  - inheritance
+  - bili-core

--- a/bili/aether/integration/__init__.py
+++ b/bili/aether/integration/__init__.py
@@ -1,0 +1,26 @@
+"""AETHER-to-bili-core integration layer.
+
+Provides role-based default resolution and inheritance application
+for ``AgentSpec`` instances that opt into bili-core features via
+``inherit_from_bili_core=True``.
+
+All bili-core imports are lazy -- this package loads without
+heavy dependencies (torch, firebase_admin, provider SDKs).
+"""
+
+from .inheritance import apply_inheritance, apply_inheritance_to_all
+from .role_registry import (
+    ROLE_DEFAULTS,
+    RoleDefaults,
+    get_role_defaults,
+    register_role_defaults,
+)
+
+__all__ = [
+    "apply_inheritance",
+    "apply_inheritance_to_all",
+    "ROLE_DEFAULTS",
+    "RoleDefaults",
+    "get_role_defaults",
+    "register_role_defaults",
+]

--- a/bili/aether/integration/inheritance.py
+++ b/bili/aether/integration/inheritance.py
@@ -1,0 +1,191 @@
+"""Core inheritance resolution for AETHER agents.
+
+Applies bili-core defaults to ``AgentSpec`` instances based on their
+inheritance flags and role-based defaults from the role registry.
+
+Priority rule: user-specified values in the ``AgentSpec`` **always**
+take priority over inherited defaults.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+LOGGER = logging.getLogger(__name__)
+
+
+def apply_inheritance(
+    agent: Any,
+    mas_config: Optional[Any] = None,
+) -> Any:
+    """Apply bili-core inheritance to a single agent.
+
+    If ``agent.inherit_from_bili_core`` is ``False``, returns the agent
+    unchanged (no copy is made).
+
+    Args:
+        agent: The ``AgentSpec`` to enrich.
+        mas_config: Optional parent ``MASConfig`` (reserved for future
+            MAS-level defaults such as shared checkpoint config).
+
+    Returns:
+        A new ``AgentSpec`` with inherited defaults merged in, or the
+        original agent if inheritance is disabled.
+    """
+    if not agent.inherit_from_bili_core:
+        return agent
+
+    from .role_registry import (  # pylint: disable=import-outside-toplevel
+        get_role_defaults,
+    )
+
+    defaults = get_role_defaults(agent.role)
+    if defaults is None:
+        LOGGER.info(
+            "No role defaults registered for '%s'; "
+            "inheritance enabled but no defaults to apply for agent '%s'",
+            agent.role,
+            agent.agent_id,
+        )
+        return agent
+
+    updates: Dict[str, object] = {}
+
+    if agent.inherit_system_prompt:
+        _apply_system_prompt(agent, defaults, updates)
+
+    if agent.inherit_llm_config:
+        _apply_llm_config(agent, defaults, updates)
+
+    if agent.inherit_tools:
+        _apply_tools(agent, defaults, updates)
+        _apply_capabilities(agent, defaults, updates)
+
+    if agent.inherit_memory:
+        _apply_memory(agent, defaults, updates)
+
+    if agent.inherit_checkpoint:
+        _apply_checkpoint(agent, defaults, updates, mas_config)
+
+    if not updates:
+        LOGGER.debug(
+            "Agent '%s': inheritance enabled but no defaults applied "
+            "(all fields already set by user)",
+            agent.agent_id,
+        )
+        return agent
+
+    LOGGER.info(
+        "Agent '%s': applied bili-core inheritance (fields: %s)",
+        agent.agent_id,
+        list(updates.keys()),
+    )
+    return agent.model_copy(update=updates)
+
+
+def apply_inheritance_to_all(
+    agents: List[Any],
+    mas_config: Optional[Any] = None,
+) -> List[Any]:
+    """Apply inheritance to a list of agents.
+
+    Returns:
+        A new list with each agent potentially replaced by an
+        enriched copy.
+    """
+    return [apply_inheritance(agent, mas_config) for agent in agents]
+
+
+# =========================================================================
+# Per-flag resolution helpers
+# =========================================================================
+
+
+def _apply_system_prompt(agent: Any, defaults: Any, updates: Dict[str, object]) -> None:
+    """Inherit system_prompt if the agent has not set one."""
+    if agent.system_prompt is None and defaults.system_prompt is not None:
+        updates["system_prompt"] = defaults.system_prompt
+        LOGGER.debug(
+            "Agent '%s': inherited system_prompt from role '%s'",
+            agent.agent_id,
+            agent.role,
+        )
+
+
+def _apply_llm_config(agent: Any, defaults: Any, updates: Dict[str, object]) -> None:
+    """Inherit temperature (when default 0.0) and model_name (when None)."""
+    if agent.temperature == 0.0 and defaults.temperature is not None:
+        updates["temperature"] = defaults.temperature
+        LOGGER.debug(
+            "Agent '%s': inherited temperature=%.2f from role '%s'",
+            agent.agent_id,
+            defaults.temperature,
+            agent.role,
+        )
+
+    if agent.model_name is None and defaults.model_name is not None:
+        updates["model_name"] = defaults.model_name
+        LOGGER.debug(
+            "Agent '%s': inherited model_name='%s' from role '%s'",
+            agent.agent_id,
+            defaults.model_name,
+            agent.role,
+        )
+
+
+def _apply_tools(agent: Any, defaults: Any, updates: Dict[str, object]) -> None:
+    """Additively merge registry tools into agent's tool list."""
+    if not defaults.tools:
+        return
+
+    merged: List[str] = list(defaults.tools)
+    for tool in agent.tools:
+        if tool not in merged:
+            merged.append(tool)
+
+    if merged != list(agent.tools):
+        updates["tools"] = merged
+        LOGGER.debug(
+            "Agent '%s': merged tools %s (was %s)",
+            agent.agent_id,
+            merged,
+            list(agent.tools),
+        )
+
+
+def _apply_capabilities(agent: Any, defaults: Any, updates: Dict[str, object]) -> None:
+    """Additively merge registry capabilities into agent's capabilities."""
+    if not defaults.capabilities:
+        return
+
+    merged = list(agent.capabilities)
+    for cap in defaults.capabilities:
+        if cap not in merged:
+            merged.append(cap)
+
+    if merged != list(agent.capabilities):
+        updates["capabilities"] = merged
+
+
+def _apply_memory(  # pylint: disable=unused-argument
+    agent: Any,
+    defaults: Any,
+    updates: Dict[str, object],
+) -> None:
+    """Apply memory-related inheritance.
+
+    Currently a no-op.  Future implementation could configure
+    agent-level memory management from bili-core settings.
+    """
+
+
+def _apply_checkpoint(  # pylint: disable=unused-argument
+    agent: Any,
+    defaults: Any,
+    updates: Dict[str, object],
+    mas_config: Optional[Any] = None,
+) -> None:
+    """Apply checkpoint-related inheritance.
+
+    Currently a no-op.  Checkpoint configuration is MAS-level (not
+    agent-level) and is already handled by ``MASConfig.checkpoint_config``.
+    """

--- a/bili/aether/integration/role_registry.py
+++ b/bili/aether/integration/role_registry.py
@@ -1,0 +1,248 @@
+"""Role-based default registry for bili-core inheritance.
+
+Maps free-form role strings to default configurations that can be
+inherited by AETHER agents when ``inherit_from_bili_core=True``.
+
+Each entry provides optional defaults for system prompt, model name,
+temperature, tools, and capabilities.  Tools listed here are name
+strings referencing ``bili.loaders.tools_loader.TOOL_REGISTRY`` keys;
+resolution to instances happens downstream in
+``bili.aether.compiler.llm_resolver.resolve_tools()``.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class RoleDefaults:
+    """Default configuration for an agent role.
+
+    All fields are optional -- ``None`` means 'no default, keep the
+    agent's own value'.  List fields are additive (merged into the
+    agent's existing list during inheritance).
+    """
+
+    system_prompt: Optional[str] = None
+    model_name: Optional[str] = None
+    temperature: Optional[float] = None
+    tools: List[str] = field(default_factory=list)
+    capabilities: List[str] = field(default_factory=list)
+
+
+# =========================================================================
+# REGISTRY
+# =========================================================================
+
+ROLE_DEFAULTS: Dict[str, RoleDefaults] = {
+    # -----------------------------------------------------------------
+    # Content Moderation
+    # -----------------------------------------------------------------
+    "content_reviewer": RoleDefaults(
+        system_prompt=(
+            "You are a content review specialist. Analyse submitted "
+            "content against established community guidelines and "
+            "platform policies. Identify potential violations, "
+            "categorise severity, and provide detailed reasoning for "
+            "each finding. Be thorough but fair in your assessments."
+        ),
+        temperature=0.3,
+        capabilities=["text_analysis", "policy_enforcement"],
+    ),
+    "policy_expert": RoleDefaults(
+        system_prompt=(
+            "You are a policy interpretation expert. When presented "
+            "with content and policy questions, provide authoritative "
+            "guidance by referencing specific policy sections. Use "
+            "your knowledge base to look up relevant policies and "
+            "precedents. Cite the exact policy clauses that apply."
+        ),
+        temperature=0.2,
+        tools=["faiss_retriever"],
+        capabilities=["policy_lookup", "rule_interpretation"],
+    ),
+    "judge": RoleDefaults(
+        system_prompt=(
+            "You are an impartial decision-maker. Review evidence and "
+            "arguments from other agents, weigh them carefully, and "
+            "render a final verdict. Your decisions must be "
+            "well-reasoned, cite specific evidence, and consider all "
+            "perspectives presented."
+        ),
+        temperature=0.1,
+        capabilities=["decision_making", "evidence_synthesis"],
+    ),
+    "appeals_specialist": RoleDefaults(
+        system_prompt=(
+            "You are an appeals review specialist. Re-examine "
+            "moderation decisions with fresh perspective, considering "
+            "context that may have been missed. Look up relevant "
+            "precedents and ensure fair treatment of all parties. "
+            "Provide a clear recommendation with supporting reasoning."
+        ),
+        temperature=0.3,
+        tools=["faiss_retriever"],
+        capabilities=["context_analysis", "precedent_lookup"],
+    ),
+    "community_manager": RoleDefaults(
+        system_prompt=(
+            "You are a community manager responsible for monitoring "
+            "content and flagging items that may require review. "
+            "Triage incoming content by severity and route it to the "
+            "appropriate specialist agents."
+        ),
+        temperature=0.3,
+        capabilities=["content_triage", "community_monitoring"],
+    ),
+    # -----------------------------------------------------------------
+    # Research & Analysis
+    # -----------------------------------------------------------------
+    "researcher": RoleDefaults(
+        system_prompt=(
+            "You are a research specialist. Search for and gather "
+            "comprehensive information on assigned topics. Compile "
+            "relevant sources, data points, and findings. Cite your "
+            "sources and organise findings clearly."
+        ),
+        temperature=0.5,
+        tools=["serp_api_tool"],
+        capabilities=["web_search", "document_analysis", "summarization"],
+    ),
+    "analyst": RoleDefaults(
+        system_prompt=(
+            "You are a data analyst. Examine provided information to "
+            "identify patterns, trends, and insights. Provide both "
+            "quantitative and qualitative analysis with clear "
+            "reasoning and actionable conclusions."
+        ),
+        temperature=0.3,
+        capabilities=["data_analysis", "pattern_recognition", "reporting"],
+    ),
+    "fact_checker": RoleDefaults(
+        system_prompt=(
+            "You are a rigorous fact-checker. Verify claims by "
+            "cross-referencing multiple sources. Flag unverified "
+            "claims, rate confidence levels, and provide source "
+            "citations for all verified facts."
+        ),
+        temperature=0.2,
+        tools=["serp_api_tool"],
+        capabilities=["web_search", "source_verification", "claim_analysis"],
+    ),
+    # -----------------------------------------------------------------
+    # Code & Technical
+    # -----------------------------------------------------------------
+    "code_reviewer": RoleDefaults(
+        system_prompt=(
+            "You are a senior code reviewer. Analyse code for quality, "
+            "security vulnerabilities, performance issues, and "
+            "adherence to best practices. Provide actionable feedback "
+            "with specific references and suggested fixes."
+        ),
+        temperature=0.2,
+        capabilities=["static_analysis", "best_practices", "security_scanning"],
+    ),
+    "security_auditor": RoleDefaults(
+        system_prompt=(
+            "You are a security auditor. Identify vulnerabilities, "
+            "assess threat models, and recommend mitigations. Follow "
+            "OWASP guidelines and industry security standards in your "
+            "analysis."
+        ),
+        temperature=0.1,
+        capabilities=["vulnerability_detection", "threat_modeling"],
+    ),
+    "documentation_writer": RoleDefaults(
+        system_prompt=(
+            "You are a technical documentation specialist. Create "
+            "clear, accurate, and well-structured documentation. "
+            "Explain complex concepts in accessible language while "
+            "maintaining technical precision."
+        ),
+        temperature=0.4,
+        capabilities=["technical_writing", "code_explanation"],
+    ),
+    # -----------------------------------------------------------------
+    # Customer Support
+    # -----------------------------------------------------------------
+    "support_agent": RoleDefaults(
+        system_prompt=(
+            "You are a customer support specialist. Help users "
+            "resolve issues by searching the knowledge base for "
+            "relevant solutions. Be empathetic, clear, and thorough "
+            "in your responses."
+        ),
+        temperature=0.4,
+        tools=["faiss_retriever"],
+        capabilities=["ticket_handling", "knowledge_base_search"],
+    ),
+    "escalation_specialist": RoleDefaults(
+        system_prompt=(
+            "You are an escalation specialist handling complex issues "
+            "that require deeper investigation. Analyse the full "
+            "context, coordinate with other agents, and advocate for "
+            "resolution."
+        ),
+        temperature=0.3,
+        capabilities=["complex_issue_resolution", "customer_advocacy"],
+    ),
+    # -----------------------------------------------------------------
+    # Workflow Patterns
+    # -----------------------------------------------------------------
+    "supervisor": RoleDefaults(
+        system_prompt=(
+            "You are a workflow supervisor. Analyse incoming tasks, "
+            "route them to the most appropriate specialist agents, "
+            "and monitor quality of outputs. Coordinate agent "
+            "activities and ensure tasks are completed effectively."
+        ),
+        temperature=0.2,
+        capabilities=["task_routing", "agent_coordination", "quality_control"],
+    ),
+    "voter": RoleDefaults(
+        system_prompt=(
+            "You are a consensus participant. Evaluate the topic at "
+            "hand, form a well-reasoned position, and cast your vote "
+            "with justification. Consider other perspectives before "
+            "finalising your decision."
+        ),
+        temperature=0.3,
+        capabilities=["evaluation", "voting"],
+    ),
+    "advocate": RoleDefaults(
+        system_prompt=(
+            "You are a debate advocate. Present well-structured "
+            "arguments supported by evidence. Anticipate "
+            "counterarguments and address them proactively."
+        ),
+        temperature=0.5,
+        capabilities=["argumentation", "evidence_presentation"],
+    ),
+}
+
+
+# =========================================================================
+# PUBLIC API
+# =========================================================================
+
+
+def get_role_defaults(role: str) -> Optional[RoleDefaults]:
+    """Look up defaults for a role.
+
+    Returns ``None`` if the role has no registered defaults.
+    """
+    return ROLE_DEFAULTS.get(role)
+
+
+def register_role_defaults(role: str, defaults: RoleDefaults) -> None:
+    """Register or override defaults for a role at runtime.
+
+    Args:
+        role: The role string (must match ``AgentSpec.role``).
+        defaults: A ``RoleDefaults`` instance with desired defaults.
+    """
+    ROLE_DEFAULTS[role] = defaults
+    LOGGER.info("Registered role defaults for '%s'", role)

--- a/bili/aether/integration/state_integration.py
+++ b/bili/aether/integration/state_integration.py
@@ -1,0 +1,31 @@
+"""State schema extensions for bili-core inheritance.
+
+Adds additional TypedDict annotation fields when agents use bili-core
+inheritance.  Currently minimal -- extended as inheritance features grow.
+"""
+
+import logging
+from typing import Any, Dict, List
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_inheritance_state_fields(
+    agents: List[Any],
+) -> Dict[str, Any]:
+    """Return additional state annotation fields for inheritance.
+
+    Args:
+        agents: List of ``AgentSpec`` instances from the MAS config.
+
+    Returns:
+        A dict of ``{field_name: type_annotation}`` to merge into the
+        state schema.  Empty if no agents use inheritance.
+    """
+    has_inheritance = any(getattr(a, "inherit_from_bili_core", False) for a in agents)
+    if not has_inheritance:
+        return {}
+
+    # Extension point: add fields like user_context, memory_state
+    # as inheritance features expand.
+    return {}

--- a/bili/aether/tests/test_bili_core_integration.py
+++ b/bili/aether/tests/test_bili_core_integration.py
@@ -1,0 +1,289 @@
+"""Tests for bili-core integration (inheritance resolution) — Task 7.
+
+Covers:
+    - Role defaults registry
+    - Inheritance resolution logic (per-flag, priority, selectivity)
+    - apply_inheritance_to_all batch helper
+    - State integration extension point
+
+All tests run under the isolated test runner (``run_tests.py``) which
+stubs the top-level ``bili`` package.  No actual bili-core dependencies
+(firebase, torch, LLM providers) are needed.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from bili.aether.integration.inheritance import (
+    apply_inheritance,
+    apply_inheritance_to_all,
+)
+from bili.aether.integration.role_registry import (
+    ROLE_DEFAULTS,
+    RoleDefaults,
+    get_role_defaults,
+    register_role_defaults,
+)
+from bili.aether.integration.state_integration import get_inheritance_state_fields
+from bili.aether.schema import AgentSpec
+
+# ======================================================================
+# Helpers
+# ======================================================================
+
+
+def _make_agent(**kwargs) -> AgentSpec:
+    """Create a minimal AgentSpec for testing."""
+    defaults = {
+        "agent_id": "test_agent",
+        "role": "researcher",
+        "objective": "Test objective for this agent",
+        "inherit_from_bili_core": True,
+    }
+    defaults.update(kwargs)
+    return AgentSpec(**defaults)
+
+
+# ======================================================================
+# Role Registry tests
+# ======================================================================
+
+
+class TestRoleRegistry:
+    """Tests for the role defaults registry."""
+
+    def test_known_roles_have_defaults(self):
+        expected_roles = [
+            "content_reviewer",
+            "policy_expert",
+            "judge",
+            "appeals_specialist",
+            "community_manager",
+            "researcher",
+            "analyst",
+            "fact_checker",
+            "code_reviewer",
+            "security_auditor",
+            "documentation_writer",
+            "support_agent",
+            "escalation_specialist",
+            "supervisor",
+            "voter",
+            "advocate",
+        ]
+        for role in expected_roles:
+            assert (
+                get_role_defaults(role) is not None
+            ), f"Role '{role}' missing from ROLE_DEFAULTS"
+
+    def test_unknown_role_returns_none(self):
+        assert get_role_defaults("nonexistent_role_xyz") is None
+
+    def test_register_custom_role(self):
+        register_role_defaults(
+            "test_custom_role_7",
+            RoleDefaults(
+                system_prompt="Custom prompt for testing",
+                tools=["mock_tool"],
+            ),
+        )
+        defaults = get_role_defaults("test_custom_role_7")
+        assert defaults is not None
+        assert defaults.system_prompt == "Custom prompt for testing"
+        assert "mock_tool" in defaults.tools
+
+    def test_all_roles_have_system_prompts(self):
+        for role, defaults in ROLE_DEFAULTS.items():
+            assert (
+                defaults.system_prompt is not None
+            ), f"Role '{role}' missing system_prompt"
+            assert (
+                len(defaults.system_prompt) > 20
+            ), f"Role '{role}' system_prompt too short"
+
+    def test_role_defaults_dataclass_defaults(self):
+        rd = RoleDefaults()
+        assert rd.system_prompt is None
+        assert rd.model_name is None
+        assert rd.temperature is None
+        assert rd.tools == []
+        assert rd.capabilities == []
+
+
+# ======================================================================
+# Inheritance Logic tests
+# ======================================================================
+
+
+class TestInheritance:
+    """Tests for apply_inheritance()."""
+
+    def test_no_inheritance_returns_same_object(self):
+        agent = _make_agent(inherit_from_bili_core=False)
+        result = apply_inheritance(agent)
+        assert result is agent
+
+    def test_system_prompt_inherited_when_none(self):
+        agent = _make_agent(system_prompt=None)
+        result = apply_inheritance(agent)
+        assert result.system_prompt is not None
+        assert "research" in result.system_prompt.lower()
+
+    def test_system_prompt_not_overridden(self):
+        agent = _make_agent(system_prompt="My custom prompt")
+        result = apply_inheritance(agent)
+        assert result.system_prompt == "My custom prompt"
+
+    def test_tools_merged_additively(self):
+        agent = _make_agent(tools=["mock_tool"])
+        result = apply_inheritance(agent)
+        assert "serp_api_tool" in result.tools
+        assert "mock_tool" in result.tools
+
+    def test_tools_deduplicated(self):
+        agent = _make_agent(tools=["serp_api_tool"])
+        result = apply_inheritance(agent)
+        assert result.tools.count("serp_api_tool") == 1
+
+    def test_tools_registry_first(self):
+        agent = _make_agent(tools=["mock_tool"])
+        result = apply_inheritance(agent)
+        assert result.tools.index("serp_api_tool") < result.tools.index("mock_tool")
+
+    def test_temperature_inherited_when_default(self):
+        agent = _make_agent(temperature=0.0)
+        result = apply_inheritance(agent)
+        assert result.temperature == 0.5  # researcher default
+
+    def test_temperature_not_overridden_when_set(self):
+        agent = _make_agent(temperature=0.8)
+        result = apply_inheritance(agent)
+        assert result.temperature == 0.8
+
+    def test_model_name_inherited_when_none(self):
+        register_role_defaults(
+            "test_model_role",
+            RoleDefaults(
+                system_prompt="Test prompt for model role",
+                model_name="gpt-4",
+            ),
+        )
+        agent = _make_agent(role="test_model_role", model_name=None)
+        result = apply_inheritance(agent)
+        assert result.model_name == "gpt-4"
+
+    def test_model_name_not_overridden(self):
+        register_role_defaults(
+            "test_model_role_2",
+            RoleDefaults(
+                system_prompt="Test prompt",
+                model_name="gpt-4",
+            ),
+        )
+        agent = _make_agent(
+            role="test_model_role_2",
+            model_name="claude-sonnet-3-5-20241022",
+        )
+        result = apply_inheritance(agent)
+        assert result.model_name == "claude-sonnet-3-5-20241022"
+
+    def test_capabilities_merged(self):
+        agent = _make_agent(capabilities=["custom_cap"])
+        result = apply_inheritance(agent)
+        assert "custom_cap" in result.capabilities
+        assert "web_search" in result.capabilities
+
+    def test_unknown_role_returns_agent_unchanged(self):
+        agent = _make_agent(role="completely_unknown_role")
+        result = apply_inheritance(agent)
+        assert result is agent
+
+    def test_selective_inherit_system_prompt_only(self):
+        agent = _make_agent(
+            inherit_tools=False,
+            inherit_llm_config=False,
+            inherit_memory=False,
+            inherit_checkpoint=False,
+        )
+        result = apply_inheritance(agent)
+        assert result.system_prompt is not None
+        assert result.tools == []
+        assert result.temperature == 0.0
+
+    def test_selective_inherit_tools_only(self):
+        agent = _make_agent(
+            inherit_system_prompt=False,
+            inherit_llm_config=False,
+        )
+        result = apply_inheritance(agent)
+        assert result.system_prompt is None
+        assert "serp_api_tool" in result.tools
+
+    def test_original_agent_not_mutated(self):
+        agent = _make_agent(tools=["mock_tool"])
+        original_tools = list(agent.tools)
+        _ = apply_inheritance(agent)
+        assert agent.tools == original_tools
+
+
+# ======================================================================
+# Batch helper tests
+# ======================================================================
+
+
+class TestApplyInheritanceToAll:
+    """Tests for apply_inheritance_to_all()."""
+
+    def test_mixed_agents(self):
+        agents = [
+            AgentSpec(
+                agent_id="a1",
+                role="researcher",
+                objective="Research something useful",
+                inherit_from_bili_core=True,
+            ),
+            AgentSpec(
+                agent_id="a2",
+                role="analyst",
+                objective="Analyse something useful",
+                inherit_from_bili_core=False,
+            ),
+        ]
+        results = apply_inheritance_to_all(agents)
+        assert len(results) == 2
+        assert results[0].system_prompt is not None
+        assert results[1].system_prompt is None
+
+    def test_empty_list(self):
+        assert apply_inheritance_to_all([]) == []
+
+
+# ======================================================================
+# State integration tests
+# ======================================================================
+
+
+class TestStateIntegration:  # pylint: disable=too-few-public-methods
+    """Tests for state integration extension point."""
+
+    def test_returns_empty_when_no_inheritance(self):
+        agents = [
+            AgentSpec(
+                agent_id="a1",
+                role="analyst",
+                objective="Analyse something useful",
+                inherit_from_bili_core=False,
+            ),
+        ]
+        assert not get_inheritance_state_fields(agents)
+
+    def test_returns_dict_when_inheritance_active(self):
+        agents = [
+            AgentSpec(
+                agent_id="a1",
+                role="researcher",
+                objective="Research something useful",
+                inherit_from_bili_core=True,
+            ),
+        ]
+        result = get_inheritance_state_fields(agents)
+        assert isinstance(result, dict)

--- a/bili/aether/tests/test_compiler.py
+++ b/bili/aether/tests/test_compiler.py
@@ -461,6 +461,7 @@ def test_deliberative_without_edges_compiles():
         "custom_escalation.yaml",
         "research_analysis.yaml",
         "code_review.yaml",
+        "inherited_research.yaml",
     ],
 )
 def test_example_yaml_compiles(fname):


### PR DESCRIPTION
### This PR introduces the following changes 

* Activate the dormant `inherit_from_bili_core` flags on `AgentSpec` by building an integration layer that resolves role-based defaults before node generation
* Create `bili/aether/integration/role_registry.py` with `RoleDefaults` dataclass and `ROLE_DEFAULTS` registry containing 16 roles, each with full system prompts, default tools, temperature, and capabilities
* Create `bili/aether/integration/inheritance.py` with `apply_inheritance()` that merges defaults per enabled sub-flag [`inherit_system_prompt`, `inherit_llm_config`, `inherit_tools`, `inherit_memory`, `inherit_checkpoint`] while preserving user-specified values as highest priority
* Hook inheritance resolution into `graph_builder.py` between state schema generation and node generation, with graceful degradation if the integration package is unavailable
* Add `state_integration.py` extension point for future state schema fields when inheritance is active
* Create `inherited_research.yaml` example demonstrating inheritance with selective opt-out [`inherit_tools: false`] and custom `system_prompt` override
* Add 24 new tests covering role registry, per-flag inheritance logic, priority rules, selectivity, immutability, and batch application [158 total, pylint 9.79/10]
* Update AETHER README with "bili-core Inheritance" section documenting flags, role registry table, and YAML usage

### Steps to Review

1. From a terminal/command prompt in the project root directory, run `git fetch`
2. Checkout the `35-v2-integrate-bili-core-features-into-aether-agents` branch on your local machine
3.  Run `git pull` to ensure you have the latest changes
4. Start the container `./scripts/development/start-container`
5. In another terminal window, attach the container `./scripts/development/attach-container`
6. From inside the container, install minimal dependencies: `pip install pydantic pytest pyyaml`
7. Update `pytest` with the following command: `pip install pytest --upgrade`
8. Review the new `bili/aether/integration/` package (4 files): `role_registry.py`, `inheritance.py`, `state_integration.py`, `__init__.py`
9. Review the hook in `bili/aether/compiler/graph_builder.py` [`_apply_inheritance()` method and its call in `build()`]
10. Review the minor addition to `bili/aether/compiler/state_generator.py` [safe ImportError fallback]
11. Review the example YAML at `bili/aether/config/examples/inherited_research.yaml`
12. Run the isolated test suite: `python bili/aether/tests/run_tests.py -v` — verify all 158 tests pass
13. Run only integration tests: `python bili/aether/tests/run_tests.py -v -k "bili_core"` — verify 24 new tests pass
14. Review the updated `bili/aether/README.md` for the new "bili-core Inheritance" section



