### PR TITLE
Task 3 wire real time agent output streaming to chat UI

### DIFF
--- a/bili/aether/compiler/agent_generator.py
+++ b/bili/aether/compiler/agent_generator.py
@@ -208,6 +208,13 @@ def _generate_direct_llm_node(agent: AgentSpec, llm: object) -> Callable[[dict],
         # Invoke the LLM directly
         response = llm.invoke(messages)
         content = response.content
+        # Some providers (e.g. Google Vertex) return content as a list of parts.
+        # Normalise to a plain string so all downstream consumers receive str.
+        if isinstance(content, list):
+            content = " ".join(
+                part.get("text", str(part)) if isinstance(part, dict) else str(part)
+                for part in content
+            )
 
         execution_ms = (time.time() - start_time) * 1000
         LOGGER.info(

--- a/bili/aether/compiler/agent_generator.py
+++ b/bili/aether/compiler/agent_generator.py
@@ -17,6 +17,22 @@ from bili.aether.schema import AgentSpec, OutputFormat
 LOGGER = logging.getLogger(__name__)
 
 
+def _normalise_content_value(content: Any) -> str:
+    """Coerce a raw LLM content value to ``str``.
+
+    Some providers (e.g. Google Vertex / Gemini) return content as a list of
+    part dicts such as ``[{"type": "text", "text": "..."}]``.  Joins text
+    parts into a single string; falls back to ``str()`` for unrecognised
+    types.  Returns an empty string for falsy input.
+    """
+    if isinstance(content, list):
+        return " ".join(
+            part.get("text", str(part)) if isinstance(part, dict) else str(part)
+            for part in content
+        )
+    return content or ""
+
+
 def _normalise_message_content(msg: Any) -> Any:
     """Return *msg* with its ``content`` coerced to ``str`` if it is a list.
 
@@ -24,15 +40,11 @@ def _normalise_message_content(msg: Any) -> Any:
     list of content-part dicts.  Forwarding such messages as conversation
     history to the same or a different provider can cause serialisation errors
     (e.g. Vertex rejects a message with an unrecognised parts structure).
-    Joining the text parts into a single string is the safest normalisation.
+    Delegates to :func:`_normalise_content_value` for the join logic.
     """
     if not hasattr(msg, "content") or not isinstance(msg.content, list):
         return msg
-    normalised = " ".join(
-        part.get("text", str(part)) if isinstance(part, dict) else str(part)
-        for part in msg.content
-    )
-    return msg.model_copy(update={"content": normalised})
+    return msg.model_copy(update={"content": _normalise_content_value(msg.content)})
 
 
 def generate_agent_node(agent: AgentSpec) -> Callable[[dict], dict]:
@@ -157,16 +169,7 @@ def _generate_tool_agent_node(
         response_messages = result.get("messages", [])
         content = ""
         if response_messages:
-            raw = response_messages[-1].content or ""
-            # Normalise list-of-parts responses (e.g. Google Vertex / Gemini)
-            # to a plain string so downstream consumers always receive str.
-            if isinstance(raw, list):
-                content = " ".join(
-                    part.get("text", str(part)) if isinstance(part, dict) else str(part)
-                    for part in raw
-                )
-            else:
-                content = raw
+            content = _normalise_content_value(response_messages[-1].content)
 
         output = _build_output(agent, content)
         agent_outputs = dict(state.get("agent_outputs") or {})
@@ -240,14 +243,7 @@ def _generate_direct_llm_node(agent: AgentSpec, llm: object) -> Callable[[dict],
 
         # Invoke the LLM directly
         response = llm.invoke(messages)
-        content = response.content
-        # Some providers (e.g. Google Vertex) return content as a list of parts.
-        # Normalise to a plain string so all downstream consumers receive str.
-        if isinstance(content, list):
-            content = " ".join(
-                part.get("text", str(part)) if isinstance(part, dict) else str(part)
-                for part in content
-            )
+        content = _normalise_content_value(response.content)
 
         execution_ms = (time.time() - start_time) * 1000
         LOGGER.info(

--- a/bili/aether/compiler/agent_generator.py
+++ b/bili/aether/compiler/agent_generator.py
@@ -17,6 +17,24 @@ from bili.aether.schema import AgentSpec, OutputFormat
 LOGGER = logging.getLogger(__name__)
 
 
+def _normalise_message_content(msg: Any) -> Any:
+    """Return *msg* with its ``content`` coerced to ``str`` if it is a list.
+
+    Some LLM providers (e.g. Google Vertex / Gemini) return ``content`` as a
+    list of content-part dicts.  Forwarding such messages as conversation
+    history to the same or a different provider can cause serialisation errors
+    (e.g. Vertex rejects a message with an unrecognised parts structure).
+    Joining the text parts into a single string is the safest normalisation.
+    """
+    if not hasattr(msg, "content") or not isinstance(msg.content, list):
+        return msg
+    normalised = " ".join(
+        part.get("text", str(part)) if isinstance(part, dict) else str(part)
+        for part in msg.content
+    )
+    return msg.model_copy(update={"content": normalised})
+
+
 def generate_agent_node(agent: AgentSpec) -> Callable[[dict], dict]:
     """Create a node callable for the given agent.
 
@@ -112,6 +130,12 @@ def _generate_tool_agent_node(
 
         messages = list(state.get("messages", []))
 
+        # Normalise any list-content messages from previous agents (e.g. Gemini
+        # returns content as a list of parts).  Providers like Google Vertex reject
+        # messages where content is a list they don't recognise when those messages
+        # are forwarded as conversation history to a subsequent agent.
+        messages = [_normalise_message_content(m) for m in messages]
+
         has_system = any(isinstance(m, SystemMessage) for m in messages)
         if not has_system:
             messages.insert(0, SystemMessage(content=system_prompt))
@@ -133,7 +157,16 @@ def _generate_tool_agent_node(
         response_messages = result.get("messages", [])
         content = ""
         if response_messages:
-            content = response_messages[-1].content or ""
+            raw = response_messages[-1].content or ""
+            # Normalise list-of-parts responses (e.g. Google Vertex / Gemini)
+            # to a plain string so downstream consumers always receive str.
+            if isinstance(raw, list):
+                content = " ".join(
+                    part.get("text", str(part)) if isinstance(part, dict) else str(part)
+                    for part in raw
+                )
+            else:
+                content = raw
 
         output = _build_output(agent, content)
         agent_outputs = dict(state.get("agent_outputs") or {})
@@ -186,10 +219,10 @@ def _generate_direct_llm_node(agent: AgentSpec, llm: object) -> Callable[[dict],
         if comm_context:
             system_prompt += "\n\n--- Messages from other agents ---\n" + comm_context
 
-        # Filter state messages to compatible types
+        # Filter state messages to compatible types and normalise list content
         state_messages = state.get("messages", [])
         compatible = [
-            m
+            _normalise_message_content(m)
             for m in state_messages
             if isinstance(m, (AIMessage, HumanMessage, SystemMessage))
         ]

--- a/bili/aether/compiler/graph_builder.py
+++ b/bili/aether/compiler/graph_builder.py
@@ -35,6 +35,14 @@ def _build_supervisor_routing_instructions(
     Args:
         supervisor_id: The supervisor agent's ID (excluded from worker list).
         workers: List of worker AgentSpec objects.
+
+    Note:
+        Assumes a single-supervisor topology where all non-supervisor agents
+        are routable workers for this supervisor.  In a hypothetical
+        multi-supervisor config each supervisor's worker list would include
+        the other supervisors, which is unlikely to be correct.  That edge
+        case is not supported by any current example config and is left as a
+        known limitation.
     """
     worker_lines = "\n".join(
         f"  - {w.agent_id} ({w.role}): {(w.objective or '').strip()[:120]}"

--- a/bili/aether/compiler/graph_builder.py
+++ b/bili/aether/compiler/graph_builder.py
@@ -23,6 +23,38 @@ from .state_generator import _merge_dicts, _replace_value, generate_state_schema
 LOGGER = logging.getLogger(__name__)
 
 
+def _build_supervisor_routing_instructions(
+    supervisor_id: str,
+    workers: list,
+) -> str:
+    """Return routing instructions to append to a supervisor agent's system prompt.
+
+    Tells the LLM the available worker agent IDs and the exact format it must
+    use to route to one of them (or end the workflow).
+
+    Args:
+        supervisor_id: The supervisor agent's ID (excluded from worker list).
+        workers: List of worker AgentSpec objects.
+    """
+    worker_lines = "\n".join(
+        f"  - {w.agent_id} ({w.role}): {(w.objective or '').strip()[:120]}"
+        for w in workers
+    )
+    return (
+        "\n\n--- ROUTING INSTRUCTIONS ---\n"
+        "You are the supervisor of a multi-agent system. After analysing the input "
+        "you MUST route to exactly one worker agent by including a routing decision "
+        "in your response.\n\n"
+        f"Available workers:\n{worker_lines}\n\n"
+        "To route to a worker, include ONE of the following in your response:\n"
+        '  JSON format (preferred): {"next_agent": "<agent_id>", ...other fields...}\n'
+        "  Text format:             ROUTE_TO: <agent_id>\n\n"
+        'Use "next_agent": "END" (or ROUTE_TO: END) only when all workers have '
+        "reported back and you are ready to produce a final synthesised answer.\n"
+        "Do NOT output a final answer on the first turn — route to a worker first."
+    )
+
+
 # Safe expression evaluator for workflow conditions
 # Allows: comparisons, boolean ops, attribute access, constants
 # Blocks: imports, exec, function calls, comprehensions
@@ -218,10 +250,29 @@ class GraphBuilder:  # pylint: disable=too-few-public-methods,too-many-instance-
         self._apply_inheritance()
 
         # 2. Generate agent node callables
+        # For supervisor workflows, inject routing instructions into the supervisor's
+        # system prompt so the LLM knows to output a "next_agent" routing decision.
+        supervisor_workers: Dict[str, list] = {}
+        if self._config.workflow_type == WorkflowType.SUPERVISOR:
+            for agent in self._config.agents:
+                if agent.is_supervisor:
+                    workers = [
+                        a for a in self._config.agents if a.agent_id != agent.agent_id
+                    ]
+                    supervisor_workers[agent.agent_id] = workers
+
         for agent in self._config.agents:
             if agent.pipeline:
                 node_fn = self._compile_pipeline_node(agent)
             else:
+                if agent.agent_id in supervisor_workers:
+                    routing_suffix = _build_supervisor_routing_instructions(
+                        agent.agent_id, supervisor_workers[agent.agent_id]
+                    )
+                    base_prompt = agent.system_prompt or agent.objective or ""
+                    agent = agent.model_copy(
+                        update={"system_prompt": base_prompt + routing_suffix}
+                    )
                 node_fn = generate_agent_node(agent)
             wrapped = wrap_agent_node(node_fn, agent.agent_id)
             self._agent_nodes[agent.agent_id] = wrapped

--- a/bili/aether/compiler/llm_resolver.py
+++ b/bili/aether/compiler/llm_resolver.py
@@ -131,15 +131,15 @@ def create_llm(agent: AgentSpec) -> Any:
             f"cannot create LLM instance."
         )
 
+    # resolve_model handles both LLM_MODELS lookup and heuristic fallback.
+    # A second call to _lookup_in_llm_models retrieves provider-specific extras
+    # (e.g. api_version for Azure OpenAI) without duplicating the fallback logic.
+    provider, model_id = resolve_model(agent.model_name)
     lookup = _lookup_in_llm_models(agent.model_name)
-    if lookup is not None:
-        provider, model_id, extra_kwargs = lookup
-    else:
-        provider, model_id = resolve_model(agent.model_name)
-        extra_kwargs = {}
+    extra_kwargs: Dict[str, Any] = lookup[2] if lookup is not None else {}
 
-    # Build kwargs for load_model — start with provider-specific extras
-    # (e.g. api_version for Azure OpenAI), then apply agent overrides.
+    # Build kwargs for load_model — start with provider-specific extras,
+    # then apply agent-level overrides (temperature, max_tokens).
     kwargs: Dict[str, Any] = {"model_name": model_id, **extra_kwargs}
     if agent.temperature is not None:
         kwargs["temperature"] = agent.temperature

--- a/bili/aether/compiler/llm_resolver.py
+++ b/bili/aether/compiler/llm_resolver.py
@@ -44,6 +44,50 @@ _HEURISTIC_RULES = [
 ]
 
 
+def _resolve_model_full(
+    model_name: str,
+) -> Tuple[str, str, Dict[str, Any]]:
+    """Resolve a model name to ``(provider_type, model_id, extra_kwargs)`` in one pass.
+
+    Search order:
+        1. Exact match on ``model_id`` in ``LLM_MODELS``
+        2. Exact match on display ``model_name`` in ``LLM_MODELS``
+        3. Heuristic fallback using prefix/substring rules
+           (``extra_kwargs`` is empty for heuristic matches)
+
+    Raises:
+        ValueError: If the model cannot be resolved to any provider.
+    """
+    # --- 1 & 2: Look up in LLM_MODELS (single pass, returns extra_kwargs) ---
+    result = _lookup_in_llm_models(model_name)
+    if result is not None:
+        provider, model_id, extra_kwargs = result
+        LOGGER.debug(
+            "Resolved '%s' via LLM_MODELS → provider=%s, model_id=%s",
+            model_name,
+            provider,
+            model_id,
+        )
+        return provider, model_id, extra_kwargs
+
+    # --- 3: Heuristic fallback (model_name IS the model_id) ---
+    lower = model_name.lower()
+    for pattern, ptype in _HEURISTIC_RULES:
+        if pattern in lower:
+            LOGGER.debug(
+                "Resolved '%s' via heuristic ('%s') → %s (using as model_id)",
+                model_name,
+                pattern,
+                ptype,
+            )
+            return ptype, model_name, {}
+
+    raise ValueError(
+        f"Cannot resolve model '{model_name}' to a provider. "
+        f"Set a recognised model_name or use bili.loaders.llm_loader directly."
+    )
+
+
 def resolve_model(model_name: str) -> Tuple[str, str]:
     """Resolve a model name to a ``(provider_type, model_id)`` pair.
 
@@ -65,34 +109,8 @@ def resolve_model(model_name: str) -> Tuple[str, str]:
     Raises:
         ValueError: If the model cannot be resolved to any provider.
     """
-    # --- 1 & 2: Look up in LLM_MODELS ---
-    result = _lookup_in_llm_models(model_name)
-    if result is not None:
-        provider, model_id, _ = result
-        LOGGER.debug(
-            "Resolved '%s' via LLM_MODELS → provider=%s, model_id=%s",
-            model_name,
-            provider,
-            model_id,
-        )
-        return provider, model_id
-
-    # --- 3: Heuristic fallback (model_name IS the model_id) ---
-    lower = model_name.lower()
-    for pattern, ptype in _HEURISTIC_RULES:
-        if pattern in lower:
-            LOGGER.debug(
-                "Resolved '%s' via heuristic ('%s') → %s (using as model_id)",
-                model_name,
-                pattern,
-                ptype,
-            )
-            return ptype, model_name
-
-    raise ValueError(
-        f"Cannot resolve model '{model_name}' to a provider. "
-        f"Set a recognised model_name or use bili.loaders.llm_loader directly."
-    )
+    provider, model_id, _ = _resolve_model_full(model_name)
+    return provider, model_id
 
 
 def resolve_provider(model_name: str) -> str:
@@ -131,16 +149,11 @@ def create_llm(agent: AgentSpec) -> Any:
             f"cannot create LLM instance."
         )
 
-    # resolve_model handles both LLM_MODELS lookup and heuristic fallback.
-    # A second call to _lookup_in_llm_models retrieves provider-specific extras
-    # (e.g. api_version for Azure OpenAI) without duplicating the fallback logic.
-    provider, model_id = resolve_model(agent.model_name)
-    lookup = _lookup_in_llm_models(agent.model_name)
-    extra_kwargs: Dict[str, Any] = lookup[2] if lookup is not None else {}
+    provider, model_id, extra_kwargs = _resolve_model_full(agent.model_name)
 
-    # Build kwargs for load_model — start with provider-specific extras,
-    # then apply agent-level overrides (temperature, max_tokens).
-    kwargs: Dict[str, Any] = {"model_name": model_id, **extra_kwargs}
+    # Build kwargs for load_model — extra_kwargs first so the resolved
+    # model_id always wins if extra_kwargs ever contains a "model_name" key.
+    kwargs: Dict[str, Any] = {**extra_kwargs, "model_name": model_id}
     if agent.temperature is not None:
         kwargs["temperature"] = agent.temperature
     if agent.max_tokens is not None:

--- a/bili/aether/compiler/llm_resolver.py
+++ b/bili/aether/compiler/llm_resolver.py
@@ -68,7 +68,7 @@ def resolve_model(model_name: str) -> Tuple[str, str]:
     # --- 1 & 2: Look up in LLM_MODELS ---
     result = _lookup_in_llm_models(model_name)
     if result is not None:
-        provider, model_id = result
+        provider, model_id, _ = result
         LOGGER.debug(
             "Resolved '%s' via LLM_MODELS → provider=%s, model_id=%s",
             model_name,
@@ -131,11 +131,16 @@ def create_llm(agent: AgentSpec) -> Any:
             f"cannot create LLM instance."
         )
 
-    provider, model_id = resolve_model(agent.model_name)
+    lookup = _lookup_in_llm_models(agent.model_name)
+    if lookup is not None:
+        provider, model_id, extra_kwargs = lookup
+    else:
+        provider, model_id = resolve_model(agent.model_name)
+        extra_kwargs = {}
 
-    # Build kwargs for load_model — each provider uses "model_name" as
-    # the kwarg, but the *value* must be the provider's model_id.
-    kwargs: Dict[str, Any] = {"model_name": model_id}
+    # Build kwargs for load_model — start with provider-specific extras
+    # (e.g. api_version for Azure OpenAI), then apply agent overrides.
+    kwargs: Dict[str, Any] = {"model_name": model_id, **extra_kwargs}
     if agent.temperature is not None:
         kwargs["temperature"] = agent.temperature
     if agent.max_tokens is not None:
@@ -215,10 +220,15 @@ def resolve_tools(agent: AgentSpec) -> list:
 # ---------------------------------------------------------------------------
 
 
-def _lookup_in_llm_models(model_name: str) -> Optional[Tuple[str, str]]:
+def _lookup_in_llm_models(
+    model_name: str,
+) -> Optional[Tuple[str, str, Dict[str, Any]]]:
     """Search ``LLM_MODELS`` for a matching model entry.
 
-    Returns ``(provider_type, model_id)`` if found, ``None`` otherwise.
+    Returns ``(provider_type, model_id, extra_kwargs)`` if found,
+    ``None`` otherwise.  ``extra_kwargs`` contains provider-specific
+    parameters stored in the entry's ``kwargs`` dict (e.g.
+    ``api_version`` for Azure OpenAI models).
     """
     try:
         from bili.config.llm_config import (  # noqa: E402  pylint: disable=import-outside-toplevel
@@ -233,13 +243,14 @@ def _lookup_in_llm_models(model_name: str) -> Optional[Tuple[str, str]]:
         for entry in models:
             entry_model_id = entry.get("model_id", "")
             entry_display = entry.get("model_name", "")
+            extra_kwargs: Dict[str, Any] = entry.get("kwargs", {})
 
             # Match on model_id (e.g. "gpt-4o")
             if entry_model_id == model_name:
-                return provider_type, entry_model_id
+                return provider_type, entry_model_id, extra_kwargs
 
             # Match on display name (e.g. "GPT-4o")
             if entry_display == model_name:
-                return provider_type, entry_model_id
+                return provider_type, entry_model_id, extra_kwargs
 
     return None

--- a/bili/aether/docs/compiler.md
+++ b/bili/aether/docs/compiler.md
@@ -430,6 +430,47 @@ result = execute_mas(config, {"messages": [HumanMessage(content="Test")]})
 | `run(input_data, thread_id, save_results)` | `MASExecutionResult` | Execute graph, collect results |
 | `run_with_checkpoint_persistence(input_data, thread_id)` | `(original, restored)` | Run twice with checkpoint save/restore |
 | `run_cross_model_test(input_data, source_model, target_model, thread_id)` | `(source, target)` | Run with two different model configurations |
+| `run_streaming(input_data, thread_id)` | `Generator[Tuple[str, Dict], None, None]` | Yield `(node_name, state_update)` per agent node — lightweight UI streaming |
+| `stream(input_data, thread_id, stream_filter)` | `Generator[StreamEvent, None, None]` | Yield structured `StreamEvent` objects (RUN_START, NODE_END, TOKEN, etc.) |
+| `astream(input_data, thread_id, stream_filter)` | `AsyncGenerator[StreamEvent, None]` | Async token-level streaming via LangGraph `astream_events(v2)` |
+
+### Streaming
+
+AETHER provides three streaming modes for different consumers:
+
+#### `run_streaming()` — UI / real-time rendering
+
+```python
+for node_name, state_update in executor.run_streaming(
+    input_data={"messages": [HumanMessage(content="Hello")]},
+    thread_id="my-thread",
+):
+    print(f"[{node_name}] {state_update}")
+```
+
+Yields one `(node_name, state_update)` tuple per agent node as it completes. Lightweight — no event envelope overhead. Used internally by the AETHER Chat UI.
+
+#### `stream()` — Structured sync streaming
+
+```python
+from bili.aether.runtime import StreamEventType
+
+for event in executor.stream(input_data):
+    if event.event_type == StreamEventType.TOKEN:
+        print(event.data["content"], end="", flush=True)
+```
+
+Yields `StreamEvent` objects with `event_type`, `data`, `node_name`, `agent_id`, and `run_id`. Event types: `RUN_START`, `NODE_START`, `NODE_END`, `TOKEN`, `ERROR`, `RUN_END`. Accepts an optional `StreamFilter` for declarative event filtering.
+
+#### `astream()` — Token-level async streaming
+
+```python
+async for event in executor.astream(input_data):
+    if event.event_type == StreamEventType.TOKEN:
+        print(event.data["content"], end="", flush=True)
+```
+
+Uses LangGraph's `astream_events(v2)` for token-level granularity when streaming LLM responses. Yields the same `StreamEvent` structure as `stream()`.
 
 ### MASExecutionResult
 

--- a/bili/aether/docs/index.md
+++ b/bili/aether/docs/index.md
@@ -42,4 +42,4 @@ end-to-end usage examples.
 
 | Doc | Contents |
 |---|---|
-| [ui.md](ui.md) | Streamlit MAS visualizer — installation, features, troubleshooting |
+| [ui.md](ui.md) | Streamlit UI — MAS graph visualizer and multi-turn chat interface; installation, navigation, features, troubleshooting |

--- a/bili/aether/docs/quickstart-stub.md
+++ b/bili/aether/docs/quickstart-stub.md
@@ -75,7 +75,7 @@ If you want to see the agent graph rendered interactively before running it:
 /app/bili-core/venv/bin/streamlit run bili/aether/ui/app.py
 ```
 
-Open [http://localhost:8502](http://localhost:8502) in your browser. Use the sidebar dropdown to select `simple_chain.yaml`. Click any node to inspect its role, objective, capabilities, and output format. See [ui.md](ui.md) for details.
+Open [http://localhost:8502](http://localhost:8502) in your browser. The sidebar shows a **Visualizer | Chat** navigation radio. On the **Visualizer** page, use the dropdown to select `simple_chain.yaml` and click any node to inspect its role, objective, capabilities, and output format. Switch to the **Chat** page to run a multi-turn conversation against the same stub config — no API keys required. See [ui.md](ui.md) for details.
 
 ---
 

--- a/bili/aether/docs/ui.md
+++ b/bili/aether/docs/ui.md
@@ -1,6 +1,6 @@
-# AETHER MAS Visualizer
+# AETHER UI — Visualizer & Chat
 
-A read-only Streamlit application that visualizes AETHER multi-agent system YAML configurations as interactive node graphs.
+Streamlit application for inspecting and interacting with AETHER multi-agent system configurations. Provides two pages in a single app: a read-only graph **Visualizer** and a multi-turn **Chat** interface.
 
 ## Installation
 
@@ -10,17 +10,26 @@ pip install --upgrade --force-reinstall "langgraph~=1.0.2"
 pip install streamlit-flow-component --ignore-installed blinker
 ```
 
-## Usage
+## Entry Points
 
-```bash
-/app/bili-core/venv/bin/streamlit run bili/aether/ui/app.py
-```
+| Command | URL | Description |
+|---------|-----|-------------|
+| `/app/bili-core/venv/bin/streamlit run bili/aether/ui/app.py` | [http://localhost:8502](http://localhost:8502) | Combined app — Visualizer **and** Chat. **Recommended.** |
+| `/app/bili-core/venv/bin/streamlit run bili/aether/ui/chat_app.py` | [http://localhost:8501](http://localhost:8501) | Chat interface only — standalone entry point |
 
-Note: the command `streamlit` will not work due to an alias that starts BiliCore. This is not important to change because AETHER will become a part of BiliCore, but for dev purposes this is worth noting for now.
+Note: the `streamlit` alias starts BiliCore rather than invoking Streamlit directly. Use the venv path above.
 
-The app will be available at [http://localhost:8502](http://localhost:8502).
+## Navigation
 
-## Features
+When running `app.py`, the sidebar shows a horizontal **Visualizer | Chat** radio at the top. Selecting a page switches the entire main area and the page-specific sidebar controls beneath the radio. The two pages maintain independent session state — switching from Visualizer to Chat and back does not lose your selected graph or conversation history.
+
+---
+
+## Visualizer Page
+
+A read-only graph viewer for exploring AETHER YAML configurations as interactive node diagrams.
+
+### Features
 
 - **YAML Selection**: Dropdown to browse all example MAS configurations
 - **Interactive Graph**: Pan, zoom, and click nodes to inspect agent properties
@@ -36,28 +45,119 @@ The app will be available at [http://localhost:8502](http://localhost:8502).
 - **Color-Coded Nodes**: Nodes are colored by agent role for quick visual identification
 - **Edge Styling**: Solid lines for channels, dashed for workflow edges, animated for conditional edges
 
+---
+
+## Chat Page
+
+A multi-turn conversation interface that executes a compiled MAS against user messages in real time.
+
+### Features
+
+- **Multi-turn conversation** with any compiled MAS configuration
+- **Live agent output panels**: expandable sections rendered as each agent node completes, collapsed automatically in conversation history
+- **Stub mode**: configs without `model_name` execute without LLM calls; a banner in the sidebar indicates stub mode
+- **Loading state**: "Initializing executor..." spinner during graph compilation on config selection
+- **Error isolation**: individual agent render failures surface as inline errors without aborting the turn
+- **Config load errors**: surfaced in the main area so the sidebar remains clean
+
+### Selecting a Config
+
+**Example configs** — the selectbox lists all `.yaml` files from `bili/aether/config/examples/`, sorted alphabetically.
+
+**Upload** — the file uploader accepts `.yaml` / `.yml` files directly in the browser:
+- Validated at upload time: YAML syntax via `yaml.safe_load`, schema via Pydantic
+- Successfully uploaded configs appear in the selectbox as `[Uploaded] filename.yaml`
+- Uploads are session-only (never written to disk) and survive page switches and "New Conversation" resets
+
+### Running a Conversation
+
+1. Select a configuration from the sidebar dropdown
+2. Wait for the "Initializing executor..." spinner to complete
+3. Type a message in the chat input and press Enter
+4. Agent output panels appear live as each node in the graph completes
+5. The status bar updates to "Complete" or "Execution failed" at the end of each turn
+6. Previous turns are preserved in the conversation history above the input
+
+### Conversation Controls
+
+**New Conversation** — clears the conversation history and assigns a new `thread_id`. Any checkpointed state from the previous conversation is no longer referenced; the next turn starts fresh.
+
+**Export Conversation** — available once at least one turn exists. Downloads the full conversation as a JSON file named `aether_chat_{mas_id}_{thread_id[:8]}.json`.
+
+Export schema:
+
+```json
+{
+  "mas_id": "simple_chain",
+  "thread_id": "a1b2c3d4-...",
+  "exported_at": "2026-03-08T12:00:00+00:00",
+  "turns": [
+    {
+      "role": "user",
+      "content": "Hello",
+      "timestamp": "2026-03-08T12:00:01+00:00",
+      "turn_index": 0,
+      "agent_outputs": [
+        {
+          "agent_id": "agent_a",
+          "output": { "messages": [{ "type": "AIMessage", "content": "..." }] }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Failed turns include an additional `"error"` field with the exception message; their `agent_outputs` contain any nodes that completed before the failure.
+
+### Session State Keys (Chat)
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `chat_config` | `MASConfig` | Active configuration |
+| `chat_executor` | `MASExecutor` | Compiled executor (set after initialization) |
+| `chat_yaml_path` | `str` | Cache key: file path string or `"uploaded:{name}"` |
+| `chat_history` | `List[Dict]` | All completed turns |
+| `chat_thread_id` | `str` | UUID for checkpoint continuity; reset on "New Conversation" |
+| `chat_uploaded_configs` | `Dict[str, MASConfig]` | Session-only uploaded configs |
+| `chat_load_error` | `str` | Error message from last failed config load |
+
+---
+
 ## Architecture
 
 ```
 bili/aether/ui/
-├── app.py                          # Main Streamlit entry point
-├── .streamlit/config.toml          # Theme configuration
+├── app.py                  # Combined entry point (Visualizer + Chat navigation)
+├── chat_app.py             # Chat interface (standalone or embedded by app.py)
+├── .streamlit/config.toml  # Theme configuration
 ├── styles/
-│   ├── bili_core_theme.py          # Theme constants and CSS
-│   └── node_styles.py             # Role-to-style mapping
+│   ├── bili_core_theme.py  # Theme constants and CSS
+│   └── node_styles.py      # Role-to-style mapping
 ├── converters/
-│   └── yaml_to_graph.py           # YAML -> streamlit-flow converter
+│   └── yaml_to_graph.py    # MASConfig → streamlit-flow nodes/edges
 └── components/
-    └── graph_viewer.py            # Graph rendering + properties panel
+    └── graph_viewer.py     # Graph rendering + properties panel
 ```
+
+`chat_app.py` exposes two public functions used by `app.py` when the Chat page is active:
+
+- `render_sidebar_content()` — chat sidebar controls (config selector, uploader, conversation buttons)
+- `render_main()` — chat main area (history display + chat input)
+
+`chat_app.render_page()` remains the standalone entry point and handles its own page configuration.
+
+---
 
 ## Troubleshooting
 
 - **streamlit-flow-component not found**: Run `pip install streamlit-flow-component`
 - **No YAML files shown**: Ensure example configs exist in `bili/aether/config/examples/`
 - **YAML fails to load**: Check that the YAML is valid against the MASConfig schema
+- **Chat spinner hangs**: Executor initialization compiles the LangGraph; for real-LLM configs this requires valid provider credentials. Check the terminal for authentication errors.
+- **"Execution failed" in chat**: A runtime error occurred during graph execution. The full traceback is logged to the terminal. Select a stub config (any config without `model_name`) to verify the UI works without credentials.
 
 ## Known Issues
 
 - **Browser console "Invalid color" warnings** (`widgetBackgroundColor`, `widgetBorderColor`, `skeletonBackgroundColor`): Harmless. A known Streamlit 1.51.x platform bug where internal theme proto fields default to empty strings; `streamlit-flow-component` exposes this when it propagates the parent theme to its React Flow iframe. No fix available without upgrading Streamlit.
-- **`bootstrap.min.css.map` terminal warning**: Suppressed via logging configuration in `app.py`. Root cause is a source map file absent from the `streamlit-flow-component` package distribution. Source maps are optional browser developer tools with no functional impact.
+- **`bootstrap.min.css.map` terminal warning**: Suppressed via logging configuration in `app.py` and `chat_app.py`. Root cause is a source map file absent from the `streamlit-flow-component` package distribution. Source maps are optional browser developer tools with no functional impact.

--- a/bili/aether/docs/ui.md
+++ b/bili/aether/docs/ui.md
@@ -44,7 +44,7 @@ A read-only graph viewer for exploring AETHER YAML configurations as interactive
 - **Metadata Bar**: Summary metrics for the selected MAS configuration
 - **Color-Coded Nodes**: Nodes are colored by agent role for quick visual identification
 - **Edge Styling**: Solid lines for channels, dashed for workflow edges, animated for conditional edges
-- **Send to Chat →** button: loads the current config into the Chat page. If model overrides have been applied in the Properties Panel, those overrides are patched onto the config before it is sent — the Chat page receives the modified config, not the original YAML
+- **Send to Chat →** button: loads the current config into the Chat page. If model overrides have been applied in the Properties Panel, those overrides are patched onto the config before it is sent — the Chat page receives the modified config, not the original YAML config
 
 ---
 

--- a/bili/aether/docs/ui.md
+++ b/bili/aether/docs/ui.md
@@ -40,10 +40,11 @@ A read-only graph viewer for exploring AETHER YAML configurations as interactive
   - Consensus: circular arrangement
   - Parallel: three-row layout (coordinator, workers, aggregator)
   - Custom/Deliberative: edge-based layered layout
-- **Properties Panel**: Click any node to view agent details (role, objective, model, capabilities, tools, etc.)
+- **Properties Panel**: Click any node to view agent details (role, objective, model, capabilities, tools, etc.). Includes a per-agent **model override selector** — choose any model from the configured LLM registry to override the agent's `model_name` for the current session without editing the YAML
 - **Metadata Bar**: Summary metrics for the selected MAS configuration
 - **Color-Coded Nodes**: Nodes are colored by agent role for quick visual identification
 - **Edge Styling**: Solid lines for channels, dashed for workflow edges, animated for conditional edges
+- **Send to Chat →** button: loads the current config into the Chat page. If model overrides have been applied in the Properties Panel, those overrides are patched onto the config before it is sent — the Chat page receives the modified config, not the original YAML
 
 ---
 
@@ -57,6 +58,8 @@ A multi-turn conversation interface that executes a compiled MAS against user me
 - **Live agent output panels**: expandable sections rendered as each agent node completes, collapsed automatically in conversation history
 - **Stub mode**: configs without `model_name` execute without LLM calls; a banner in the sidebar indicates stub mode
 - **Loading state**: "Initializing executor..." spinner during graph compilation on config selection
+- **Config validation**: structural validation runs automatically on every config load and on every model patch. Errors block execution; warnings surface as non-blocking notices. Results are shown inline in the sidebar
+- **Model picker**: switch any loaded config between stub mode and a real LLM without editing YAML (see [Model Settings](#model-settings))
 - **Error isolation**: individual agent render failures surface as inline errors without aborting the turn
 - **Config load errors**: surfaced in the main area so the sidebar remains clean
 
@@ -77,6 +80,23 @@ A multi-turn conversation interface that executes a compiled MAS against user me
 4. Agent output panels appear live as each node in the graph completes
 5. The status bar updates to "Complete" or "Execution failed" at the end of each turn
 6. Previous turns are preserved in the conversation history above the input
+
+### Model Settings
+
+After a config is loaded, a **Model Settings** section appears in the sidebar below the config metadata. It lets you switch between stub mode and a real LLM without editing or reloading the YAML.
+
+| Control | Behaviour |
+|---------|-----------|
+| **Model selectbox** | Lists all LLMs from `bili/config/llm_config.py` (74 models), grouped by provider |
+| **Apply to all** | Patches every agent in the loaded config with the selected model and reinitialises the executor. Conversation history is cleared |
+| **Stub mode** | Clears `model_name` from all agents and reinitialises; stub mode indicator reappears |
+
+**Important notes:**
+
+- Patches are **in-memory only** — the original YAML on disk is never modified. Selecting a different config from the dropdown resets to the clean YAML
+- The original loaded config is preserved as a base internally, so clicking **Apply to all** and then **Stub mode** (or vice versa) always patches from the unmodified YAML, not from a previously patched state
+- Applying the same model twice does not trigger a redundant reinit (cache hit)
+- If the config contains **pipeline agents**, a warning is shown because pipeline agents use their own internal node models and the top-level override may have no effect on them
 
 ### Conversation Controls
 
@@ -114,9 +134,10 @@ Failed turns include an additional `"error"` field with the exception message; t
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `chat_config` | `MASConfig` | Active configuration |
+| `chat_config` | `MASConfig` | Active configuration (may be model-patched) |
+| `chat_config_base` | `MASConfig` | Original YAML-loaded config, preserved across model picker operations. Always the unpatched base |
 | `chat_executor` | `MASExecutor` | Compiled executor (set after initialization) |
-| `chat_yaml_path` | `str` | Cache key: file path string or `"uploaded:{name}"` |
+| `chat_yaml_path` | `str` | Cache key: bare file path, `"uploaded:{name}"`, or suffixed with `":model={model_id}"` / `":stub"` after model picker use |
 | `chat_history` | `List[Dict]` | All completed turns |
 | `chat_thread_id` | `str` | UUID for checkpoint continuity; reset on "New Conversation" |
 | `chat_uploaded_configs` | `Dict[str, MASConfig]` | Session-only uploaded configs |
@@ -156,6 +177,12 @@ bili/aether/ui/
 - **YAML fails to load**: Check that the YAML is valid against the MASConfig schema
 - **Chat spinner hangs**: Executor initialization compiles the LangGraph; for real-LLM configs this requires valid provider credentials. Check the terminal for authentication errors.
 - **"Execution failed" in chat**: A runtime error occurred during graph execution. The full traceback is logged to the terminal. Select a stub config (any config without `model_name`) to verify the UI works without credentials.
+- **`ImportError: cannot import name 'MODEL_KEEP_SENTINEL'`** (or similar after updating): The venv has a stale non-editable install of bili-core shadowing the local source. Fix with:
+  ```bash
+  pip uninstall bili-core -y && pip install -e /app/bili-core --ignore-installed blinker
+  ```
+- **Chat stays in stub mode after applying a model**: Confirm the terminal shows "Creating LLM for agent..." log lines. If the executor initialises twice (two "MASExecutor initialized" lines with the second showing no LLM creation), the site-packages install is stale — run the reinstall command above.
+- **Model picker shows no effect on pipeline agents**: Pipeline agents (e.g. `researcher` in `pipeline_agents.yaml`) use internal node models; the top-level `model_name` field has no effect. The UI shows a warning when this case is detected.
 
 ## Known Issues
 

--- a/bili/aether/runtime/executor.py
+++ b/bili/aether/runtime/executor.py
@@ -422,7 +422,8 @@ class MASExecutor:  # pylint: disable=too-many-instance-attributes
         except Exception as exc:  # pylint: disable=broad-exception-caught
             LOGGER.error("run_streaming execution failed: %s", exc, exc_info=True)
             raise
-        LOGGER.info("MAS streaming execution complete: %s", execution_id)
+        finally:
+            LOGGER.info("MAS streaming execution complete: %s", execution_id)
 
     async def astream(
         self,

--- a/bili/aether/ui/app.py
+++ b/bili/aether/ui/app.py
@@ -39,6 +39,7 @@ from bili.aether.ui.chat_app import (
     render_sidebar_content as render_chat_sidebar_content,
 )
 from bili.aether.ui.components.graph_viewer import (
+    MODEL_KEEP_SENTINEL,
     build_model_options,
     render_graph_viewer,
     render_metadata_bar,
@@ -171,7 +172,9 @@ def _on_send_to_chat() -> None:
             display = overrides.get(agent.agent_id)
             patched = (
                 agent.model_copy(update={"model_name": display_to_model_name[display]})
-                if display and display in display_to_model_name
+                if display
+                and display != MODEL_KEEP_SENTINEL
+                and display in display_to_model_name
                 else agent
             )
             patched_agents.append(patched)

--- a/bili/aether/ui/app.py
+++ b/bili/aether/ui/app.py
@@ -1,8 +1,9 @@
 """
-AETHER MAS YAML Visualization App.
+AETHER — MAS Visualizer and Chat.
 
-A read-only Streamlit application that visualizes AETHER multi-agent
-system YAML configurations as interactive node graphs.
+A Streamlit application that combines the AETHER multi-agent system graph
+visualizer with the multi-turn chat interface. Use the sidebar navigation
+to switch between pages.
 
 Usage:
     streamlit run bili/aether/ui/app.py
@@ -33,6 +34,10 @@ except ImportError:
     st.stop()
 
 from bili.aether.config.loader import load_mas_from_yaml
+from bili.aether.ui.chat_app import render_main as render_chat_main
+from bili.aether.ui.chat_app import (
+    render_sidebar_content as render_chat_sidebar_content,
+)
 from bili.aether.ui.components.graph_viewer import (
     render_graph_viewer,
     render_metadata_bar,
@@ -46,38 +51,23 @@ LOGO_PATH = Path(__file__).resolve().parent.parent.parent / "images" / "logo.png
 
 
 def main() -> None:
-    """Main entry point for the AETHER visualization app."""
+    """Main entry point for the AETHER app."""
     _configure_page()
 
     with st.sidebar:
         _render_sidebar()
 
-    config = st.session_state.get("mas_config")
-    if config is None:
-        st.info("Select a YAML configuration from the sidebar to visualize it.")
-        return
-
-    # Title and description
-    st.markdown(f"### {config.name}")
-    if config.description:
-        st.caption(config.description)
-
-    # Convert and render
-    nodes, edges = convert_mas_to_graph(config)
-    render_graph_viewer(config, nodes, edges)
-
-    # Metadata bar below graph
-    st.markdown("---")
-    render_metadata_bar(config)
-
-    # Legend
-    _render_legend()
+    page = st.session_state.get("aether_page", "Visualizer")
+    if page == "Chat":
+        render_chat_main()
+    else:
+        _render_visualizer_main()
 
 
 def _configure_page() -> None:
     """Set up Streamlit page config."""
     st.set_page_config(
-        page_title="AETHER - MAS Visualizer",
+        page_title="AETHER",
         page_icon="A",
         layout="wide",
     )
@@ -85,15 +75,33 @@ def _configure_page() -> None:
 
 
 def _render_sidebar() -> None:
-    """Render the sidebar with YAML selector and MAS info."""
+    """Render the sidebar: logo, nav radio, then page-specific controls."""
     if LOGO_PATH.exists():
         st.image(str(LOGO_PATH), width=80)
 
-    st.markdown("## AETHER Visualizer")
-    st.caption("Multi-Agent System Graph Viewer")
+    st.markdown("## AETHER")
     st.markdown("---")
 
-    # Find all YAML files in examples directory
+    st.radio(
+        "Navigation",
+        ["Visualizer", "Chat"],
+        key="aether_page",
+        label_visibility="collapsed",
+        horizontal=True,
+    )
+    st.markdown("---")
+
+    page = st.session_state.get("aether_page", "Visualizer")
+    if page == "Chat":
+        render_chat_sidebar_content()
+    else:
+        _render_visualizer_sidebar()
+
+
+def _render_visualizer_sidebar() -> None:
+    """Render the visualizer-specific sidebar content."""
+    st.caption("Multi-Agent System Graph Viewer")
+
     if not EXAMPLES_DIR.exists():
         st.error(f"Examples directory not found: {EXAMPLES_DIR}")
         return
@@ -117,9 +125,28 @@ def _render_sidebar() -> None:
         _load_config(yaml_path)
 
 
-def _load_config(yaml_path: Path):
+def _render_visualizer_main() -> None:
+    """Render the visualizer main area."""
+    config = st.session_state.get("mas_config")
+    if config is None:
+        st.info("Select a YAML configuration from the sidebar to visualize it.")
+        return
+
+    st.markdown(f"### {config.name}")
+    if config.description:
+        st.caption(config.description)
+
+    nodes, edges = convert_mas_to_graph(config)
+    render_graph_viewer(config, nodes, edges)
+
+    st.markdown("---")
+    render_metadata_bar(config)
+
+    _render_legend()
+
+
+def _load_config(yaml_path: Path) -> None:
     """Load a YAML config and store it in session state."""
-    # Only reload if the path changed
     current_path = st.session_state.get("current_yaml_path")
     if current_path == str(yaml_path) and "mas_config" in st.session_state:
         config = st.session_state.mas_config
@@ -138,7 +165,7 @@ def _load_config(yaml_path: Path):
             ]
             for k in keys_to_clear:
                 del st.session_state[k]
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             st.error(f"Failed to load `{yaml_path.name}`:\n\n{e}")
             st.session_state.mas_config = None
             return

--- a/bili/aether/ui/app.py
+++ b/bili/aether/ui/app.py
@@ -39,7 +39,7 @@ from bili.aether.ui.chat_app import (
     render_sidebar_content as render_chat_sidebar_content,
 )
 from bili.aether.ui.components.graph_viewer import (
-    _build_model_options,
+    build_model_options,
     render_graph_viewer,
     render_metadata_bar,
 )
@@ -165,15 +165,16 @@ def _on_send_to_chat() -> None:
     # Apply model overrides from the Visualizer properties panel
     overrides: dict = st.session_state.get(f"model_overrides_{config.mas_id}", {})
     if overrides:
-        _, display_to_model_name, _ = _build_model_options()
+        _, display_to_model_name, _ = build_model_options()
         patched_agents = []
         for agent in config.agents:
             display = overrides.get(agent.agent_id)
-            if display and display in display_to_model_name:
-                agent = agent.model_copy(
-                    update={"model_name": display_to_model_name[display]}
-                )
-            patched_agents.append(agent)
+            patched = (
+                agent.model_copy(update={"model_name": display_to_model_name[display]})
+                if display and display in display_to_model_name
+                else agent
+            )
+            patched_agents.append(patched)
         config = config.model_copy(update={"agents": patched_agents})
 
     name = st.session_state.get("current_yaml_path", "visualizer_config")
@@ -181,7 +182,7 @@ def _on_send_to_chat() -> None:
         st.session_state.chat_uploaded_configs = {}
     st.session_state.chat_uploaded_configs[name] = config
     st.session_state.aether_page = "Chat"
-    st.session_state._chat_autoload_name = name
+    st.session_state.chat_autoload_name = name
 
 
 def _load_config(yaml_path: Path) -> None:

--- a/bili/aether/ui/app.py
+++ b/bili/aether/ui/app.py
@@ -39,6 +39,7 @@ from bili.aether.ui.chat_app import (
     render_sidebar_content as render_chat_sidebar_content,
 )
 from bili.aether.ui.components.graph_viewer import (
+    _build_model_options,
     render_graph_viewer,
     render_metadata_bar,
 )
@@ -97,7 +98,7 @@ def _render_sidebar() -> str:
 
     page: str = st.session_state.get("aether_page", _DEFAULT_PAGE)
     if page == "Chat":
-        render_chat_sidebar_content()
+        render_chat_sidebar_content(examples_dir=EXAMPLES_DIR)
     else:
         _render_visualizer_sidebar()
     return page
@@ -150,6 +151,39 @@ def _render_visualizer_main() -> None:
     _render_legend()
 
 
+def _on_send_to_chat() -> None:
+    """Button callback: push the current visualizer config to the Chat page.
+
+    Applies any model overrides selected in the Visualizer before sending.
+    Runs before the next render cycle so ``aether_page`` can be written
+    safely without conflicting with the already-instantiated radio widget.
+    """
+    config = st.session_state.get("mas_config")
+    if config is None:
+        return
+
+    # Apply model overrides from the Visualizer properties panel
+    overrides: dict = st.session_state.get(f"model_overrides_{config.mas_id}", {})
+    if overrides:
+        _, display_to_model_name, _ = _build_model_options()
+        patched_agents = []
+        for agent in config.agents:
+            display = overrides.get(agent.agent_id)
+            if display and display in display_to_model_name:
+                agent = agent.model_copy(
+                    update={"model_name": display_to_model_name[display]}
+                )
+            patched_agents.append(agent)
+        config = config.model_copy(update={"agents": patched_agents})
+
+    name = st.session_state.get("current_yaml_path", "visualizer_config")
+    if "chat_uploaded_configs" not in st.session_state:
+        st.session_state.chat_uploaded_configs = {}
+    st.session_state.chat_uploaded_configs[name] = config
+    st.session_state.aether_page = "Chat"
+    st.session_state._chat_autoload_name = name
+
+
 def _load_config(yaml_path: Path) -> None:
     """Load a YAML config and store it in session state."""
     current_path = st.session_state.get("current_yaml_path")
@@ -189,7 +223,12 @@ def _load_config(yaml_path: Path) -> None:
         st.warning("Human-in-loop enabled")
 
     st.markdown("---")
-    st.button("Deploy", disabled=True, use_container_width=True)
+    st.button(
+        "Send to Chat \u2192",
+        disabled=st.session_state.get("mas_config") is None,
+        use_container_width=True,
+        on_click=_on_send_to_chat,
+    )
 
 
 def _render_legend() -> None:

--- a/bili/aether/ui/app.py
+++ b/bili/aether/ui/app.py
@@ -49,15 +49,16 @@ from bili.aether.ui.styles.bili_core_theme import CUSTOM_CSS
 EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "config" / "examples"
 LOGO_PATH = Path(__file__).resolve().parent.parent.parent / "images" / "logo.png"
 
+_DEFAULT_PAGE = "Visualizer"
+
 
 def main() -> None:
     """Main entry point for the AETHER app."""
     _configure_page()
 
     with st.sidebar:
-        _render_sidebar()
+        page = _render_sidebar()
 
-    page = st.session_state.get("aether_page", "Visualizer")
     if page == "Chat":
         render_chat_main()
     else:
@@ -74,8 +75,11 @@ def _configure_page() -> None:
     st.markdown(CUSTOM_CSS, unsafe_allow_html=True)
 
 
-def _render_sidebar() -> None:
-    """Render the sidebar: logo, nav radio, then page-specific controls."""
+def _render_sidebar() -> str:
+    """Render the sidebar: logo, nav radio, then page-specific controls.
+
+    Returns the active page name (``"Visualizer"`` or ``"Chat"``).
+    """
     if LOGO_PATH.exists():
         st.image(str(LOGO_PATH), width=80)
 
@@ -91,11 +95,12 @@ def _render_sidebar() -> None:
     )
     st.markdown("---")
 
-    page = st.session_state.get("aether_page", "Visualizer")
+    page: str = st.session_state.get("aether_page", _DEFAULT_PAGE)
     if page == "Chat":
         render_chat_sidebar_content()
     else:
         _render_visualizer_sidebar()
+    return page
 
 
 def _render_visualizer_sidebar() -> None:

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -52,6 +52,27 @@ def _is_stub_config(config: MASConfig) -> bool:
     return any(not agent.model_name for agent in config.agents)
 
 
+@st.cache_data
+def _build_chat_model_options() -> tuple[list[str], list[str]]:
+    """Return ``(display_list, model_id_list)`` from LLM_MODELS, grouped by provider.
+
+    Lazy-imports ``LLM_MODELS`` so this module loads without bili-core's heavy
+    LLM dependencies.  Result is cached for the lifetime of the Streamlit process.
+    """
+    from bili.config.llm_config import (  # pylint: disable=import-outside-toplevel
+        LLM_MODELS,
+    )
+
+    display: list[str] = []
+    ids: list[str] = []
+    for provider_info in LLM_MODELS.values():
+        label = provider_info["name"]
+        for entry in provider_info["models"]:
+            display.append(f"[{label}] {entry['model_name']}")
+            ids.append(entry["model_id"])
+    return display, ids
+
+
 def _serialize_state_update(state_update: Dict[str, Any]) -> Dict[str, Any]:
     """Convert a raw graph state update to a JSON-serializable dict.
 
@@ -154,6 +175,7 @@ def _load_config(yaml_path: Path) -> None:
         for key in ("chat_config", "chat_yaml_path", "chat_executor"):
             st.session_state.pop(key, None)
         return
+    st.session_state.chat_config_base = config
     _initialize_executor(config, str(yaml_path))
 
 
@@ -163,6 +185,7 @@ def _load_uploaded_config(name: str, config: MASConfig) -> None:
         for key in ("chat_config", "chat_yaml_path", "chat_executor"):
             st.session_state.pop(key, None)
         return
+    st.session_state.chat_config_base = config
     _initialize_executor(config, f"uploaded:{name}")
 
 
@@ -287,6 +310,63 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     st.markdown(f"**MAS ID:** `{config.mas_id}`")
     st.markdown(f"**Workflow:** {config.workflow_type.value}")
     st.markdown(f"**Agents:** {len(config.agents)}")
+
+    st.markdown("---")
+    st.markdown("**Model Settings**")
+
+    display_opts, id_opts = _build_chat_model_options()
+    st.selectbox(
+        "Model",
+        range(len(display_opts)),
+        format_func=lambda i: display_opts[i],
+        key="chat_model_selector",
+        label_visibility="collapsed",
+    )
+
+    col1, col2 = st.columns(2)
+    with col1:
+        apply_clicked = st.button(
+            "Apply to all",
+            use_container_width=True,
+            help="Set this model on every agent",
+        )
+    with col2:
+        stub_clicked = st.button(
+            "Stub mode",
+            use_container_width=True,
+            help="Clear model from all agents",
+        )
+
+    base_config: Optional[MASConfig] = st.session_state.get("chat_config_base")
+    if base_config is not None:
+        if apply_clicked:
+            selected_idx = st.session_state.get("chat_model_selector", 0)
+            model_id = id_opts[selected_idx]
+            patched_agents = [
+                a.model_copy(update={"model_name": model_id})
+                for a in base_config.agents
+            ]
+            patched = base_config.model_copy(update={"agents": patched_agents})
+            if _validate_config(patched):
+                base_key = (
+                    st.session_state.get("chat_yaml_path", "config")
+                    .split(":model=")[0]
+                    .split(":stub")[0]
+                )
+                _initialize_executor(patched, f"{base_key}:model={model_id}")
+
+        if stub_clicked:
+            patched_agents = [
+                a.model_copy(update={"model_name": None}) for a in base_config.agents
+            ]
+            patched = base_config.model_copy(update={"agents": patched_agents})
+            if _validate_config(patched):
+                base_key = (
+                    st.session_state.get("chat_yaml_path", "config")
+                    .split(":model=")[0]
+                    .split(":stub")[0]
+                )
+                _initialize_executor(patched, f"{base_key}:stub")
 
     st.markdown("---")
 

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -139,14 +139,21 @@ def _load_uploaded_config(name: str, config: MASConfig) -> None:
 
 
 def _render_sidebar() -> None:
-    """Render sidebar with YAML selector, stub indicator, and controls."""
+    """Render standalone sidebar: logo, title, and chat controls."""
     if LOGO_PATH.exists():
         st.image(str(LOGO_PATH), width=80)
 
     st.markdown("## AETHER Chat")
     st.caption("Multi-Agent System Conversation")
     st.markdown("---")
+    render_sidebar_content()
 
+
+def render_sidebar_content() -> None:
+    """Render the chat sidebar controls — config selector, upload, and buttons.
+
+    Public: called by ``app.py`` when the Chat page is active.
+    """
     uploaded = st.file_uploader("Upload YAML config", type=["yaml", "yml"])
     if uploaded and uploaded.name not in st.session_state.get(
         "chat_uploaded_configs", {}
@@ -398,12 +405,20 @@ def _render_chat_area() -> None:
 # ---------------------------------------------------------------------------
 
 
+def render_main() -> None:
+    """Render the chat main area.
+
+    Public: called by ``app.py`` when the Chat page is active.
+    """
+    _render_chat_area()
+
+
 def render_page() -> None:
     """Main entry point — callable from app.py navigation or standalone."""
     _configure_page()
     with st.sidebar:
         _render_sidebar()
-    _render_chat_area()
+    render_main()
 
 
 if __name__ == "__main__":

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -229,6 +229,8 @@ def _render_stored_turn(turn: Dict[str, Any]) -> None:
     with st.chat_message("user"):
         st.markdown(turn["content"])
     with st.chat_message("assistant"):
+        if "error" in turn:
+            st.error(f"Execution failed: {turn['error']}")
         for agent_out in turn.get("agent_outputs", []):
             _render_agent_panel(
                 agent_out["agent_id"], agent_out["output"], expanded=False
@@ -285,7 +287,7 @@ def _run_turn(user_input: str) -> None:
             except Exception as exc:  # pylint: disable=broad-exception-caught
                 status.update(label="Execution failed", state="error")
                 st.error(f"Execution failed: {exc}")
-                return
+                turn["error"] = str(exc)
 
     turn["agent_outputs"] = agent_outputs
 

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -34,6 +34,7 @@ from bili.aether.config.loader import load_mas_from_dict, load_mas_from_yaml
 from bili.aether.runtime import MASExecutor
 from bili.aether.schema import MASConfig
 from bili.aether.ui.styles.bili_core_theme import CUSTOM_CSS
+from bili.aether.validation import validate_mas
 
 EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "config" / "examples"
 LOGO_PATH = Path(__file__).resolve().parent.parent.parent / "images" / "logo.png"
@@ -68,6 +69,27 @@ def _serialize_state_update(state_update: Dict[str, Any]) -> Dict[str, Any]:
         return value
 
     return {k: _convert(v) for k, v in state_update.items()}
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_config(config: MASConfig) -> bool:
+    """Run structural validation and display results in the sidebar.
+
+    Returns ``True`` if the config is valid (errors list is empty).
+    Warnings are displayed but do not block execution.
+    """
+    result = validate_mas(config)
+    for err in result.errors:
+        st.error(f"Config error: {err}")
+    for warn in result.warnings:
+        st.warning(f"Config warning: {warn}")
+    if result.valid and not result.warnings:
+        st.success("Config valid ✓")
+    return result.valid
 
 
 # ---------------------------------------------------------------------------
@@ -125,11 +147,15 @@ def _load_config(yaml_path: Path) -> None:
         for key in ("chat_config", "chat_yaml_path", "chat_executor"):
             st.session_state.pop(key, None)
         return
+    if not _validate_config(config):
+        return
     _initialize_executor(config, str(yaml_path))
 
 
 def _load_uploaded_config(name: str, config: MASConfig) -> None:
     """Initialize the executor from an already-parsed uploaded MASConfig."""
+    if not _validate_config(config):
+        return
     _initialize_executor(config, f"uploaded:{name}")
 
 
@@ -347,6 +373,8 @@ def _run_turn(user_input: str) -> None:
                     input_data={"messages": [HumanMessage(content=user_input)]},
                     thread_id=st.session_state.chat_thread_id,
                 ):
+                    if state_update is None:
+                        continue
                     try:
                         _render_agent_output(node_name, state_update)
                     except (

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -292,14 +292,30 @@ def render_sidebar_content() -> None:
 
 
 def _render_agent_panel(
-    agent_id: str, output: Dict[str, Any], *, expanded: bool
+    agent_id: str,
+    output: Dict[str, Any],
+    *,
+    expanded: bool,
+    use_expander: bool = True,
 ) -> None:
-    """Render one agent's output inside an expander.
+    """Render one agent's output inside an expander or plain container.
 
     Accepts both raw graph state updates (containing ``BaseMessage`` objects)
     and already-serialized output dicts stored in ``chat_history``.
+
+    When *use_expander* is ``False`` the panel is rendered as a ``st.container``
+    with a bold header — suitable for use inside an outer expander to avoid
+    nesting expanders inside expanders.
     """
-    with st.expander(f"Agent: {agent_id}", expanded=expanded):
+    if use_expander:
+        ctx = st.expander(f"Agent: {agent_id}", expanded=expanded)
+    else:
+        ctx = st.container()
+
+    with ctx:
+        if not use_expander:
+            st.markdown(f"**Agent: {agent_id}**")
+
         # Prefer the structured agent_outputs entry for this node
         agent_outputs: Dict[str, Any] = output.get("agent_outputs", {})
         if agent_id in agent_outputs:
@@ -342,10 +358,15 @@ def _render_stored_turn(turn: Dict[str, Any]) -> None:
             st.error(f"Execution failed: {turn['error']}")
         agent_trace = turn.get("agent_trace", [])
         if agent_trace:
+            if "error" in turn:
+                st.divider()
             with st.expander("Agent trace", expanded=False):
                 for agent_out in agent_trace:
                     _render_agent_panel(
-                        agent_out["agent_id"], agent_out["output"], expanded=False
+                        agent_out["agent_id"],
+                        agent_out["output"],
+                        expanded=False,
+                        use_expander=False,
                     )
 
 

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -182,11 +182,40 @@ def _render_sidebar() -> None:
     render_sidebar_content()
 
 
-def render_sidebar_content() -> None:
+def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     """Render the chat sidebar controls — config selector, upload, and buttons.
 
     Public: called by ``app.py`` when the Chat page is active.
+
+    Args:
+        examples_dir: Override the directory scanned for built-in YAML configs.
+            When ``app.py`` imports this module as a package the module-level
+            ``EXAMPLES_DIR`` may resolve to the installed site-packages copy
+            (which lacks the example files).  Pass ``app.py``'s own
+            ``EXAMPLES_DIR`` to guarantee the correct source-tree path.
     """
+    effective_examples_dir = examples_dir if examples_dir is not None else EXAMPLES_DIR
+
+    autoload_name = st.session_state.pop("_chat_autoload_name", None)
+    if autoload_name is not None:
+        pending = st.session_state.get("chat_uploaded_configs", {}).get(autoload_name)
+        if pending is not None:
+            _load_uploaded_config(autoload_name, pending)
+            # Pre-select the config in the selectbox so the selectbox's else-branch
+            # does not immediately clear the session state we just populated.
+            _n_yaml = (
+                len(sorted(effective_examples_dir.glob("*.yaml")))
+                if effective_examples_dir.exists()
+                else 0
+            )
+            _uploaded_sorted = sorted(
+                st.session_state.get("chat_uploaded_configs", {}).keys()
+            )
+            if autoload_name in _uploaded_sorted:
+                st.session_state.chat_yaml_selector = _n_yaml + _uploaded_sorted.index(
+                    autoload_name
+                )
+
     uploaded = st.file_uploader("Upload YAML config", type=["yaml", "yml"])
     if uploaded and uploaded.name not in st.session_state.get(
         "chat_uploaded_configs", {}
@@ -204,11 +233,11 @@ def render_sidebar_content() -> None:
         except Exception as exc:  # pylint: disable=broad-exception-caught
             st.error(f"Invalid config: {exc}")
 
-    if not EXAMPLES_DIR.exists():
-        st.error(f"Examples directory not found: {EXAMPLES_DIR}")
+    if not effective_examples_dir.exists():
+        st.error(f"Examples directory not found: {effective_examples_dir}")
         return
 
-    yaml_files = sorted(EXAMPLES_DIR.glob("*.yaml"))
+    yaml_files = sorted(effective_examples_dir.glob("*.yaml"))
     uploaded_configs: Dict[str, MASConfig] = st.session_state.get(
         "chat_uploaded_configs", {}
     )

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -77,7 +77,7 @@ def _serialize_state_update(state_update: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _validate_config(config: MASConfig) -> bool:
-    """Run structural validation and display results in the sidebar.
+    """Run structural validation and display results in the active Streamlit context.
 
     Returns ``True`` if the config is valid (errors list is empty).
     Warnings are displayed but do not block execution.
@@ -87,8 +87,11 @@ def _validate_config(config: MASConfig) -> bool:
         st.error(f"Config error: {err}")
     for warn in result.warnings:
         st.warning(f"Config warning: {warn}")
-    if result.valid and not result.warnings:
-        st.success("Config valid ✓")
+    if result.valid:
+        if result.warnings:
+            st.success("Config valid with warnings ✓")
+        else:
+            st.success("Config valid ✓")
     return result.valid
 
 
@@ -148,6 +151,8 @@ def _load_config(yaml_path: Path) -> None:
             st.session_state.pop(key, None)
         return
     if not _validate_config(config):
+        for key in ("chat_config", "chat_yaml_path", "chat_executor"):
+            st.session_state.pop(key, None)
         return
     _initialize_executor(config, str(yaml_path))
 
@@ -155,6 +160,8 @@ def _load_config(yaml_path: Path) -> None:
 def _load_uploaded_config(name: str, config: MASConfig) -> None:
     """Initialize the executor from an already-parsed uploaded MASConfig."""
     if not _validate_config(config):
+        for key in ("chat_config", "chat_yaml_path", "chat_executor"):
+            st.session_state.pop(key, None)
         return
     _initialize_executor(config, f"uploaded:{name}")
 

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -193,7 +193,7 @@ def _render_thread_list() -> None:
         is_active = tid == active_id
 
         if editing_id == tid:
-            c1, c2, c3 = st.columns([4, 1, 1])
+            c1, c2, c3 = st.columns([4, 1, 1], vertical_alignment="center")
             with c1:
                 new_name = st.text_input(
                     "Rename thread",
@@ -211,7 +211,7 @@ def _render_thread_list() -> None:
                     st.session_state.pop("chat_editing_thread", None)
                     st.rerun()
         else:
-            c1, c2, c3 = st.columns([5, 1, 1])
+            c1, c2, c3 = st.columns([5, 1, 1], vertical_alignment="center")
             with c1:
                 btn_type = "primary" if is_active else "secondary"
                 if st.button(
@@ -414,15 +414,22 @@ def _extract_content(output: Dict[str, Any]) -> str:
     """Extract a readable content string from a serialized agent output dict.
 
     Mirrors the display priority of ``_render_agent_panel`` but returns a plain
-    string suitable for text-based exports.
+    string suitable for text-based exports. Unlike the render panel (which
+    receives a single agent_id), this function collects *all* agent_outputs
+    entries and joins them so no entry is silently dropped.
     """
     agent_outputs: Dict[str, Any] = output.get("agent_outputs", {})
-    for inner in agent_outputs.values():
-        if inner.get("status") == "stub":
-            return inner.get("message", str(inner))
-        parts = [f"{k}: {v}" for k, v in inner.items() if k != "agent_id"]
-        if parts:
-            return " | ".join(parts)
+    if agent_outputs:
+        collected: List[str] = []
+        for inner in agent_outputs.values():
+            if inner.get("status") == "stub":
+                collected.append(inner.get("message", str(inner)))
+            else:
+                kv_parts = [f"{k}: {v}" for k, v in inner.items() if k != "agent_id"]
+                if kv_parts:
+                    collected.append(" | ".join(kv_parts))
+        if collected:
+            return "\n".join(collected)
     messages: List[Any] = output.get("messages", [])
     if messages:
         last = messages[-1]
@@ -433,7 +440,7 @@ def _extract_content(output: Dict[str, Any]) -> str:
 
 
 def _build_markdown_export(
-    config: "MASConfig", thread_id: str, chat_history: List[Dict]
+    config: MASConfig, thread_id: str, chat_history: List[Dict]
 ) -> str:
     """Build a Markdown export string for the active conversation."""
     lines = [
@@ -446,6 +453,9 @@ def _build_markdown_export(
         lines += [
             f"## Turn {i}",
             "",
+            # turn['content'] is inserted verbatim; any markdown the user typed
+            # (headings, links, etc.) will render as-is in the exported file.
+            # This is acceptable since users are exporting their own conversations.
             f"**User:** {turn['content']}",
             "",
             "**MAS Response:**",
@@ -614,11 +624,14 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     chat_history = _active_messages_or_empty()
     thread_id = st.session_state.get("chat_thread_id", "")
     if chat_history:
+        base_name = f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}"
         export_json = {
             "mas_id": config.mas_id,
             "thread_id": thread_id,
             "exported_at": datetime.now(timezone.utc).isoformat(),
             "turns": [
+                # Explicitly include agent_trace so the key is always present,
+                # even for turns stored before this field was introduced.
                 {**turn, "agent_trace": turn.get("agent_trace", [])}
                 for turn in chat_history
             ],
@@ -628,7 +641,7 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
             st.download_button(
                 "Export JSON",
                 data=json.dumps(export_json, indent=2),
-                file_name=f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}.json",
+                file_name=f"{base_name}.json",
                 mime="application/json",
                 use_container_width=True,
             )
@@ -636,7 +649,7 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
             st.download_button(
                 "Export Markdown",
                 data=_build_markdown_export(config, thread_id, chat_history),
-                file_name=f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}.md",
+                file_name=f"{base_name}.md",
                 mime="text/markdown",
                 use_container_width=True,
             )

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -52,6 +52,43 @@ def _is_stub_config(config: MASConfig) -> bool:
     return any(not agent.model_name for agent in config.agents)
 
 
+def _base_cache_key() -> str:
+    """Return the canonical cache key for the current config, stripping any model/stub suffix."""
+    raw = st.session_state.get("chat_yaml_path", "config")
+    return raw.split(":model=")[0].split(":stub")[0]
+
+
+def _apply_model_patch(base_config: MASConfig, model_id: Optional[str]) -> None:
+    """Patch every agent in *base_config* with *model_id* (``None`` = stub), then reinit.
+
+    Warns when pipeline agents are present and *model_id* is not ``None``, because
+    pipeline agents use internal node models and the top-level override may have no effect.
+    Validates the patched config before reinitialising the executor.
+    """
+    if model_id is not None:
+        pipeline_agents = [
+            a.agent_id for a in base_config.agents if a.pipeline is not None
+        ]
+        if pipeline_agents:
+            st.warning(
+                f"Pipeline agents ({', '.join(pipeline_agents)}) use internal node "
+                "models — the top-level model override may have no effect on them."
+            )
+
+    patched_agents = [
+        a.model_copy(update={"model_name": model_id}) for a in base_config.agents
+    ]
+    patched = base_config.model_copy(update={"agents": patched_agents})
+    if not _validate_config(patched):
+        return
+
+    base_key = _base_cache_key()
+    cache_key = (
+        f"{base_key}:model={model_id}" if model_id is not None else f"{base_key}:stub"
+    )
+    _initialize_executor(patched, cache_key)
+
+
 @st.cache_data
 def _build_chat_model_options() -> tuple[list[str], list[str]]:
     """Return ``(display_list, model_id_list)`` from LLM_MODELS, grouped by provider.
@@ -294,6 +331,7 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
             "chat_yaml_path",
             "chat_executor",
             "chat_load_error",
+            "chat_config_base",
         ):
             st.session_state.pop(key, None)
         return
@@ -340,33 +378,14 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     base_config: Optional[MASConfig] = st.session_state.get("chat_config_base")
     if base_config is not None:
         if apply_clicked:
-            selected_idx = st.session_state.get("chat_model_selector", 0)
-            model_id = id_opts[selected_idx]
-            patched_agents = [
-                a.model_copy(update={"model_name": model_id})
-                for a in base_config.agents
-            ]
-            patched = base_config.model_copy(update={"agents": patched_agents})
-            if _validate_config(patched):
-                base_key = (
-                    st.session_state.get("chat_yaml_path", "config")
-                    .split(":model=")[0]
-                    .split(":stub")[0]
-                )
-                _initialize_executor(patched, f"{base_key}:model={model_id}")
+            model_idx = st.session_state.get("chat_model_selector", 0)
+            if model_idx < 0 or model_idx >= len(id_opts):
+                st.error("Invalid model selection. Please re-select a model.")
+            else:
+                _apply_model_patch(base_config, id_opts[model_idx])
 
         if stub_clicked:
-            patched_agents = [
-                a.model_copy(update={"model_name": None}) for a in base_config.agents
-            ]
-            patched = base_config.model_copy(update={"agents": patched_agents})
-            if _validate_config(patched):
-                base_key = (
-                    st.session_state.get("chat_yaml_path", "config")
-                    .split(":model=")[0]
-                    .split(":stub")[0]
-                )
-                _initialize_executor(patched, f"{base_key}:stub")
+            _apply_model_patch(base_config, None)
 
     st.markdown("---")
 

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -189,7 +189,7 @@ def _render_sidebar() -> None:
         st.download_button(
             "Export Conversation",
             data=json.dumps(export, indent=2),
-            file_name=f"aether_chat_{config.mas_id}_{thread_id[:8]}.json",
+            file_name=f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}.json",
             mime="application/json",
             use_container_width=True,
         )

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -200,6 +200,13 @@ def _initialize_executor(config: MASConfig, cache_key: str) -> None:
 
 def _load_config(yaml_path: Path) -> None:
     """Load a YAML config and initialize the executor when the path changes."""
+    # If the current executor was already initialized from this YAML (possibly
+    # with a model-picker suffix applied by _apply_model_patch), skip the reload
+    # to avoid overwriting the patched executor on each Streamlit rerun.
+    current_key = st.session_state.get("chat_yaml_path", "")
+    if current_key.startswith(str(yaml_path)) and "chat_config" in st.session_state:
+        return
+
     try:
         config = load_mas_from_yaml(yaml_path)
     except Exception as exc:  # pylint: disable=broad-exception-caught
@@ -218,12 +225,19 @@ def _load_config(yaml_path: Path) -> None:
 
 def _load_uploaded_config(name: str, config: MASConfig) -> None:
     """Initialize the executor from an already-parsed uploaded MASConfig."""
+    # Same guard as _load_config: skip if the current executor is already based
+    # on this uploaded config (possibly with a model-picker suffix).
+    current_key = st.session_state.get("chat_yaml_path", "")
+    base_key = f"uploaded:{name}"
+    if current_key.startswith(base_key) and "chat_config" in st.session_state:
+        return
+
     if not _validate_config(config):
         for key in ("chat_config", "chat_yaml_path", "chat_executor"):
             st.session_state.pop(key, None)
         return
     st.session_state.chat_config_base = config
-    _initialize_executor(config, f"uploaded:{name}")
+    _initialize_executor(config, base_key)
 
 
 # ---------------------------------------------------------------------------

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -17,6 +17,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import yaml
+
 # Suppress the FileNotFoundError traceback that Streamlit logs when the browser
 # requests bootstrap.min.css.map — a source map file absent from the
 # streamlit-flow-component package distribution. Source maps are optional
@@ -28,7 +30,7 @@ logging.getLogger("streamlit.web.server.component_request_handler").setLevel(
 import streamlit as st
 from langchain_core.messages import BaseMessage, HumanMessage
 
-from bili.aether.config.loader import load_mas_from_yaml
+from bili.aether.config.loader import load_mas_from_dict, load_mas_from_yaml
 from bili.aether.runtime import MASExecutor
 from bili.aether.schema import MASConfig
 from bili.aether.ui.styles.bili_core_theme import CUSTOM_CSS
@@ -97,7 +99,8 @@ def _load_config(yaml_path: Path) -> None:
     try:
         config = load_mas_from_yaml(yaml_path)
         executor = MASExecutor(config)
-        executor.initialize()
+        with st.spinner("Initializing executor..."):
+            executor.initialize()
         st.session_state.chat_config = config
         st.session_state.chat_yaml_path = str(yaml_path)
         st.session_state.chat_executor = executor
@@ -106,6 +109,34 @@ def _load_config(yaml_path: Path) -> None:
         st.session_state.pop("chat_load_error", None)
     except Exception as exc:  # pylint: disable=broad-exception-caught
         LOGGER.error("Failed to load config %s: %s", yaml_path.name, exc, exc_info=True)
+        st.session_state.chat_load_error = str(exc)
+        for key in ("chat_config", "chat_yaml_path", "chat_executor"):
+            st.session_state.pop(key, None)
+
+
+def _load_uploaded_config(name: str, config: MASConfig) -> None:
+    """Initialize the executor from an already-parsed uploaded MASConfig."""
+    cache_key = f"uploaded:{name}"
+    if (
+        st.session_state.get("chat_yaml_path") == cache_key
+        and "chat_config" in st.session_state
+    ):
+        return
+
+    try:
+        executor = MASExecutor(config)
+        with st.spinner("Initializing executor..."):
+            executor.initialize()
+        st.session_state.chat_config = config
+        st.session_state.chat_yaml_path = cache_key
+        st.session_state.chat_executor = executor
+        st.session_state.chat_history = []
+        st.session_state.pop("chat_thread_id", None)
+        st.session_state.pop("chat_load_error", None)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        LOGGER.error(
+            "Failed to initialize uploaded config %s: %s", name, exc, exc_info=True
+        )
         st.session_state.chat_load_error = str(exc)
         for key in ("chat_config", "chat_yaml_path", "chat_executor"):
             st.session_state.pop(key, None)
@@ -125,28 +156,54 @@ def _render_sidebar() -> None:
     st.caption("Multi-Agent System Conversation")
     st.markdown("---")
 
+    uploaded = st.file_uploader("Upload YAML config", type=["yaml", "yml"])
+    if uploaded:
+        try:
+            raw = yaml.safe_load(uploaded.read())
+            if not isinstance(raw, dict):
+                raise ValueError("YAML must be a mapping at the top level.")
+            upload_config = load_mas_from_dict(raw)
+            if "chat_uploaded_configs" not in st.session_state:
+                st.session_state.chat_uploaded_configs = {}
+            st.session_state.chat_uploaded_configs[uploaded.name] = upload_config
+            st.success(f"Uploaded: {uploaded.name}")
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            st.error(f"Invalid config: {exc}")
+
     if not EXAMPLES_DIR.exists():
         st.error(f"Examples directory not found: {EXAMPLES_DIR}")
         return
 
     yaml_files = sorted(EXAMPLES_DIR.glob("*.yaml"))
-    if not yaml_files:
+    uploaded_configs: Dict[str, MASConfig] = st.session_state.get(
+        "chat_uploaded_configs", {}
+    )
+    uploaded_names = sorted(uploaded_configs.keys())
+
+    if not yaml_files and not uploaded_names:
         st.warning("No YAML files found in examples directory.")
         return
 
-    yaml_display = [f.stem.replace("_", " ").title() for f in yaml_files]
+    all_display = [f.stem.replace("_", " ").title() for f in yaml_files] + [
+        f"[Uploaded] {n}" for n in uploaded_names
+    ]
+    n_files = len(yaml_files)
 
     selected_idx = st.selectbox(
         "Select Configuration",
-        range(len(yaml_files)),
+        range(len(all_display)),
         index=None,
         placeholder="Choose a MAS config...",
-        format_func=lambda i: yaml_display[i],
+        format_func=lambda i: all_display[i],
         key="chat_yaml_selector",
     )
 
     if selected_idx is not None:
-        _load_config(yaml_files[selected_idx])
+        if selected_idx < n_files:
+            _load_config(yaml_files[selected_idx])
+        else:
+            name = uploaded_names[selected_idx - n_files]
+            _load_uploaded_config(name, uploaded_configs[name])
     else:
         for key in (
             "chat_config",

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -340,10 +340,13 @@ def _render_stored_turn(turn: Dict[str, Any]) -> None:
     with st.chat_message("assistant"):
         if "error" in turn:
             st.error(f"Execution failed: {turn['error']}")
-        for agent_out in turn.get("agent_outputs", []):
-            _render_agent_panel(
-                agent_out["agent_id"], agent_out["output"], expanded=False
-            )
+        agent_trace = turn.get("agent_trace", [])
+        if agent_trace:
+            with st.expander("Agent trace", expanded=False):
+                for agent_out in agent_trace:
+                    _render_agent_panel(
+                        agent_out["agent_id"], agent_out["output"], expanded=False
+                    )
 
 
 # ---------------------------------------------------------------------------
@@ -366,13 +369,13 @@ def _run_turn(user_input: str) -> None:
         "content": user_input,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "turn_index": len(st.session_state.get("chat_history", [])),
-        "agent_outputs": [],
+        "agent_trace": [],
     }
 
     with st.chat_message("user"):
         st.markdown(user_input)
 
-    agent_outputs: List[Dict[str, Any]] = []
+    agent_trace: List[Dict[str, Any]] = []
     with st.chat_message("assistant"):
         with st.status("Running MAS...", expanded=True) as status:
             try:
@@ -388,7 +391,7 @@ def _run_turn(user_input: str) -> None:
                         Exception
                     ) as render_exc:  # pylint: disable=broad-exception-caught
                         st.error(f"Agent {node_name} failed to render: {render_exc}")
-                    agent_outputs.append(
+                    agent_trace.append(
                         {
                             "agent_id": node_name,
                             "output": _serialize_state_update(state_update),
@@ -400,7 +403,7 @@ def _run_turn(user_input: str) -> None:
                 st.error(f"Execution failed: {exc}")
                 turn["error"] = str(exc)
 
-    turn["agent_outputs"] = agent_outputs
+    turn["agent_trace"] = agent_trace
 
     if "chat_history" not in st.session_state:
         st.session_state.chat_history = []

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 # pylint: disable=import-error
+import json
 import logging
 import uuid
 from datetime import datetime, timezone
@@ -175,6 +176,23 @@ def _render_sidebar() -> None:
         st.session_state.chat_history = []
         st.session_state.chat_thread_id = str(uuid.uuid4())
         st.rerun()
+
+    chat_history = st.session_state.get("chat_history", [])
+    thread_id = st.session_state.get("chat_thread_id", "")
+    if chat_history:
+        export = {
+            "mas_id": config.mas_id,
+            "thread_id": thread_id,
+            "exported_at": datetime.now(timezone.utc).isoformat(),
+            "turns": chat_history,
+        }
+        st.download_button(
+            "Export Conversation",
+            data=json.dumps(export, indent=2),
+            file_name=f"aether_chat_{config.mas_id}_{thread_id[:8]}.json",
+            mime="application/json",
+            use_container_width=True,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -618,9 +618,9 @@ def _render_agent_output(node_name: str, state_update: Dict[str, Any]) -> None:
 
 def _render_stored_turn(turn: Dict[str, Any]) -> None:
     """Re-render a previously completed turn from chat_history."""
-    with st.chat_message("👤"):
+    with st.chat_message("user", avatar="👤"):
         st.markdown(turn["content"])
-    with st.chat_message("🤖"):
+    with st.chat_message("assistant", avatar="🤖"):
         if "error" in turn:
             st.error(f"Execution failed: {turn['error']}")
         agent_trace = turn.get("agent_trace", [])
@@ -660,11 +660,11 @@ def _run_turn(user_input: str) -> None:
         "agent_trace": [],
     }
 
-    with st.chat_message("👤"):
+    with st.chat_message("user", avatar="👤"):
         st.markdown(user_input)
 
     agent_trace: List[Dict[str, Any]] = []
-    with st.chat_message("🤖"):
+    with st.chat_message("assistant", avatar="🤖"):
         with st.status("Running MAS...", expanded=True) as status:
             try:
                 for node_name, state_update in executor.run_streaming(

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -90,33 +90,8 @@ def _configure_page() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _load_config(yaml_path: Path) -> None:
-    """Load a YAML config and initialize the executor when the path changes."""
-    current_path = st.session_state.get("chat_yaml_path")
-    if current_path == str(yaml_path) and "chat_config" in st.session_state:
-        return
-
-    try:
-        config = load_mas_from_yaml(yaml_path)
-        executor = MASExecutor(config)
-        with st.spinner("Initializing executor..."):
-            executor.initialize()
-        st.session_state.chat_config = config
-        st.session_state.chat_yaml_path = str(yaml_path)
-        st.session_state.chat_executor = executor
-        st.session_state.chat_history = []
-        st.session_state.pop("chat_thread_id", None)
-        st.session_state.pop("chat_load_error", None)
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        LOGGER.error("Failed to load config %s: %s", yaml_path.name, exc, exc_info=True)
-        st.session_state.chat_load_error = str(exc)
-        for key in ("chat_config", "chat_yaml_path", "chat_executor"):
-            st.session_state.pop(key, None)
-
-
-def _load_uploaded_config(name: str, config: MASConfig) -> None:
-    """Initialize the executor from an already-parsed uploaded MASConfig."""
-    cache_key = f"uploaded:{name}"
+def _initialize_executor(config: MASConfig, cache_key: str) -> None:
+    """Compile the executor and update session state, or store the error."""
     if (
         st.session_state.get("chat_yaml_path") == cache_key
         and "chat_config" in st.session_state
@@ -134,12 +109,28 @@ def _load_uploaded_config(name: str, config: MASConfig) -> None:
         st.session_state.pop("chat_thread_id", None)
         st.session_state.pop("chat_load_error", None)
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        LOGGER.error(
-            "Failed to initialize uploaded config %s: %s", name, exc, exc_info=True
-        )
+        LOGGER.error("Failed to load config %s: %s", cache_key, exc, exc_info=True)
         st.session_state.chat_load_error = str(exc)
         for key in ("chat_config", "chat_yaml_path", "chat_executor"):
             st.session_state.pop(key, None)
+
+
+def _load_config(yaml_path: Path) -> None:
+    """Load a YAML config and initialize the executor when the path changes."""
+    try:
+        config = load_mas_from_yaml(yaml_path)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        LOGGER.error("Failed to load config %s: %s", yaml_path.name, exc, exc_info=True)
+        st.session_state.chat_load_error = str(exc)
+        for key in ("chat_config", "chat_yaml_path", "chat_executor"):
+            st.session_state.pop(key, None)
+        return
+    _initialize_executor(config, str(yaml_path))
+
+
+def _load_uploaded_config(name: str, config: MASConfig) -> None:
+    """Initialize the executor from an already-parsed uploaded MASConfig."""
+    _initialize_executor(config, f"uploaded:{name}")
 
 
 # ---------------------------------------------------------------------------
@@ -157,16 +148,19 @@ def _render_sidebar() -> None:
     st.markdown("---")
 
     uploaded = st.file_uploader("Upload YAML config", type=["yaml", "yml"])
-    if uploaded:
+    if uploaded and uploaded.name not in st.session_state.get(
+        "chat_uploaded_configs", {}
+    ):
         try:
             raw = yaml.safe_load(uploaded.read())
             if not isinstance(raw, dict):
-                raise ValueError("YAML must be a mapping at the top level.")
-            upload_config = load_mas_from_dict(raw)
-            if "chat_uploaded_configs" not in st.session_state:
-                st.session_state.chat_uploaded_configs = {}
-            st.session_state.chat_uploaded_configs[uploaded.name] = upload_config
-            st.success(f"Uploaded: {uploaded.name}")
+                st.error("Invalid config: YAML must be a mapping at the top level.")
+            else:
+                upload_config = load_mas_from_dict(raw)
+                if "chat_uploaded_configs" not in st.session_state:
+                    st.session_state.chat_uploaded_configs = {}
+                st.session_state.chat_uploaded_configs[uploaded.name] = upload_config
+                st.success(f"Uploaded: {uploaded.name}")
         except Exception as exc:  # pylint: disable=broad-exception-caught
             st.error(f"Invalid config: {exc}")
 

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -89,6 +89,125 @@ def _apply_model_patch(base_config: MASConfig, model_id: Optional[str]) -> None:
     _initialize_executor(patched, cache_key)
 
 
+def _active_messages() -> List[Dict]:
+    """Return the messages list for the active thread.
+
+    Returns a direct reference to the list stored in ``chat_threads`` so that
+    in-place ``append`` calls update session state correctly.  Returns an empty
+    list when no active thread exists.
+    """
+    thread_id = st.session_state.get("chat_thread_id")
+    threads = st.session_state.get("chat_threads", {})
+    if thread_id and thread_id in threads:
+        return threads[thread_id]["messages"]
+    return []
+
+
+def _new_thread(mas_id: str) -> str:
+    """Create a new thread, set it active, and return the new thread ID."""
+    now = datetime.now(timezone.utc)
+    thread_id = str(uuid.uuid4())
+    threads = st.session_state.setdefault("chat_threads", {})
+    threads[thread_id] = {
+        "name": f"{mas_id} \u2013 {now.strftime('%H:%M:%S')}",
+        "messages": [],
+        "mas_id": mas_id,
+        "created_at": now.isoformat(),
+    }
+    st.session_state.chat_thread_id = thread_id
+    return thread_id
+
+
+def _ensure_active_thread(mas_id: str) -> None:
+    """Create a thread if no active thread exists — called before first message send."""
+    thread_id = st.session_state.get("chat_thread_id")
+    if not thread_id or thread_id not in st.session_state.get("chat_threads", {}):
+        _new_thread(mas_id)
+
+
+def _delete_thread(thread_id: str) -> None:
+    """Remove a thread; auto-switch to most recent remaining thread if it was active."""
+    threads = st.session_state.get("chat_threads", {})
+    threads.pop(thread_id, None)
+    if st.session_state.get("chat_thread_id") == thread_id:
+        if threads:
+            newest_id = max(threads, key=lambda t: threads[t]["created_at"])
+            st.session_state.chat_thread_id = newest_id
+        else:
+            st.session_state.pop("chat_thread_id", None)
+
+
+def _render_thread_list() -> None:
+    """Render the in-sidebar thread list with filter, rename, and delete controls."""
+    threads: Dict[str, Any] = st.session_state.get("chat_threads", {})
+    if not threads:
+        return
+
+    st.markdown("---")
+    st.markdown("**Conversations**")
+    st.caption("In-session only — threads are lost on page reload.")
+
+    filter_text: str = st.text_input(
+        "Filter conversations",
+        key="chat_thread_filter",
+        placeholder="Search…",
+        label_visibility="collapsed",
+    )
+
+    active_id: Optional[str] = st.session_state.get("chat_thread_id")
+    editing_id: Optional[str] = st.session_state.get("chat_editing_thread")
+
+    sorted_threads = sorted(
+        threads.items(), key=lambda x: x[1]["created_at"], reverse=True
+    )
+    if filter_text:
+        sorted_threads = [
+            (tid, t)
+            for tid, t in sorted_threads
+            if filter_text.lower() in t["name"].lower()
+        ]
+
+    for tid, thread in sorted_threads:
+        is_active = tid == active_id
+
+        if editing_id == tid:
+            c1, c2 = st.columns([4, 1])
+            with c1:
+                new_name = st.text_input(
+                    "Rename thread",
+                    value=thread["name"],
+                    key=f"chat_rename_input_{tid}",
+                    label_visibility="collapsed",
+                )
+            with c2:
+                if st.button("✓", key=f"chat_rename_confirm_{tid}", help="Save name"):
+                    threads[tid]["name"] = new_name
+                    st.session_state.pop("chat_editing_thread", None)
+                    st.rerun()
+        else:
+            timestamp = thread["created_at"][11:16]
+            c1, c2, c3 = st.columns([5, 1, 1])
+            with c1:
+                btn_type = "primary" if is_active else "secondary"
+                if st.button(
+                    f"{thread['name']}  {timestamp}",
+                    key=f"chat_select_thread_{tid}",
+                    use_container_width=True,
+                    type=btn_type,
+                ):
+                    if not is_active:
+                        st.session_state.chat_thread_id = tid
+                        st.rerun()
+            with c2:
+                if st.button("✏️", key=f"chat_edit_thread_{tid}", help="Rename"):
+                    st.session_state.chat_editing_thread = tid
+                    st.rerun()
+            with c3:
+                if st.button("🗑️", key=f"chat_delete_thread_{tid}", help="Delete"):
+                    _delete_thread(tid)
+                    st.rerun()
+
+
 @st.cache_data
 def _build_chat_model_options() -> tuple[list[str], list[str]]:
     """Return ``(display_list, model_id_list)`` from LLM_MODELS, grouped by provider.
@@ -351,6 +470,8 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
             "chat_executor",
             "chat_load_error",
             "chat_config_base",
+            # chat_threads and chat_thread_id are intentionally kept — threads
+            # persist across config switches so the list remains visible.
         ):
             st.session_state.pop(key, None)
         return
@@ -409,11 +530,10 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     st.markdown("---")
 
     if st.button("New Conversation", use_container_width=True):
-        st.session_state.chat_history = []
-        st.session_state.chat_thread_id = str(uuid.uuid4())
+        _new_thread(config.mas_id)
         st.rerun()
 
-    chat_history = st.session_state.get("chat_history", [])
+    chat_history = _active_messages()
     thread_id = st.session_state.get("chat_thread_id", "")
     if chat_history:
         export = {
@@ -429,6 +549,8 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
             mime="application/json",
             use_container_width=True,
         )
+
+    _render_thread_list()
 
 
 # ---------------------------------------------------------------------------
@@ -527,14 +649,14 @@ def _run_turn(user_input: str) -> None:
         st.error("No executor available. Select a configuration first.")
         return
 
-    if "chat_thread_id" not in st.session_state:
-        st.session_state.chat_thread_id = str(uuid.uuid4())
+    config: Optional[MASConfig] = st.session_state.get("chat_config")
+    _ensure_active_thread(config.mas_id if config else "unknown")
 
     turn: Dict[str, Any] = {
         "role": "user",
         "content": user_input,
         "timestamp": datetime.now(timezone.utc).isoformat(),
-        "turn_index": len(st.session_state.get("chat_history", [])),
+        "turn_index": len(_active_messages()),
         "agent_trace": [],
     }
 
@@ -570,10 +692,7 @@ def _run_turn(user_input: str) -> None:
                 turn["error"] = str(exc)
 
     turn["agent_trace"] = agent_trace
-
-    if "chat_history" not in st.session_state:
-        st.session_state.chat_history = []
-    st.session_state.chat_history.append(turn)
+    _active_messages().append(turn)
 
 
 # ---------------------------------------------------------------------------
@@ -596,7 +715,7 @@ def _render_chat_area() -> None:
     if config.description:
         st.caption(config.description)
 
-    for turn in st.session_state.get("chat_history", []):
+    for turn in _active_messages():
         _render_stored_turn(turn)
 
     user_input = st.chat_input("Send a message to the MAS...")

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -196,25 +196,28 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     """
     effective_examples_dir = examples_dir if examples_dir is not None else EXAMPLES_DIR
 
-    autoload_name = st.session_state.pop("_chat_autoload_name", None)
+    if not effective_examples_dir.exists():
+        st.error(f"Examples directory not found: {effective_examples_dir}")
+        return
+
+    # Build option lists once — reused by both the autoload block and the selectbox.
+    yaml_files = sorted(effective_examples_dir.glob("*.yaml"))
+    uploaded_configs: Dict[str, MASConfig] = st.session_state.get(
+        "chat_uploaded_configs", {}
+    )
+    uploaded_names = sorted(uploaded_configs.keys())
+
+    autoload_name = st.session_state.pop("chat_autoload_name", None)
     if autoload_name is not None:
-        pending = st.session_state.get("chat_uploaded_configs", {}).get(autoload_name)
+        pending = uploaded_configs.get(autoload_name)
         if pending is not None:
             _load_uploaded_config(autoload_name, pending)
             # Pre-select the config in the selectbox so the selectbox's else-branch
             # does not immediately clear the session state we just populated.
-            _n_yaml = (
-                len(sorted(effective_examples_dir.glob("*.yaml")))
-                if effective_examples_dir.exists()
-                else 0
-            )
-            _uploaded_sorted = sorted(
-                st.session_state.get("chat_uploaded_configs", {}).keys()
-            )
-            if autoload_name in _uploaded_sorted:
-                st.session_state.chat_yaml_selector = _n_yaml + _uploaded_sorted.index(
-                    autoload_name
-                )
+            if autoload_name in uploaded_names:
+                st.session_state.chat_yaml_selector = len(
+                    yaml_files
+                ) + uploaded_names.index(autoload_name)
 
     uploaded = st.file_uploader("Upload YAML config", type=["yaml", "yml"])
     if uploaded and uploaded.name not in st.session_state.get(
@@ -233,14 +236,9 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
         except Exception as exc:  # pylint: disable=broad-exception-caught
             st.error(f"Invalid config: {exc}")
 
-    if not effective_examples_dir.exists():
-        st.error(f"Examples directory not found: {effective_examples_dir}")
-        return
-
-    yaml_files = sorted(effective_examples_dir.glob("*.yaml"))
-    uploaded_configs: Dict[str, MASConfig] = st.session_state.get(
-        "chat_uploaded_configs", {}
-    )
+    # Re-read uploaded_configs after the uploader so newly uploaded files
+    # appear in the selectbox on the same rerun.
+    uploaded_configs = st.session_state.get("chat_uploaded_configs", {})
     uploaded_names = sorted(uploaded_configs.keys())
 
     if not yaml_files and not uploaded_names:

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -93,14 +93,20 @@ def _active_messages() -> List[Dict]:
     """Return the messages list for the active thread.
 
     Returns a direct reference to the list stored in ``chat_threads`` so that
-    in-place ``append`` calls update session state correctly.  Returns an empty
-    list when no active thread exists.
+    in-place ``append`` calls update session state correctly.
+
+    Raises:
+        RuntimeError: If no active thread exists. Callers must ensure a thread
+            is active (e.g. via ``_ensure_active_thread``) before appending.
     """
     thread_id = st.session_state.get("chat_thread_id")
     threads = st.session_state.get("chat_threads", {})
     if thread_id and thread_id in threads:
         return threads[thread_id]["messages"]
-    return []
+    raise RuntimeError(
+        "_active_messages() called with no active thread. "
+        "Call _ensure_active_thread() before appending."
+    )
 
 
 def _new_thread(mas_id: str) -> str:
@@ -112,7 +118,7 @@ def _new_thread(mas_id: str) -> str:
         "name": f"{mas_id} \u2013 {now.strftime('%H:%M:%S')}",
         "messages": [],
         "mas_id": mas_id,
-        "created_at": now.isoformat(),
+        "created_at": now.timestamp(),
     }
     st.session_state.chat_thread_id = thread_id
     return thread_id
@@ -185,12 +191,11 @@ def _render_thread_list() -> None:
                     st.session_state.pop("chat_editing_thread", None)
                     st.rerun()
         else:
-            timestamp = thread["created_at"][11:16]
             c1, c2, c3 = st.columns([5, 1, 1])
             with c1:
                 btn_type = "primary" if is_active else "secondary"
                 if st.button(
-                    f"{thread['name']}  {timestamp}",
+                    thread["name"],
                     key=f"chat_select_thread_{tid}",
                     use_container_width=True,
                     type=btn_type,
@@ -307,7 +312,6 @@ def _initialize_executor(config: MASConfig, cache_key: str) -> None:
         st.session_state.chat_config = config
         st.session_state.chat_yaml_path = cache_key
         st.session_state.chat_executor = executor
-        st.session_state.chat_history = []
         st.session_state.pop("chat_thread_id", None)
         st.session_state.pop("chat_load_error", None)
     except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -123,7 +123,9 @@ def _active_messages_or_empty() -> List[Dict]:
 def _new_thread(mas_id: str) -> str:
     """Create a new thread, set it active, and return the new thread ID."""
     now = datetime.now(timezone.utc)
-    display_time = datetime.now().strftime("%H:%M:%S")  # local time for readability
+    display_time = now.astimezone().strftime(
+        "%H:%M:%S"
+    )  # convert to local time for readability
     thread_id = str(uuid.uuid4())
     threads = st.session_state.setdefault("chat_threads", {})
     threads[thread_id] = {
@@ -331,8 +333,11 @@ def _initialize_executor(config: MASConfig, cache_key: str) -> None:
         st.session_state.chat_config = config
         st.session_state.chat_yaml_path = cache_key
         st.session_state.chat_executor = executor
-        # Clear active pointer only; chat_threads persists across config switches
-        # so the user can re-activate a previous thread by clicking it in the list.
+        # Clear active pointer only; chat_threads persists across config switches so
+        # the user can re-activate a previous thread by clicking it in the list.
+        # Render paths use _active_messages_or_empty() which safely returns [] when
+        # no thread is active; _active_messages() (write path) requires a prior
+        # _ensure_active_thread() call and will raise if this pointer is absent.
         st.session_state.pop("chat_thread_id", None)
         st.session_state.pop("chat_load_error", None)
     except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -463,7 +463,9 @@ def _build_markdown_export(
         ]
         for agent_out in turn.get("agent_trace", []):
             content = _extract_content(agent_out.get("output", {}))
-            lines.append(f"> **{agent_out['agent_id']}:** {content}")
+            # Prefix every line so multi-line content is fully blockquoted.
+            content_lines = content.replace("\n", "\n> ")
+            lines.append(f"> **{agent_out['agent_id']}:** {content_lines}")
         lines.append("")
     return "\n".join(lines)
 

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -123,10 +123,11 @@ def _active_messages_or_empty() -> List[Dict]:
 def _new_thread(mas_id: str) -> str:
     """Create a new thread, set it active, and return the new thread ID."""
     now = datetime.now(timezone.utc)
+    display_time = datetime.now().strftime("%H:%M:%S")  # local time for readability
     thread_id = str(uuid.uuid4())
     threads = st.session_state.setdefault("chat_threads", {})
     threads[thread_id] = {
-        "name": f"{mas_id} \u2013 {now.strftime('%H:%M:%S')}",
+        "name": f"{mas_id} \u2013 {display_time}",
         "messages": [],
         "mas_id": mas_id,
         "created_at": now.timestamp(),
@@ -146,6 +147,8 @@ def _delete_thread(thread_id: str) -> None:
     """Remove a thread; auto-switch to most recent remaining thread if it was active."""
     threads = st.session_state.get("chat_threads", {})
     threads.pop(thread_id, None)
+    if st.session_state.get("chat_editing_thread") == thread_id:
+        st.session_state.pop("chat_editing_thread", None)
     if st.session_state.get("chat_thread_id") == thread_id:
         if threads:
             newest_id = max(threads, key=lambda t: threads[t]["created_at"])
@@ -328,6 +331,8 @@ def _initialize_executor(config: MASConfig, cache_key: str) -> None:
         st.session_state.chat_config = config
         st.session_state.chat_yaml_path = cache_key
         st.session_state.chat_executor = executor
+        # Clear active pointer only; chat_threads persists across config switches
+        # so the user can re-activate a previous thread by clicking it in the list.
         st.session_state.pop("chat_thread_id", None)
         st.session_state.pop("chat_load_error", None)
     except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -204,7 +204,10 @@ def _load_config(yaml_path: Path) -> None:
     # with a model-picker suffix applied by _apply_model_patch), skip the reload
     # to avoid overwriting the patched executor on each Streamlit rerun.
     current_key = st.session_state.get("chat_yaml_path", "")
-    if current_key.startswith(str(yaml_path)) and "chat_config" in st.session_state:
+    base = str(yaml_path)
+    if (
+        current_key == base or current_key.startswith(f"{base}:")
+    ) and "chat_config" in st.session_state:
         return
 
     try:
@@ -229,7 +232,9 @@ def _load_uploaded_config(name: str, config: MASConfig) -> None:
     # on this uploaded config (possibly with a model-picker suffix).
     current_key = st.session_state.get("chat_yaml_path", "")
     base_key = f"uploaded:{name}"
-    if current_key.startswith(base_key) and "chat_config" in st.session_state:
+    if (
+        current_key == base_key or current_key.startswith(f"{base_key}:")
+    ) and "chat_config" in st.session_state:
         return
 
     if not _validate_config(config):

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -496,9 +496,9 @@ def _render_agent_output(node_name: str, state_update: Dict[str, Any]) -> None:
 
 def _render_stored_turn(turn: Dict[str, Any]) -> None:
     """Re-render a previously completed turn from chat_history."""
-    with st.chat_message("user"):
+    with st.chat_message("👤"):
         st.markdown(turn["content"])
-    with st.chat_message("assistant"):
+    with st.chat_message("🤖"):
         if "error" in turn:
             st.error(f"Execution failed: {turn['error']}")
         agent_trace = turn.get("agent_trace", [])
@@ -538,11 +538,11 @@ def _run_turn(user_input: str) -> None:
         "agent_trace": [],
     }
 
-    with st.chat_message("user"):
+    with st.chat_message("👤"):
         st.markdown(user_input)
 
     agent_trace: List[Dict[str, Any]] = []
-    with st.chat_message("assistant"):
+    with st.chat_message("🤖"):
         with st.status("Running MAS...", expanded=True) as status:
             try:
                 for node_name, state_update in executor.run_streaming(

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -263,21 +263,29 @@ def _run_turn(user_input: str) -> None:
 
     agent_outputs: List[Dict[str, Any]] = []
     with st.chat_message("assistant"):
-        try:
-            for node_name, state_update in executor.run_streaming(
-                input_data={"messages": [HumanMessage(content=user_input)]},
-                thread_id=st.session_state.chat_thread_id,
-            ):
-                _render_agent_output(node_name, state_update)
-                agent_outputs.append(
-                    {
-                        "agent_id": node_name,
-                        "output": _serialize_state_update(state_update),
-                    }
-                )
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            st.error(f"Execution failed: {exc}")
-            return
+        with st.status("Running MAS...", expanded=True) as status:
+            try:
+                for node_name, state_update in executor.run_streaming(
+                    input_data={"messages": [HumanMessage(content=user_input)]},
+                    thread_id=st.session_state.chat_thread_id,
+                ):
+                    try:
+                        _render_agent_output(node_name, state_update)
+                    except (
+                        Exception
+                    ) as render_exc:  # pylint: disable=broad-exception-caught
+                        st.error(f"Agent {node_name} failed to render: {render_exc}")
+                    agent_outputs.append(
+                        {
+                            "agent_id": node_name,
+                            "output": _serialize_state_update(state_update),
+                        }
+                    )
+                status.update(label="Complete", state="complete", expanded=False)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                status.update(label="Execution failed", state="error")
+                st.error(f"Execution failed: {exc}")
+                return
 
     turn["agent_outputs"] = agent_outputs
 

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -109,6 +109,17 @@ def _active_messages() -> List[Dict]:
     )
 
 
+def _active_messages_or_empty() -> List[Dict]:
+    """Return the active thread's messages or an empty list when no thread exists.
+
+    Safe for read-only call sites (iteration, length checks) where no active
+    thread is a valid state (e.g. before the first message is sent).
+    """
+    thread_id = st.session_state.get("chat_thread_id")
+    threads = st.session_state.get("chat_threads", {})
+    return threads.get(thread_id, {}).get("messages", []) if thread_id else []
+
+
 def _new_thread(mas_id: str) -> str:
     """Create a new thread, set it active, and return the new thread ID."""
     now = datetime.now(timezone.utc)
@@ -177,7 +188,7 @@ def _render_thread_list() -> None:
         is_active = tid == active_id
 
         if editing_id == tid:
-            c1, c2 = st.columns([4, 1])
+            c1, c2, c3 = st.columns([4, 1, 1])
             with c1:
                 new_name = st.text_input(
                     "Rename thread",
@@ -190,6 +201,10 @@ def _render_thread_list() -> None:
                     threads[tid]["name"] = new_name
                     st.session_state.pop("chat_editing_thread", None)
                     st.rerun()
+            with c3:
+                if st.button("✕", key=f"chat_rename_cancel_{tid}", help="Cancel"):
+                    st.session_state.pop("chat_editing_thread", None)
+                    st.rerun()
         else:
             c1, c2, c3 = st.columns([5, 1, 1])
             with c1:
@@ -200,6 +215,7 @@ def _render_thread_list() -> None:
                     use_container_width=True,
                     type=btn_type,
                 ):
+                    st.session_state.pop("chat_editing_thread", None)
                     if not is_active:
                         st.session_state.chat_thread_id = tid
                         st.rerun()
@@ -537,7 +553,7 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
         _new_thread(config.mas_id)
         st.rerun()
 
-    chat_history = _active_messages()
+    chat_history = _active_messages_or_empty()
     thread_id = st.session_state.get("chat_thread_id", "")
     if chat_history:
         export = {
@@ -719,7 +735,7 @@ def _render_chat_area() -> None:
     if config.description:
         st.caption(config.description)
 
-    for turn in _active_messages():
+    for turn in _active_messages_or_empty():
         _render_stored_turn(turn)
 
     user_input = st.chat_input("Send a message to the MAS...")

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -410,6 +410,54 @@ def _render_sidebar() -> None:
     render_sidebar_content()
 
 
+def _extract_content(output: Dict[str, Any]) -> str:
+    """Extract a readable content string from a serialized agent output dict.
+
+    Mirrors the display priority of ``_render_agent_panel`` but returns a plain
+    string suitable for text-based exports.
+    """
+    agent_outputs: Dict[str, Any] = output.get("agent_outputs", {})
+    for inner in agent_outputs.values():
+        if inner.get("status") == "stub":
+            return inner.get("message", str(inner))
+        parts = [f"{k}: {v}" for k, v in inner.items() if k != "agent_id"]
+        if parts:
+            return " | ".join(parts)
+    messages: List[Any] = output.get("messages", [])
+    if messages:
+        last = messages[-1]
+        if isinstance(last, dict):
+            return last.get("content", str(last))
+        return getattr(last, "content", str(last))
+    return str(output)
+
+
+def _build_markdown_export(
+    config: "MASConfig", thread_id: str, chat_history: List[Dict]
+) -> str:
+    """Build a Markdown export string for the active conversation."""
+    lines = [
+        f"# Conversation — {config.mas_id}",
+        f"Thread: {thread_id}",
+        f"Exported: {datetime.now(timezone.utc).isoformat()}",
+        "",
+    ]
+    for i, turn in enumerate(chat_history, 1):
+        lines += [
+            f"## Turn {i}",
+            "",
+            f"**User:** {turn['content']}",
+            "",
+            "**MAS Response:**",
+            "",
+        ]
+        for agent_out in turn.get("agent_trace", []):
+            content = _extract_content(agent_out.get("output", {}))
+            lines.append(f"> **{agent_out['agent_id']}:** {content}")
+        lines.append("")
+    return "\n".join(lines)
+
+
 def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     """Render the chat sidebar controls — config selector, upload, and buttons.
 
@@ -566,19 +614,32 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     chat_history = _active_messages_or_empty()
     thread_id = st.session_state.get("chat_thread_id", "")
     if chat_history:
-        export = {
+        export_json = {
             "mas_id": config.mas_id,
             "thread_id": thread_id,
             "exported_at": datetime.now(timezone.utc).isoformat(),
-            "turns": chat_history,
+            "turns": [
+                {**turn, "agent_trace": turn.get("agent_trace", [])}
+                for turn in chat_history
+            ],
         }
-        st.download_button(
-            "Export Conversation",
-            data=json.dumps(export, indent=2),
-            file_name=f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}.json",
-            mime="application/json",
-            use_container_width=True,
-        )
+        col_json, col_md = st.columns(2)
+        with col_json:
+            st.download_button(
+                "Export JSON",
+                data=json.dumps(export_json, indent=2),
+                file_name=f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}.json",
+                mime="application/json",
+                use_container_width=True,
+            )
+        with col_md:
+            st.download_button(
+                "Export Markdown",
+                data=_build_markdown_export(config, thread_id, chat_history),
+                file_name=f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}.md",
+                mime="text/markdown",
+                use_container_width=True,
+            )
 
     _render_thread_list()
 

--- a/bili/aether/ui/components/graph_viewer.py
+++ b/bili/aether/ui/components/graph_viewer.py
@@ -20,7 +20,7 @@ def _overrides_key(mas_id: str) -> str:
 
 
 @st.cache_data
-def _build_model_options() -> tuple[list[str], dict[str, str], dict[str, str]]:
+def build_model_options() -> tuple[list[str], dict[str, str], dict[str, str]]:
     """Return (display_list, display_to_model_name, model_lookup) from LLM_MODELS.
 
     The ``display_to_model_name`` dict maps each display string back to the
@@ -140,7 +140,7 @@ def _render_list_section(title: str, items: list) -> None:
 def _render_model_selector(agent: AgentSpec, mas_id: str) -> None:
     """Render the model override selectbox and persist the selection to session state."""
     _keep = "(keep from YAML)"
-    options, _, model_lookup = _build_model_options()
+    options, _, model_lookup = build_model_options()
     overrides = st.session_state[_overrides_key(mas_id)]
 
     current_override = overrides.get(agent.agent_id)

--- a/bili/aether/ui/components/graph_viewer.py
+++ b/bili/aether/ui/components/graph_viewer.py
@@ -14,6 +14,8 @@ from streamlit_flow.state import StreamlitFlowState
 from bili.aether.schema.agent_spec import AgentSpec
 from bili.aether.schema.mas_config import MASConfig
 
+MODEL_KEEP_SENTINEL = "(keep from YAML)"
+
 
 def _overrides_key(mas_id: str) -> str:
     return f"model_overrides_{mas_id}"
@@ -139,7 +141,6 @@ def _render_list_section(title: str, items: list) -> None:
 
 def _render_model_selector(agent: AgentSpec, mas_id: str) -> None:
     """Render the model override selectbox and persist the selection to session state."""
-    _keep = "(keep from YAML)"
     options, _, model_lookup = build_model_options()
     overrides = st.session_state[_overrides_key(mas_id)]
 
@@ -155,14 +156,14 @@ def _render_model_selector(agent: AgentSpec, mas_id: str) -> None:
     st.markdown("**Model**")
     selected = st.selectbox(
         "Model",
-        [_keep] + options,
+        [MODEL_KEEP_SENTINEL] + options,
         index=start_index,
         key=f"model_select_{mas_id}_{agent.agent_id}",
         help="Override the LLM for this agent. '(keep from YAML)' uses the configured model.",
         label_visibility="collapsed",
     )
 
-    if selected == _keep:
+    if selected == MODEL_KEEP_SENTINEL:
         overrides.pop(agent.agent_id, None)
     else:
         overrides[agent.agent_id] = selected


### PR DESCRIPTION
### This PR introduces the following changes

- Wraps the `run_streaming()` loop in `_run_turn()` with `st.status("Running MAS...", expanded=True)` so the user sees a live spinner while the MAS executes
- Adds per-node try/except around `_render_agent_output()` so a rendering failure in one agent's expander displays an inline error without aborting the remaining stream
- Updates the outer try/except to call `status.update(label="Execution failed", state="error")` on graph-level failures, giving the status container a red error badge alongside the existing `st.error()` message
- On success, calls `status.update(label="Complete", state="complete", expanded=False)` to collapse the status container to a green checkmark after all agents complete
- Raw agent outputs are always appended to agent_outputs regardless of render failures, preserving full history for later export

### Steps to Review

1. Checkout the `91-task-3-wire-real-time-agent-output-streaming-to-chat-ui` branch on your local machine
2. Start the development container: `./scripts/development/start-container`
3. In a second terminal, attach to the container: `./scripts/development/attach-container`
4. Inside the container, install the new dependency: `/app/bili-core/venv/bin/pip install streamlit-flow-component --ignore-installed blinker`
5. Ensure langgraph is up to date: `/app/bili-core/venv/bin/pip install --upgrade --force-reinstall "langgraph~=1.0.2"`
6. Run the visualizer: `/app/bili-core/venv/bin/streamlit run bili/aether/ui/app.py` [use this long command to bypass `streamlit` alias]
8. Run ./run_python_formatters.sh and confirm pylint score ≥ 9.0
9. Optionally verify the existing visualizer has no regressions: `/app/bili-core/venv/bin/streamlit run bili/aether/ui/app.py` (use the full venv path to bypass the streamlit alias)
10. Run the chat UI: `/app/bili-core/venv/bin/streamlit run bili/aether/ui/chat_app.py`
11. Select a stub config from the sidebar — confirm the MAS ID, workflow, and agent count appear
12. Send a message — confirm the "Running MAS..." spinner appears with agent expanders populating in order inside it
13. Confirm the status collapses to a green "Complete" checkmark after all agents finish
14. Send a second message — confirm the first turn replays as collapsed expanders (not wrapped in a status container) and the new turn shows the spinner again