### PR TITLE
Add additional_headers param for Vertex AI Priority/Provisioned Throughput

### DIFF
--- a/bili/loaders/llm_loader.py
+++ b/bili/loaders/llm_loader.py
@@ -17,8 +17,9 @@ Functions:
     - load_llamacpp_model(model_name, max_tokens, temperature, top_p=1.0, top_k=50, seed=None):
       Loads a compatible model using the LlamaCpp library with specified configuration options.
     - load_remote_gcp_vertex_model(model_name, max_tokens, temperature,
-            top_p=None, top_k=None, seed=None):
+            top_p=None, top_k=None, seed=None, additional_headers=None):
       Loads a remote GCP Vertex AI model with the specified configuration parameters.
+      Supports additional_headers for Priority PayGo and Provisioned Throughput.
     - load_remote_bedrock_model(model_name, max_tokens, temperature, top_p=None,
             top_k=None, seed=None):
       Initializes and loads a remote bedrock model from AWS Bedrock service.


### PR DESCRIPTION
## Summary
- Adds `additional_headers` parameter to `load_remote_gcp_vertex_model()` 
- Enables Priority PayGo and Provisioned Throughput support for Vertex AI

## Usage

**Priority PayGo (1.8x cost, higher priority queue):**
```python
load_model(
    model_type="remote_google_vertex",
    model_name="gemini-2.5-flash",
    additional_headers={
        "X-Vertex-AI-LLM-Request-Type": "shared",
        "X-Vertex-AI-LLM-Shared-Request-Type": "priority"
    }
)
```

**Provisioned Throughput (dedicated capacity):**
```python
load_model(
    model_type="remote_google_vertex",
    model_name="gemini-2.5-flash",
    additional_headers={
        "X-Vertex-AI-LLM-Request-Type": "dedicated"
    }
)
```

## Context
Addressing P99 latency spikes (93s observed) in Katie. Priority PayGo allows testing latency improvements without commitment before considering Provisioned Throughput.

## Test plan
- [ ] Verify `additional_headers` passed through to ChatVertexAI
- [ ] Test with Priority header and check `trafficType: ON_DEMAND_PRIORITY` in response