### PR TITLE
fix: Separate historical_context from summary in system prompt

### DIFF
--- a/bili/nodes/add_persona_and_summary.py
+++ b/bili/nodes/add_persona_and_summary.py
@@ -158,7 +158,7 @@ def build_add_persona_and_summary_node(persona: str, **_kwargs):
         # Inject historical context (previous session summaries) if present.
         # This is kept separate from the rolling summary to prevent recursive nesting.
         if "historical_context" in state and state["historical_context"]:
-            message_content += f"\n\n{state['historical_context']}"
+            message_content += f"\n\nPrevious session context:\n{state['historical_context']}"
 
         if "summary" in state and state["summary"]:
             message_content += (


### PR DESCRIPTION
## Summary
- Injects `historical_context` (previous session summaries) as a distinct section in the system prompt, separate from the rolling `summary`
- Prevents `trim_summarize` from folding historical summaries into the rolling summary, which caused recursive nesting and exponential token bloat across sessions (35K+ → 5K input tokens)
- Uses duck-typing (`if "historical_context" in state`) so no changes to bili-core's `State` class are needed — consumers define the field in their own state classes
- Adds "Previous session context:" header label for consistency with the rolling summary's "Summary of the current conversation:" label
- Documents the `historical_context` state key in the function's docstring

## Context
When consumers inject previous session summaries into `state["summary"]`, `trim_summarize` reads that field as `existing_summary_content` and folds it into the new rolling summary. Each subsequent trim re-nests the historical content deeper. After ~8 sessions, a simple greeting consumed 38K input tokens — 33K from nested summary content.

This fix separates the two concepts:
- `state["historical_context"]` — previous session summaries (injected once, never touched by `trim_summarize`)
- `state["summary"]` — rolling current-session summary (owned exclusively by `trim_summarize`)

## Test plan
- [x] Verified with 90-utterance conversation: input tokens stable at 5-8K (was 35-39K before fix)
- [x] Confirmed `state["summary"]` stays empty on new sessions
- [x] Confirmed `state["historical_context"]` appears correctly in system prompt with header label
- [x] Confirmed `trim_summarize` runs cleanly without historical content
- [x] No HTTP 413 errors from oversized summary payloads