### PR TITLE
Add checkpointer factory and per-agent middleware support for AETHER …

### DIFF
--- a/bili/aether/config/examples/middleware_checkpointer.yaml
+++ b/bili/aether/config/examples/middleware_checkpointer.yaml
@@ -1,0 +1,73 @@
+# =============================================================================
+# Middleware + Checkpointer Configuration Example
+# =============================================================================
+#
+# Demonstrates per-agent middleware and MAS-level checkpoint configuration.
+#
+# Features shown:
+#   - Per-agent summarization middleware
+#   - Per-agent model call limiting
+#   - MAS-level checkpoint type selection (auto-detect)
+#   - keep_last_n configuration for checkpointer pruning
+#
+# To use real LLMs, add model_name to each agent (e.g. model_name: gpt-4o).
+# Without model_name, agents run in stub mode for testing.
+# =============================================================================
+
+mas_id: middleware_checkpointer_demo
+name: Middleware and Checkpointer Demo
+description: >
+  Demonstrates per-agent middleware (summarization, model call limiting)
+  and MAS-level checkpoint configuration with auto-detection.
+version: "1.0.0"
+
+workflow_type: sequential
+
+# Checkpoint configuration (MAS-level)
+checkpoint_enabled: true
+checkpoint_config:
+  type: auto        # auto-detect: postgres > mongo > memory
+  keep_last_n: 10   # keep last 10 checkpoints per thread
+
+agents:
+  - agent_id: researcher
+    role: researcher
+    objective: >
+      Search for information on the given topic and compile findings.
+      Summarise sources for downstream analysis.
+    temperature: 0.5
+    tools:
+      - serp_api_tool
+    middleware:
+      - summarization
+    middleware_params:
+      summarization:
+        max_tokens_before_summary: 4000
+        messages_to_keep: 20
+    # Add model_name: gpt-4o for real LLM execution
+
+  - agent_id: analyst
+    role: analyst
+    objective: >
+      Analyse the research findings.  Rate-limit model calls to prevent
+      runaway analysis loops.
+    temperature: 0.3
+    tools:
+      - serp_api_tool
+    middleware:
+      - model_call_limit
+    middleware_params:
+      model_call_limit:
+        run_limit: 10
+
+  - agent_id: writer
+    role: documentation_writer
+    objective: >
+      Write a clear, well-structured report from the analysis findings.
+    temperature: 0.4
+    # No middleware — straightforward generation task
+
+tags:
+  - middleware
+  - checkpointer
+  - auto-detection

--- a/bili/aether/integration/__init__.py
+++ b/bili/aether/integration/__init__.py
@@ -1,13 +1,14 @@
 """AETHER-to-bili-core integration layer.
 
-Provides role-based default resolution and inheritance application
-for ``AgentSpec`` instances that opt into bili-core features via
-``inherit_from_bili_core=True``.
+Provides role-based default resolution, inheritance application,
+and checkpointer factory for ``AgentSpec`` / ``MASConfig`` instances
+that opt into bili-core features.
 
 All bili-core imports are lazy -- this package loads without
 heavy dependencies (torch, firebase_admin, provider SDKs).
 """
 
+from .checkpointer_factory import create_checkpointer_from_config
 from .inheritance import apply_inheritance, apply_inheritance_to_all
 from .role_registry import (
     ROLE_DEFAULTS,
@@ -19,6 +20,7 @@ from .role_registry import (
 __all__ = [
     "apply_inheritance",
     "apply_inheritance_to_all",
+    "create_checkpointer_from_config",
     "ROLE_DEFAULTS",
     "RoleDefaults",
     "get_role_defaults",

--- a/bili/aether/integration/checkpointer_factory.py
+++ b/bili/aether/integration/checkpointer_factory.py
@@ -1,0 +1,162 @@
+"""Checkpointer factory — maps MASConfig.checkpoint_config to bili-core checkpointers.
+
+All bili-core imports are lazy so this module loads without heavy
+dependencies (psycopg, pymongo, etc.).
+"""
+
+import logging
+from typing import Any, Dict
+
+LOGGER = logging.getLogger(__name__)
+
+# Supported type aliases → canonical names
+_TYPE_ALIASES: Dict[str, str] = {
+    "memory": "memory",
+    "postgres": "postgres",
+    "pg": "postgres",
+    "mongo": "mongo",
+    "mongodb": "mongo",
+    "auto": "auto",
+}
+
+
+def create_checkpointer_from_config(config: Dict[str, Any]) -> Any:
+    """Create a checkpointer instance from a checkpoint_config dict.
+
+    Args:
+        config: Dict with at minimum a ``"type"`` key.  Additional keys
+            (e.g. ``"keep_last_n"``) are forwarded to the checkpointer
+            constructor where supported.
+
+    Returns:
+        A checkpointer instance suitable for
+        ``StateGraph.compile(checkpointer=...)``.  Falls back to
+        ``MemorySaver`` if the requested type is unavailable.
+    """
+    raw_type = config.get("type", "memory")
+    checkpoint_type = _TYPE_ALIASES.get(raw_type.lower())
+
+    if checkpoint_type is None:
+        LOGGER.warning(
+            "Unknown checkpoint type '%s'; falling back to memory. "
+            "Supported types: %s",
+            raw_type,
+            list(_TYPE_ALIASES.keys()),
+        )
+        return _create_memory_checkpointer()
+
+    dispatch = {
+        "memory": _create_memory_checkpointer,
+        "postgres": _create_postgres_checkpointer,
+        "mongo": _create_mongo_checkpointer,
+        "auto": _create_auto_checkpointer,
+    }
+    return dispatch[checkpoint_type](config)
+
+
+# =========================================================================
+# Per-type helpers
+# =========================================================================
+
+
+def _create_memory_checkpointer(
+    _config: Dict[str, Any] = None,  # pylint: disable=unused-argument
+) -> Any:
+    """Create a QueryableMemorySaver, falling back to plain MemorySaver."""
+    try:
+        from bili.checkpointers.memory_checkpointer import (  # pylint: disable=import-outside-toplevel
+            QueryableMemorySaver,
+        )
+
+        LOGGER.info("Created QueryableMemorySaver checkpointer")
+        return QueryableMemorySaver()
+    except ImportError:
+        pass
+
+    from langgraph.checkpoint.memory import (  # pylint: disable=import-error,import-outside-toplevel
+        MemorySaver,
+    )
+
+    LOGGER.info(
+        "Created MemorySaver checkpointer " "(QueryableMemorySaver unavailable)"
+    )
+    return MemorySaver()
+
+
+def _create_postgres_checkpointer(config: Dict[str, Any]) -> Any:
+    """Create a PostgreSQL checkpointer via bili-core."""
+    keep_last_n = config.get("keep_last_n", 5)
+    try:
+        from bili.checkpointers.pg_checkpointer import (  # pylint: disable=import-outside-toplevel
+            get_pg_checkpointer,
+        )
+
+        checkpointer = get_pg_checkpointer(keep_last_n=keep_last_n)
+        if checkpointer is not None:
+            LOGGER.info(
+                "Created PostgreSQL checkpointer (keep_last_n=%d)",
+                keep_last_n,
+            )
+            return checkpointer
+        LOGGER.warning(
+            "PostgreSQL checkpointer returned None "
+            "(POSTGRES_CONNECTION_STRING not set?); "
+            "falling back to memory"
+        )
+    except ImportError:
+        LOGGER.warning(
+            "bili.checkpointers.pg_checkpointer not available; "
+            "falling back to memory"
+        )
+    return _create_memory_checkpointer()
+
+
+def _create_mongo_checkpointer(config: Dict[str, Any]) -> Any:
+    """Create a MongoDB checkpointer via bili-core."""
+    keep_last_n = config.get("keep_last_n", 5)
+    try:
+        from bili.checkpointers.mongo_checkpointer import (  # pylint: disable=import-outside-toplevel
+            get_mongo_checkpointer,
+        )
+
+        checkpointer = get_mongo_checkpointer(keep_last_n=keep_last_n)
+        if checkpointer is not None:
+            LOGGER.info(
+                "Created MongoDB checkpointer (keep_last_n=%d)",
+                keep_last_n,
+            )
+            return checkpointer
+        LOGGER.warning(
+            "MongoDB checkpointer returned None "
+            "(MONGO_CONNECTION_STRING not set?); "
+            "falling back to memory"
+        )
+    except ImportError:
+        LOGGER.warning(
+            "bili.checkpointers.mongo_checkpointer not available; "
+            "falling back to memory"
+        )
+    return _create_memory_checkpointer()
+
+
+def _create_auto_checkpointer(
+    _config: Dict[str, Any] = None,  # pylint: disable=unused-argument
+) -> Any:
+    """Auto-detect checkpointer using bili-core's ``get_checkpointer()``."""
+    try:
+        from bili.checkpointers.checkpointer_functions import (  # pylint: disable=import-outside-toplevel
+            get_checkpointer,
+        )
+
+        checkpointer = get_checkpointer()
+        LOGGER.info(
+            "Auto-detected checkpointer: %s",
+            type(checkpointer).__name__,
+        )
+        return checkpointer
+    except ImportError:
+        LOGGER.warning(
+            "bili.checkpointers.checkpointer_functions not available; "
+            "falling back to memory"
+        )
+    return _create_memory_checkpointer()

--- a/bili/aether/schema/__init__.py
+++ b/bili/aether/schema/__init__.py
@@ -16,9 +16,6 @@ Modules:
 - enums.py: Structural enumerations (workflow types, protocols, etc.)
 """
 
-# Agent specification
-from .agent_spec import AgentSpec
-
 # Agent presets
 from .agent_presets import (
     AGENT_PRESETS,
@@ -28,12 +25,11 @@ from .agent_presets import (
     register_preset,
 )
 
+# Agent specification
+from .agent_spec import AgentSpec
+
 # Structural enums only (no domain-specific enums)
-from .enums import (
-    CommunicationProtocol,
-    OutputFormat,
-    WorkflowType,
-)
+from .enums import CommunicationProtocol, OutputFormat, WorkflowType
 
 # MAS configuration
 from .mas_config import Channel, MASConfig, WorkflowEdge

--- a/bili/aether/schema/agent_spec.py
+++ b/bili/aether/schema/agent_spec.py
@@ -127,6 +127,28 @@ class AgentSpec(BaseModel):
     )
 
     # =========================================================================
+    # MIDDLEWARE CONFIGURATION
+    # =========================================================================
+
+    middleware: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Middleware names to apply to this agent's execution. "
+            "Available: 'summarization', 'model_call_limit'. "
+            "Middleware only applies to tool-enabled agents (via create_agent)."
+        ),
+    )
+
+    middleware_params: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Parameters for middleware, keyed by middleware name. "
+            "E.g. {'summarization': {'max_tokens_before_summary': 4000}, "
+            "'model_call_limit': {'run_limit': 10}}"
+        ),
+    )
+
+    # =========================================================================
     # bili-core INTEGRATION
     # =========================================================================
 

--- a/bili/aether/schema/mas_config.py
+++ b/bili/aether/schema/mas_config.py
@@ -209,8 +209,13 @@ class MASConfig(BaseModel):
     )
 
     checkpoint_config: Dict[str, Any] = Field(
-        default_factory=lambda: {"type": "sqlite", "path": "checkpoints.db"},
-        description="Checkpoint configuration (type, path, etc.)",
+        default_factory=lambda: {"type": "memory"},
+        description=(
+            "Checkpoint backend configuration. Supported types: "
+            "'memory' (default), 'postgres'/'pg', 'mongo'/'mongodb', "
+            "'auto' (env-based detection). Additional keys like "
+            "'keep_last_n' are forwarded to the checkpointer constructor."
+        ),
     )
 
     # =========================================================================

--- a/bili/aether/tests/test_compiler.py
+++ b/bili/aether/tests/test_compiler.py
@@ -462,6 +462,7 @@ def test_deliberative_without_edges_compiles():
         "research_analysis.yaml",
         "code_review.yaml",
         "inherited_research.yaml",
+        "middleware_checkpointer.yaml",
     ],
 )
 def test_example_yaml_compiles(fname):


### PR DESCRIPTION
### This PR introduces the following changes 

* **Checkpointer factory** — `checkpoint_config` in `MASConfig` now actually creates bili-core checkpointers (`QueryableMemorySaver`, `PruningPostgresSaver`, `PruningMongoDBSaver`, or auto-detect) instead of being ignored; fixed misleading `sqlite` default to `memory`
* **Per-agent middleware** — Added `middleware` and `middleware_params` fields to `AgentSpec`, wired through `agent_generator.py` to pass resolved middleware instances to `create_agent()` for tool-enabled agents
* **New module** `bili/aether/integration/checkpointer_factory.py` with type dispatch, aliases (`pg`→`postgres`, `mongodb`→`mongo`), and graceful fallback to `MemorySaver` when backends are unavailable
* **New middleware resolution** in `agent_generator.py` via `_resolve_middleware()` using bili-core's `initialize_middleware()`, with warning when middleware is configured on agents without tools
* **New example config** `middleware_checkpointer.yaml` demonstrating per-agent summarization, model call limiting, and auto-detect checkpoint config
* **15 new tests** (10 checkpointer factory, 5 middleware fields) — total suite now at 174 tests passing, pylint 9.80/10
* **README updated** with Checkpointer Configuration and Per-Agent Middleware documentation sections


### Steps to Review

1. From a terminal/command prompt in the project root directory, run `git fetch`
2. Checkout the `46-optional-integrate-bilicore-x-aether-checkpointer-factory-and-middleware` branch on your local machine
3.  Run `git pull` to ensure you have the latest changes
4. Start the container `./scripts/development/start-container`
5. In another terminal window, attach the container `./scripts/development/attach-container`
6. From inside the container, install minimal dependencies: `pip install pydantic pytest pyyaml`
7. Update `pytest` with the following command: `pip install pytest --upgrade`
8. Run the AETHER test suite: `python bili/aether/tests/run_tests.py -v`
9. Run only the new tests: `python bili/aether/tests/run_tests.py -v -k "Checkpointer or Middleware"`
10. Review the new factory module at `bili/aether/integration/checkpointer_factory.py` — verify fallback chains match bili-core's checkpointer hierarchy
11. Review middleware wiring in `bili/aether/compiler/agent_generator.py` — confirm it mirrors the pattern in `bili/nodes/react_agent_node.py`
12. Check the example config compiles: `python bili/aether/tests/run_tests.py -v -k "test_example_yaml"`