### PR TITLE
Task 12 Implement model picker to stub toggle

### DIFF
--- a/bili/aether/compiler/agent_generator.py
+++ b/bili/aether/compiler/agent_generator.py
@@ -208,6 +208,13 @@ def _generate_direct_llm_node(agent: AgentSpec, llm: object) -> Callable[[dict],
         # Invoke the LLM directly
         response = llm.invoke(messages)
         content = response.content
+        # Some providers (e.g. Google Vertex) return content as a list of parts.
+        # Normalise to a plain string so all downstream consumers receive str.
+        if isinstance(content, list):
+            content = " ".join(
+                part.get("text", str(part)) if isinstance(part, dict) else str(part)
+                for part in content
+            )
 
         execution_ms = (time.time() - start_time) * 1000
         LOGGER.info(

--- a/bili/aether/compiler/agent_generator.py
+++ b/bili/aether/compiler/agent_generator.py
@@ -17,6 +17,22 @@ from bili.aether.schema import AgentSpec, OutputFormat
 LOGGER = logging.getLogger(__name__)
 
 
+def _normalise_content_value(content: Any) -> str:
+    """Coerce a raw LLM content value to ``str``.
+
+    Some providers (e.g. Google Vertex / Gemini) return content as a list of
+    part dicts such as ``[{"type": "text", "text": "..."}]``.  Joins text
+    parts into a single string; falls back to ``str()`` for unrecognised
+    types.  Returns an empty string for falsy input.
+    """
+    if isinstance(content, list):
+        return " ".join(
+            part.get("text", str(part)) if isinstance(part, dict) else str(part)
+            for part in content
+        )
+    return content or ""
+
+
 def _normalise_message_content(msg: Any) -> Any:
     """Return *msg* with its ``content`` coerced to ``str`` if it is a list.
 
@@ -24,15 +40,11 @@ def _normalise_message_content(msg: Any) -> Any:
     list of content-part dicts.  Forwarding such messages as conversation
     history to the same or a different provider can cause serialisation errors
     (e.g. Vertex rejects a message with an unrecognised parts structure).
-    Joining the text parts into a single string is the safest normalisation.
+    Delegates to :func:`_normalise_content_value` for the join logic.
     """
     if not hasattr(msg, "content") or not isinstance(msg.content, list):
         return msg
-    normalised = " ".join(
-        part.get("text", str(part)) if isinstance(part, dict) else str(part)
-        for part in msg.content
-    )
-    return msg.model_copy(update={"content": normalised})
+    return msg.model_copy(update={"content": _normalise_content_value(msg.content)})
 
 
 def generate_agent_node(agent: AgentSpec) -> Callable[[dict], dict]:
@@ -157,16 +169,7 @@ def _generate_tool_agent_node(
         response_messages = result.get("messages", [])
         content = ""
         if response_messages:
-            raw = response_messages[-1].content or ""
-            # Normalise list-of-parts responses (e.g. Google Vertex / Gemini)
-            # to a plain string so downstream consumers always receive str.
-            if isinstance(raw, list):
-                content = " ".join(
-                    part.get("text", str(part)) if isinstance(part, dict) else str(part)
-                    for part in raw
-                )
-            else:
-                content = raw
+            content = _normalise_content_value(response_messages[-1].content)
 
         output = _build_output(agent, content)
         agent_outputs = dict(state.get("agent_outputs") or {})
@@ -240,14 +243,7 @@ def _generate_direct_llm_node(agent: AgentSpec, llm: object) -> Callable[[dict],
 
         # Invoke the LLM directly
         response = llm.invoke(messages)
-        content = response.content
-        # Some providers (e.g. Google Vertex) return content as a list of parts.
-        # Normalise to a plain string so all downstream consumers receive str.
-        if isinstance(content, list):
-            content = " ".join(
-                part.get("text", str(part)) if isinstance(part, dict) else str(part)
-                for part in content
-            )
+        content = _normalise_content_value(response.content)
 
         execution_ms = (time.time() - start_time) * 1000
         LOGGER.info(

--- a/bili/aether/compiler/agent_generator.py
+++ b/bili/aether/compiler/agent_generator.py
@@ -17,6 +17,24 @@ from bili.aether.schema import AgentSpec, OutputFormat
 LOGGER = logging.getLogger(__name__)
 
 
+def _normalise_message_content(msg: Any) -> Any:
+    """Return *msg* with its ``content`` coerced to ``str`` if it is a list.
+
+    Some LLM providers (e.g. Google Vertex / Gemini) return ``content`` as a
+    list of content-part dicts.  Forwarding such messages as conversation
+    history to the same or a different provider can cause serialisation errors
+    (e.g. Vertex rejects a message with an unrecognised parts structure).
+    Joining the text parts into a single string is the safest normalisation.
+    """
+    if not hasattr(msg, "content") or not isinstance(msg.content, list):
+        return msg
+    normalised = " ".join(
+        part.get("text", str(part)) if isinstance(part, dict) else str(part)
+        for part in msg.content
+    )
+    return msg.model_copy(update={"content": normalised})
+
+
 def generate_agent_node(agent: AgentSpec) -> Callable[[dict], dict]:
     """Create a node callable for the given agent.
 
@@ -112,6 +130,12 @@ def _generate_tool_agent_node(
 
         messages = list(state.get("messages", []))
 
+        # Normalise any list-content messages from previous agents (e.g. Gemini
+        # returns content as a list of parts).  Providers like Google Vertex reject
+        # messages where content is a list they don't recognise when those messages
+        # are forwarded as conversation history to a subsequent agent.
+        messages = [_normalise_message_content(m) for m in messages]
+
         has_system = any(isinstance(m, SystemMessage) for m in messages)
         if not has_system:
             messages.insert(0, SystemMessage(content=system_prompt))
@@ -133,7 +157,16 @@ def _generate_tool_agent_node(
         response_messages = result.get("messages", [])
         content = ""
         if response_messages:
-            content = response_messages[-1].content or ""
+            raw = response_messages[-1].content or ""
+            # Normalise list-of-parts responses (e.g. Google Vertex / Gemini)
+            # to a plain string so downstream consumers always receive str.
+            if isinstance(raw, list):
+                content = " ".join(
+                    part.get("text", str(part)) if isinstance(part, dict) else str(part)
+                    for part in raw
+                )
+            else:
+                content = raw
 
         output = _build_output(agent, content)
         agent_outputs = dict(state.get("agent_outputs") or {})
@@ -186,10 +219,10 @@ def _generate_direct_llm_node(agent: AgentSpec, llm: object) -> Callable[[dict],
         if comm_context:
             system_prompt += "\n\n--- Messages from other agents ---\n" + comm_context
 
-        # Filter state messages to compatible types
+        # Filter state messages to compatible types and normalise list content
         state_messages = state.get("messages", [])
         compatible = [
-            m
+            _normalise_message_content(m)
             for m in state_messages
             if isinstance(m, (AIMessage, HumanMessage, SystemMessage))
         ]

--- a/bili/aether/compiler/graph_builder.py
+++ b/bili/aether/compiler/graph_builder.py
@@ -35,6 +35,14 @@ def _build_supervisor_routing_instructions(
     Args:
         supervisor_id: The supervisor agent's ID (excluded from worker list).
         workers: List of worker AgentSpec objects.
+
+    Note:
+        Assumes a single-supervisor topology where all non-supervisor agents
+        are routable workers for this supervisor.  In a hypothetical
+        multi-supervisor config each supervisor's worker list would include
+        the other supervisors, which is unlikely to be correct.  That edge
+        case is not supported by any current example config and is left as a
+        known limitation.
     """
     worker_lines = "\n".join(
         f"  - {w.agent_id} ({w.role}): {(w.objective or '').strip()[:120]}"

--- a/bili/aether/compiler/graph_builder.py
+++ b/bili/aether/compiler/graph_builder.py
@@ -23,6 +23,38 @@ from .state_generator import _merge_dicts, _replace_value, generate_state_schema
 LOGGER = logging.getLogger(__name__)
 
 
+def _build_supervisor_routing_instructions(
+    supervisor_id: str,
+    workers: list,
+) -> str:
+    """Return routing instructions to append to a supervisor agent's system prompt.
+
+    Tells the LLM the available worker agent IDs and the exact format it must
+    use to route to one of them (or end the workflow).
+
+    Args:
+        supervisor_id: The supervisor agent's ID (excluded from worker list).
+        workers: List of worker AgentSpec objects.
+    """
+    worker_lines = "\n".join(
+        f"  - {w.agent_id} ({w.role}): {(w.objective or '').strip()[:120]}"
+        for w in workers
+    )
+    return (
+        "\n\n--- ROUTING INSTRUCTIONS ---\n"
+        "You are the supervisor of a multi-agent system. After analysing the input "
+        "you MUST route to exactly one worker agent by including a routing decision "
+        "in your response.\n\n"
+        f"Available workers:\n{worker_lines}\n\n"
+        "To route to a worker, include ONE of the following in your response:\n"
+        '  JSON format (preferred): {"next_agent": "<agent_id>", ...other fields...}\n'
+        "  Text format:             ROUTE_TO: <agent_id>\n\n"
+        'Use "next_agent": "END" (or ROUTE_TO: END) only when all workers have '
+        "reported back and you are ready to produce a final synthesised answer.\n"
+        "Do NOT output a final answer on the first turn — route to a worker first."
+    )
+
+
 # Safe expression evaluator for workflow conditions
 # Allows: comparisons, boolean ops, attribute access, constants
 # Blocks: imports, exec, function calls, comprehensions
@@ -218,10 +250,29 @@ class GraphBuilder:  # pylint: disable=too-few-public-methods,too-many-instance-
         self._apply_inheritance()
 
         # 2. Generate agent node callables
+        # For supervisor workflows, inject routing instructions into the supervisor's
+        # system prompt so the LLM knows to output a "next_agent" routing decision.
+        supervisor_workers: Dict[str, list] = {}
+        if self._config.workflow_type == WorkflowType.SUPERVISOR:
+            for agent in self._config.agents:
+                if agent.is_supervisor:
+                    workers = [
+                        a for a in self._config.agents if a.agent_id != agent.agent_id
+                    ]
+                    supervisor_workers[agent.agent_id] = workers
+
         for agent in self._config.agents:
             if agent.pipeline:
                 node_fn = self._compile_pipeline_node(agent)
             else:
+                if agent.agent_id in supervisor_workers:
+                    routing_suffix = _build_supervisor_routing_instructions(
+                        agent.agent_id, supervisor_workers[agent.agent_id]
+                    )
+                    base_prompt = agent.system_prompt or agent.objective or ""
+                    agent = agent.model_copy(
+                        update={"system_prompt": base_prompt + routing_suffix}
+                    )
                 node_fn = generate_agent_node(agent)
             wrapped = wrap_agent_node(node_fn, agent.agent_id)
             self._agent_nodes[agent.agent_id] = wrapped

--- a/bili/aether/docs/ui.md
+++ b/bili/aether/docs/ui.md
@@ -44,7 +44,7 @@ A read-only graph viewer for exploring AETHER YAML configurations as interactive
 - **Metadata Bar**: Summary metrics for the selected MAS configuration
 - **Color-Coded Nodes**: Nodes are colored by agent role for quick visual identification
 - **Edge Styling**: Solid lines for channels, dashed for workflow edges, animated for conditional edges
-- **Send to Chat →** button: loads the current config into the Chat page. If model overrides have been applied in the Properties Panel, those overrides are patched onto the config before it is sent — the Chat page receives the modified config, not the original YAML
+- **Send to Chat →** button: loads the current config into the Chat page. If model overrides have been applied in the Properties Panel, those overrides are patched onto the config before it is sent — the Chat page receives the modified config, not the original YAML config
 
 ---
 

--- a/bili/aether/docs/ui.md
+++ b/bili/aether/docs/ui.md
@@ -40,10 +40,11 @@ A read-only graph viewer for exploring AETHER YAML configurations as interactive
   - Consensus: circular arrangement
   - Parallel: three-row layout (coordinator, workers, aggregator)
   - Custom/Deliberative: edge-based layered layout
-- **Properties Panel**: Click any node to view agent details (role, objective, model, capabilities, tools, etc.)
+- **Properties Panel**: Click any node to view agent details (role, objective, model, capabilities, tools, etc.). Includes a per-agent **model override selector** — choose any model from the configured LLM registry to override the agent's `model_name` for the current session without editing the YAML
 - **Metadata Bar**: Summary metrics for the selected MAS configuration
 - **Color-Coded Nodes**: Nodes are colored by agent role for quick visual identification
 - **Edge Styling**: Solid lines for channels, dashed for workflow edges, animated for conditional edges
+- **Send to Chat →** button: loads the current config into the Chat page. If model overrides have been applied in the Properties Panel, those overrides are patched onto the config before it is sent — the Chat page receives the modified config, not the original YAML
 
 ---
 
@@ -57,6 +58,8 @@ A multi-turn conversation interface that executes a compiled MAS against user me
 - **Live agent output panels**: expandable sections rendered as each agent node completes, collapsed automatically in conversation history
 - **Stub mode**: configs without `model_name` execute without LLM calls; a banner in the sidebar indicates stub mode
 - **Loading state**: "Initializing executor..." spinner during graph compilation on config selection
+- **Config validation**: structural validation runs automatically on every config load and on every model patch. Errors block execution; warnings surface as non-blocking notices. Results are shown inline in the sidebar
+- **Model picker**: switch any loaded config between stub mode and a real LLM without editing YAML (see [Model Settings](#model-settings))
 - **Error isolation**: individual agent render failures surface as inline errors without aborting the turn
 - **Config load errors**: surfaced in the main area so the sidebar remains clean
 
@@ -77,6 +80,23 @@ A multi-turn conversation interface that executes a compiled MAS against user me
 4. Agent output panels appear live as each node in the graph completes
 5. The status bar updates to "Complete" or "Execution failed" at the end of each turn
 6. Previous turns are preserved in the conversation history above the input
+
+### Model Settings
+
+After a config is loaded, a **Model Settings** section appears in the sidebar below the config metadata. It lets you switch between stub mode and a real LLM without editing or reloading the YAML.
+
+| Control | Behaviour |
+|---------|-----------|
+| **Model selectbox** | Lists all LLMs from `bili/config/llm_config.py` (74 models), grouped by provider |
+| **Apply to all** | Patches every agent in the loaded config with the selected model and reinitialises the executor. Conversation history is cleared |
+| **Stub mode** | Clears `model_name` from all agents and reinitialises; stub mode indicator reappears |
+
+**Important notes:**
+
+- Patches are **in-memory only** — the original YAML on disk is never modified. Selecting a different config from the dropdown resets to the clean YAML
+- The original loaded config is preserved as a base internally, so clicking **Apply to all** and then **Stub mode** (or vice versa) always patches from the unmodified YAML, not from a previously patched state
+- Applying the same model twice does not trigger a redundant reinit (cache hit)
+- If the config contains **pipeline agents**, a warning is shown because pipeline agents use their own internal node models and the top-level override may have no effect on them
 
 ### Conversation Controls
 
@@ -114,9 +134,10 @@ Failed turns include an additional `"error"` field with the exception message; t
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `chat_config` | `MASConfig` | Active configuration |
+| `chat_config` | `MASConfig` | Active configuration (may be model-patched) |
+| `chat_config_base` | `MASConfig` | Original YAML-loaded config, preserved across model picker operations. Always the unpatched base |
 | `chat_executor` | `MASExecutor` | Compiled executor (set after initialization) |
-| `chat_yaml_path` | `str` | Cache key: file path string or `"uploaded:{name}"` |
+| `chat_yaml_path` | `str` | Cache key: bare file path, `"uploaded:{name}"`, or suffixed with `":model={model_id}"` / `":stub"` after model picker use |
 | `chat_history` | `List[Dict]` | All completed turns |
 | `chat_thread_id` | `str` | UUID for checkpoint continuity; reset on "New Conversation" |
 | `chat_uploaded_configs` | `Dict[str, MASConfig]` | Session-only uploaded configs |
@@ -156,6 +177,12 @@ bili/aether/ui/
 - **YAML fails to load**: Check that the YAML is valid against the MASConfig schema
 - **Chat spinner hangs**: Executor initialization compiles the LangGraph; for real-LLM configs this requires valid provider credentials. Check the terminal for authentication errors.
 - **"Execution failed" in chat**: A runtime error occurred during graph execution. The full traceback is logged to the terminal. Select a stub config (any config without `model_name`) to verify the UI works without credentials.
+- **`ImportError: cannot import name 'MODEL_KEEP_SENTINEL'`** (or similar after updating): The venv has a stale non-editable install of bili-core shadowing the local source. Fix with:
+  ```bash
+  pip uninstall bili-core -y && pip install -e /app/bili-core --ignore-installed blinker
+  ```
+- **Chat stays in stub mode after applying a model**: Confirm the terminal shows "Creating LLM for agent..." log lines. If the executor initialises twice (two "MASExecutor initialized" lines with the second showing no LLM creation), the site-packages install is stale — run the reinstall command above.
+- **Model picker shows no effect on pipeline agents**: Pipeline agents (e.g. `researcher` in `pipeline_agents.yaml`) use internal node models; the top-level `model_name` field has no effect. The UI shows a warning when this case is detected.
 
 ## Known Issues
 

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -52,6 +52,27 @@ def _is_stub_config(config: MASConfig) -> bool:
     return any(not agent.model_name for agent in config.agents)
 
 
+@st.cache_data
+def _build_chat_model_options() -> tuple[list[str], list[str]]:
+    """Return ``(display_list, model_id_list)`` from LLM_MODELS, grouped by provider.
+
+    Lazy-imports ``LLM_MODELS`` so this module loads without bili-core's heavy
+    LLM dependencies.  Result is cached for the lifetime of the Streamlit process.
+    """
+    from bili.config.llm_config import (  # pylint: disable=import-outside-toplevel
+        LLM_MODELS,
+    )
+
+    display: list[str] = []
+    ids: list[str] = []
+    for provider_info in LLM_MODELS.values():
+        label = provider_info["name"]
+        for entry in provider_info["models"]:
+            display.append(f"[{label}] {entry['model_name']}")
+            ids.append(entry["model_id"])
+    return display, ids
+
+
 def _serialize_state_update(state_update: Dict[str, Any]) -> Dict[str, Any]:
     """Convert a raw graph state update to a JSON-serializable dict.
 
@@ -154,6 +175,7 @@ def _load_config(yaml_path: Path) -> None:
         for key in ("chat_config", "chat_yaml_path", "chat_executor"):
             st.session_state.pop(key, None)
         return
+    st.session_state.chat_config_base = config
     _initialize_executor(config, str(yaml_path))
 
 
@@ -163,6 +185,7 @@ def _load_uploaded_config(name: str, config: MASConfig) -> None:
         for key in ("chat_config", "chat_yaml_path", "chat_executor"):
             st.session_state.pop(key, None)
         return
+    st.session_state.chat_config_base = config
     _initialize_executor(config, f"uploaded:{name}")
 
 
@@ -287,6 +310,63 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     st.markdown(f"**MAS ID:** `{config.mas_id}`")
     st.markdown(f"**Workflow:** {config.workflow_type.value}")
     st.markdown(f"**Agents:** {len(config.agents)}")
+
+    st.markdown("---")
+    st.markdown("**Model Settings**")
+
+    display_opts, id_opts = _build_chat_model_options()
+    st.selectbox(
+        "Model",
+        range(len(display_opts)),
+        format_func=lambda i: display_opts[i],
+        key="chat_model_selector",
+        label_visibility="collapsed",
+    )
+
+    col1, col2 = st.columns(2)
+    with col1:
+        apply_clicked = st.button(
+            "Apply to all",
+            use_container_width=True,
+            help="Set this model on every agent",
+        )
+    with col2:
+        stub_clicked = st.button(
+            "Stub mode",
+            use_container_width=True,
+            help="Clear model from all agents",
+        )
+
+    base_config: Optional[MASConfig] = st.session_state.get("chat_config_base")
+    if base_config is not None:
+        if apply_clicked:
+            selected_idx = st.session_state.get("chat_model_selector", 0)
+            model_id = id_opts[selected_idx]
+            patched_agents = [
+                a.model_copy(update={"model_name": model_id})
+                for a in base_config.agents
+            ]
+            patched = base_config.model_copy(update={"agents": patched_agents})
+            if _validate_config(patched):
+                base_key = (
+                    st.session_state.get("chat_yaml_path", "config")
+                    .split(":model=")[0]
+                    .split(":stub")[0]
+                )
+                _initialize_executor(patched, f"{base_key}:model={model_id}")
+
+        if stub_clicked:
+            patched_agents = [
+                a.model_copy(update={"model_name": None}) for a in base_config.agents
+            ]
+            patched = base_config.model_copy(update={"agents": patched_agents})
+            if _validate_config(patched):
+                base_key = (
+                    st.session_state.get("chat_yaml_path", "config")
+                    .split(":model=")[0]
+                    .split(":stub")[0]
+                )
+                _initialize_executor(patched, f"{base_key}:stub")
 
     st.markdown("---")
 

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -193,7 +193,7 @@ def _render_thread_list() -> None:
         is_active = tid == active_id
 
         if editing_id == tid:
-            c1, c2, c3 = st.columns([4, 1, 1])
+            c1, c2, c3 = st.columns([4, 1, 1], vertical_alignment="center")
             with c1:
                 new_name = st.text_input(
                     "Rename thread",
@@ -211,7 +211,7 @@ def _render_thread_list() -> None:
                     st.session_state.pop("chat_editing_thread", None)
                     st.rerun()
         else:
-            c1, c2, c3 = st.columns([5, 1, 1])
+            c1, c2, c3 = st.columns([5, 1, 1], vertical_alignment="center")
             with c1:
                 btn_type = "primary" if is_active else "secondary"
                 if st.button(
@@ -414,15 +414,22 @@ def _extract_content(output: Dict[str, Any]) -> str:
     """Extract a readable content string from a serialized agent output dict.
 
     Mirrors the display priority of ``_render_agent_panel`` but returns a plain
-    string suitable for text-based exports.
+    string suitable for text-based exports. Unlike the render panel (which
+    receives a single agent_id), this function collects *all* agent_outputs
+    entries and joins them so no entry is silently dropped.
     """
     agent_outputs: Dict[str, Any] = output.get("agent_outputs", {})
-    for inner in agent_outputs.values():
-        if inner.get("status") == "stub":
-            return inner.get("message", str(inner))
-        parts = [f"{k}: {v}" for k, v in inner.items() if k != "agent_id"]
-        if parts:
-            return " | ".join(parts)
+    if agent_outputs:
+        collected: List[str] = []
+        for inner in agent_outputs.values():
+            if inner.get("status") == "stub":
+                collected.append(inner.get("message", str(inner)))
+            else:
+                kv_parts = [f"{k}: {v}" for k, v in inner.items() if k != "agent_id"]
+                if kv_parts:
+                    collected.append(" | ".join(kv_parts))
+        if collected:
+            return "\n".join(collected)
     messages: List[Any] = output.get("messages", [])
     if messages:
         last = messages[-1]
@@ -433,7 +440,7 @@ def _extract_content(output: Dict[str, Any]) -> str:
 
 
 def _build_markdown_export(
-    config: "MASConfig", thread_id: str, chat_history: List[Dict]
+    config: MASConfig, thread_id: str, chat_history: List[Dict]
 ) -> str:
     """Build a Markdown export string for the active conversation."""
     lines = [
@@ -446,6 +453,9 @@ def _build_markdown_export(
         lines += [
             f"## Turn {i}",
             "",
+            # turn['content'] is inserted verbatim; any markdown the user typed
+            # (headings, links, etc.) will render as-is in the exported file.
+            # This is acceptable since users are exporting their own conversations.
             f"**User:** {turn['content']}",
             "",
             "**MAS Response:**",
@@ -614,11 +624,14 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     chat_history = _active_messages_or_empty()
     thread_id = st.session_state.get("chat_thread_id", "")
     if chat_history:
+        base_name = f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}"
         export_json = {
             "mas_id": config.mas_id,
             "thread_id": thread_id,
             "exported_at": datetime.now(timezone.utc).isoformat(),
             "turns": [
+                # Explicitly include agent_trace so the key is always present,
+                # even for turns stored before this field was introduced.
                 {**turn, "agent_trace": turn.get("agent_trace", [])}
                 for turn in chat_history
             ],
@@ -628,7 +641,7 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
             st.download_button(
                 "Export JSON",
                 data=json.dumps(export_json, indent=2),
-                file_name=f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}.json",
+                file_name=f"{base_name}.json",
                 mime="application/json",
                 use_container_width=True,
             )
@@ -636,7 +649,7 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
             st.download_button(
                 "Export Markdown",
                 data=_build_markdown_export(config, thread_id, chat_history),
-                file_name=f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}.md",
+                file_name=f"{base_name}.md",
                 mime="text/markdown",
                 use_container_width=True,
             )

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -52,6 +52,43 @@ def _is_stub_config(config: MASConfig) -> bool:
     return any(not agent.model_name for agent in config.agents)
 
 
+def _base_cache_key() -> str:
+    """Return the canonical cache key for the current config, stripping any model/stub suffix."""
+    raw = st.session_state.get("chat_yaml_path", "config")
+    return raw.split(":model=")[0].split(":stub")[0]
+
+
+def _apply_model_patch(base_config: MASConfig, model_id: Optional[str]) -> None:
+    """Patch every agent in *base_config* with *model_id* (``None`` = stub), then reinit.
+
+    Warns when pipeline agents are present and *model_id* is not ``None``, because
+    pipeline agents use internal node models and the top-level override may have no effect.
+    Validates the patched config before reinitialising the executor.
+    """
+    if model_id is not None:
+        pipeline_agents = [
+            a.agent_id for a in base_config.agents if a.pipeline is not None
+        ]
+        if pipeline_agents:
+            st.warning(
+                f"Pipeline agents ({', '.join(pipeline_agents)}) use internal node "
+                "models — the top-level model override may have no effect on them."
+            )
+
+    patched_agents = [
+        a.model_copy(update={"model_name": model_id}) for a in base_config.agents
+    ]
+    patched = base_config.model_copy(update={"agents": patched_agents})
+    if not _validate_config(patched):
+        return
+
+    base_key = _base_cache_key()
+    cache_key = (
+        f"{base_key}:model={model_id}" if model_id is not None else f"{base_key}:stub"
+    )
+    _initialize_executor(patched, cache_key)
+
+
 @st.cache_data
 def _build_chat_model_options() -> tuple[list[str], list[str]]:
     """Return ``(display_list, model_id_list)`` from LLM_MODELS, grouped by provider.
@@ -294,6 +331,7 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
             "chat_yaml_path",
             "chat_executor",
             "chat_load_error",
+            "chat_config_base",
         ):
             st.session_state.pop(key, None)
         return
@@ -340,33 +378,14 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     base_config: Optional[MASConfig] = st.session_state.get("chat_config_base")
     if base_config is not None:
         if apply_clicked:
-            selected_idx = st.session_state.get("chat_model_selector", 0)
-            model_id = id_opts[selected_idx]
-            patched_agents = [
-                a.model_copy(update={"model_name": model_id})
-                for a in base_config.agents
-            ]
-            patched = base_config.model_copy(update={"agents": patched_agents})
-            if _validate_config(patched):
-                base_key = (
-                    st.session_state.get("chat_yaml_path", "config")
-                    .split(":model=")[0]
-                    .split(":stub")[0]
-                )
-                _initialize_executor(patched, f"{base_key}:model={model_id}")
+            model_idx = st.session_state.get("chat_model_selector", 0)
+            if model_idx < 0 or model_idx >= len(id_opts):
+                st.error("Invalid model selection. Please re-select a model.")
+            else:
+                _apply_model_patch(base_config, id_opts[model_idx])
 
         if stub_clicked:
-            patched_agents = [
-                a.model_copy(update={"model_name": None}) for a in base_config.agents
-            ]
-            patched = base_config.model_copy(update={"agents": patched_agents})
-            if _validate_config(patched):
-                base_key = (
-                    st.session_state.get("chat_yaml_path", "config")
-                    .split(":model=")[0]
-                    .split(":stub")[0]
-                )
-                _initialize_executor(patched, f"{base_key}:stub")
+            _apply_model_patch(base_config, None)
 
     st.markdown("---")
 

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -200,6 +200,13 @@ def _initialize_executor(config: MASConfig, cache_key: str) -> None:
 
 def _load_config(yaml_path: Path) -> None:
     """Load a YAML config and initialize the executor when the path changes."""
+    # If the current executor was already initialized from this YAML (possibly
+    # with a model-picker suffix applied by _apply_model_patch), skip the reload
+    # to avoid overwriting the patched executor on each Streamlit rerun.
+    current_key = st.session_state.get("chat_yaml_path", "")
+    if current_key.startswith(str(yaml_path)) and "chat_config" in st.session_state:
+        return
+
     try:
         config = load_mas_from_yaml(yaml_path)
     except Exception as exc:  # pylint: disable=broad-exception-caught
@@ -218,12 +225,19 @@ def _load_config(yaml_path: Path) -> None:
 
 def _load_uploaded_config(name: str, config: MASConfig) -> None:
     """Initialize the executor from an already-parsed uploaded MASConfig."""
+    # Same guard as _load_config: skip if the current executor is already based
+    # on this uploaded config (possibly with a model-picker suffix).
+    current_key = st.session_state.get("chat_yaml_path", "")
+    base_key = f"uploaded:{name}"
+    if current_key.startswith(base_key) and "chat_config" in st.session_state:
+        return
+
     if not _validate_config(config):
         for key in ("chat_config", "chat_yaml_path", "chat_executor"):
             st.session_state.pop(key, None)
         return
     st.session_state.chat_config_base = config
-    _initialize_executor(config, f"uploaded:{name}")
+    _initialize_executor(config, base_key)
 
 
 # ---------------------------------------------------------------------------

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -618,9 +618,9 @@ def _render_agent_output(node_name: str, state_update: Dict[str, Any]) -> None:
 
 def _render_stored_turn(turn: Dict[str, Any]) -> None:
     """Re-render a previously completed turn from chat_history."""
-    with st.chat_message("👤"):
+    with st.chat_message("user", avatar="👤"):
         st.markdown(turn["content"])
-    with st.chat_message("🤖"):
+    with st.chat_message("assistant", avatar="🤖"):
         if "error" in turn:
             st.error(f"Execution failed: {turn['error']}")
         agent_trace = turn.get("agent_trace", [])
@@ -660,11 +660,11 @@ def _run_turn(user_input: str) -> None:
         "agent_trace": [],
     }
 
-    with st.chat_message("👤"):
+    with st.chat_message("user", avatar="👤"):
         st.markdown(user_input)
 
     agent_trace: List[Dict[str, Any]] = []
-    with st.chat_message("🤖"):
+    with st.chat_message("assistant", avatar="🤖"):
         with st.status("Running MAS...", expanded=True) as status:
             try:
                 for node_name, state_update in executor.run_streaming(

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -89,6 +89,125 @@ def _apply_model_patch(base_config: MASConfig, model_id: Optional[str]) -> None:
     _initialize_executor(patched, cache_key)
 
 
+def _active_messages() -> List[Dict]:
+    """Return the messages list for the active thread.
+
+    Returns a direct reference to the list stored in ``chat_threads`` so that
+    in-place ``append`` calls update session state correctly.  Returns an empty
+    list when no active thread exists.
+    """
+    thread_id = st.session_state.get("chat_thread_id")
+    threads = st.session_state.get("chat_threads", {})
+    if thread_id and thread_id in threads:
+        return threads[thread_id]["messages"]
+    return []
+
+
+def _new_thread(mas_id: str) -> str:
+    """Create a new thread, set it active, and return the new thread ID."""
+    now = datetime.now(timezone.utc)
+    thread_id = str(uuid.uuid4())
+    threads = st.session_state.setdefault("chat_threads", {})
+    threads[thread_id] = {
+        "name": f"{mas_id} \u2013 {now.strftime('%H:%M:%S')}",
+        "messages": [],
+        "mas_id": mas_id,
+        "created_at": now.isoformat(),
+    }
+    st.session_state.chat_thread_id = thread_id
+    return thread_id
+
+
+def _ensure_active_thread(mas_id: str) -> None:
+    """Create a thread if no active thread exists — called before first message send."""
+    thread_id = st.session_state.get("chat_thread_id")
+    if not thread_id or thread_id not in st.session_state.get("chat_threads", {}):
+        _new_thread(mas_id)
+
+
+def _delete_thread(thread_id: str) -> None:
+    """Remove a thread; auto-switch to most recent remaining thread if it was active."""
+    threads = st.session_state.get("chat_threads", {})
+    threads.pop(thread_id, None)
+    if st.session_state.get("chat_thread_id") == thread_id:
+        if threads:
+            newest_id = max(threads, key=lambda t: threads[t]["created_at"])
+            st.session_state.chat_thread_id = newest_id
+        else:
+            st.session_state.pop("chat_thread_id", None)
+
+
+def _render_thread_list() -> None:
+    """Render the in-sidebar thread list with filter, rename, and delete controls."""
+    threads: Dict[str, Any] = st.session_state.get("chat_threads", {})
+    if not threads:
+        return
+
+    st.markdown("---")
+    st.markdown("**Conversations**")
+    st.caption("In-session only — threads are lost on page reload.")
+
+    filter_text: str = st.text_input(
+        "Filter conversations",
+        key="chat_thread_filter",
+        placeholder="Search…",
+        label_visibility="collapsed",
+    )
+
+    active_id: Optional[str] = st.session_state.get("chat_thread_id")
+    editing_id: Optional[str] = st.session_state.get("chat_editing_thread")
+
+    sorted_threads = sorted(
+        threads.items(), key=lambda x: x[1]["created_at"], reverse=True
+    )
+    if filter_text:
+        sorted_threads = [
+            (tid, t)
+            for tid, t in sorted_threads
+            if filter_text.lower() in t["name"].lower()
+        ]
+
+    for tid, thread in sorted_threads:
+        is_active = tid == active_id
+
+        if editing_id == tid:
+            c1, c2 = st.columns([4, 1])
+            with c1:
+                new_name = st.text_input(
+                    "Rename thread",
+                    value=thread["name"],
+                    key=f"chat_rename_input_{tid}",
+                    label_visibility="collapsed",
+                )
+            with c2:
+                if st.button("✓", key=f"chat_rename_confirm_{tid}", help="Save name"):
+                    threads[tid]["name"] = new_name
+                    st.session_state.pop("chat_editing_thread", None)
+                    st.rerun()
+        else:
+            timestamp = thread["created_at"][11:16]
+            c1, c2, c3 = st.columns([5, 1, 1])
+            with c1:
+                btn_type = "primary" if is_active else "secondary"
+                if st.button(
+                    f"{thread['name']}  {timestamp}",
+                    key=f"chat_select_thread_{tid}",
+                    use_container_width=True,
+                    type=btn_type,
+                ):
+                    if not is_active:
+                        st.session_state.chat_thread_id = tid
+                        st.rerun()
+            with c2:
+                if st.button("✏️", key=f"chat_edit_thread_{tid}", help="Rename"):
+                    st.session_state.chat_editing_thread = tid
+                    st.rerun()
+            with c3:
+                if st.button("🗑️", key=f"chat_delete_thread_{tid}", help="Delete"):
+                    _delete_thread(tid)
+                    st.rerun()
+
+
 @st.cache_data
 def _build_chat_model_options() -> tuple[list[str], list[str]]:
     """Return ``(display_list, model_id_list)`` from LLM_MODELS, grouped by provider.
@@ -351,6 +470,8 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
             "chat_executor",
             "chat_load_error",
             "chat_config_base",
+            # chat_threads and chat_thread_id are intentionally kept — threads
+            # persist across config switches so the list remains visible.
         ):
             st.session_state.pop(key, None)
         return
@@ -409,11 +530,10 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     st.markdown("---")
 
     if st.button("New Conversation", use_container_width=True):
-        st.session_state.chat_history = []
-        st.session_state.chat_thread_id = str(uuid.uuid4())
+        _new_thread(config.mas_id)
         st.rerun()
 
-    chat_history = st.session_state.get("chat_history", [])
+    chat_history = _active_messages()
     thread_id = st.session_state.get("chat_thread_id", "")
     if chat_history:
         export = {
@@ -429,6 +549,8 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
             mime="application/json",
             use_container_width=True,
         )
+
+    _render_thread_list()
 
 
 # ---------------------------------------------------------------------------
@@ -527,14 +649,14 @@ def _run_turn(user_input: str) -> None:
         st.error("No executor available. Select a configuration first.")
         return
 
-    if "chat_thread_id" not in st.session_state:
-        st.session_state.chat_thread_id = str(uuid.uuid4())
+    config: Optional[MASConfig] = st.session_state.get("chat_config")
+    _ensure_active_thread(config.mas_id if config else "unknown")
 
     turn: Dict[str, Any] = {
         "role": "user",
         "content": user_input,
         "timestamp": datetime.now(timezone.utc).isoformat(),
-        "turn_index": len(st.session_state.get("chat_history", [])),
+        "turn_index": len(_active_messages()),
         "agent_trace": [],
     }
 
@@ -570,10 +692,7 @@ def _run_turn(user_input: str) -> None:
                 turn["error"] = str(exc)
 
     turn["agent_trace"] = agent_trace
-
-    if "chat_history" not in st.session_state:
-        st.session_state.chat_history = []
-    st.session_state.chat_history.append(turn)
+    _active_messages().append(turn)
 
 
 # ---------------------------------------------------------------------------
@@ -596,7 +715,7 @@ def _render_chat_area() -> None:
     if config.description:
         st.caption(config.description)
 
-    for turn in st.session_state.get("chat_history", []):
+    for turn in _active_messages():
         _render_stored_turn(turn)
 
     user_input = st.chat_input("Send a message to the MAS...")

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -93,14 +93,20 @@ def _active_messages() -> List[Dict]:
     """Return the messages list for the active thread.
 
     Returns a direct reference to the list stored in ``chat_threads`` so that
-    in-place ``append`` calls update session state correctly.  Returns an empty
-    list when no active thread exists.
+    in-place ``append`` calls update session state correctly.
+
+    Raises:
+        RuntimeError: If no active thread exists. Callers must ensure a thread
+            is active (e.g. via ``_ensure_active_thread``) before appending.
     """
     thread_id = st.session_state.get("chat_thread_id")
     threads = st.session_state.get("chat_threads", {})
     if thread_id and thread_id in threads:
         return threads[thread_id]["messages"]
-    return []
+    raise RuntimeError(
+        "_active_messages() called with no active thread. "
+        "Call _ensure_active_thread() before appending."
+    )
 
 
 def _new_thread(mas_id: str) -> str:
@@ -112,7 +118,7 @@ def _new_thread(mas_id: str) -> str:
         "name": f"{mas_id} \u2013 {now.strftime('%H:%M:%S')}",
         "messages": [],
         "mas_id": mas_id,
-        "created_at": now.isoformat(),
+        "created_at": now.timestamp(),
     }
     st.session_state.chat_thread_id = thread_id
     return thread_id
@@ -185,12 +191,11 @@ def _render_thread_list() -> None:
                     st.session_state.pop("chat_editing_thread", None)
                     st.rerun()
         else:
-            timestamp = thread["created_at"][11:16]
             c1, c2, c3 = st.columns([5, 1, 1])
             with c1:
                 btn_type = "primary" if is_active else "secondary"
                 if st.button(
-                    f"{thread['name']}  {timestamp}",
+                    thread["name"],
                     key=f"chat_select_thread_{tid}",
                     use_container_width=True,
                     type=btn_type,
@@ -307,7 +312,6 @@ def _initialize_executor(config: MASConfig, cache_key: str) -> None:
         st.session_state.chat_config = config
         st.session_state.chat_yaml_path = cache_key
         st.session_state.chat_executor = executor
-        st.session_state.chat_history = []
         st.session_state.pop("chat_thread_id", None)
         st.session_state.pop("chat_load_error", None)
     except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -123,7 +123,9 @@ def _active_messages_or_empty() -> List[Dict]:
 def _new_thread(mas_id: str) -> str:
     """Create a new thread, set it active, and return the new thread ID."""
     now = datetime.now(timezone.utc)
-    display_time = datetime.now().strftime("%H:%M:%S")  # local time for readability
+    display_time = now.astimezone().strftime(
+        "%H:%M:%S"
+    )  # convert to local time for readability
     thread_id = str(uuid.uuid4())
     threads = st.session_state.setdefault("chat_threads", {})
     threads[thread_id] = {
@@ -331,8 +333,11 @@ def _initialize_executor(config: MASConfig, cache_key: str) -> None:
         st.session_state.chat_config = config
         st.session_state.chat_yaml_path = cache_key
         st.session_state.chat_executor = executor
-        # Clear active pointer only; chat_threads persists across config switches
-        # so the user can re-activate a previous thread by clicking it in the list.
+        # Clear active pointer only; chat_threads persists across config switches so
+        # the user can re-activate a previous thread by clicking it in the list.
+        # Render paths use _active_messages_or_empty() which safely returns [] when
+        # no thread is active; _active_messages() (write path) requires a prior
+        # _ensure_active_thread() call and will raise if this pointer is absent.
         st.session_state.pop("chat_thread_id", None)
         st.session_state.pop("chat_load_error", None)
     except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -463,7 +463,9 @@ def _build_markdown_export(
         ]
         for agent_out in turn.get("agent_trace", []):
             content = _extract_content(agent_out.get("output", {}))
-            lines.append(f"> **{agent_out['agent_id']}:** {content}")
+            # Prefix every line so multi-line content is fully blockquoted.
+            content_lines = content.replace("\n", "\n> ")
+            lines.append(f"> **{agent_out['agent_id']}:** {content_lines}")
         lines.append("")
     return "\n".join(lines)
 

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -123,10 +123,11 @@ def _active_messages_or_empty() -> List[Dict]:
 def _new_thread(mas_id: str) -> str:
     """Create a new thread, set it active, and return the new thread ID."""
     now = datetime.now(timezone.utc)
+    display_time = datetime.now().strftime("%H:%M:%S")  # local time for readability
     thread_id = str(uuid.uuid4())
     threads = st.session_state.setdefault("chat_threads", {})
     threads[thread_id] = {
-        "name": f"{mas_id} \u2013 {now.strftime('%H:%M:%S')}",
+        "name": f"{mas_id} \u2013 {display_time}",
         "messages": [],
         "mas_id": mas_id,
         "created_at": now.timestamp(),
@@ -146,6 +147,8 @@ def _delete_thread(thread_id: str) -> None:
     """Remove a thread; auto-switch to most recent remaining thread if it was active."""
     threads = st.session_state.get("chat_threads", {})
     threads.pop(thread_id, None)
+    if st.session_state.get("chat_editing_thread") == thread_id:
+        st.session_state.pop("chat_editing_thread", None)
     if st.session_state.get("chat_thread_id") == thread_id:
         if threads:
             newest_id = max(threads, key=lambda t: threads[t]["created_at"])
@@ -328,6 +331,8 @@ def _initialize_executor(config: MASConfig, cache_key: str) -> None:
         st.session_state.chat_config = config
         st.session_state.chat_yaml_path = cache_key
         st.session_state.chat_executor = executor
+        # Clear active pointer only; chat_threads persists across config switches
+        # so the user can re-activate a previous thread by clicking it in the list.
         st.session_state.pop("chat_thread_id", None)
         st.session_state.pop("chat_load_error", None)
     except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -204,7 +204,10 @@ def _load_config(yaml_path: Path) -> None:
     # with a model-picker suffix applied by _apply_model_patch), skip the reload
     # to avoid overwriting the patched executor on each Streamlit rerun.
     current_key = st.session_state.get("chat_yaml_path", "")
-    if current_key.startswith(str(yaml_path)) and "chat_config" in st.session_state:
+    base = str(yaml_path)
+    if (
+        current_key == base or current_key.startswith(f"{base}:")
+    ) and "chat_config" in st.session_state:
         return
 
     try:
@@ -229,7 +232,9 @@ def _load_uploaded_config(name: str, config: MASConfig) -> None:
     # on this uploaded config (possibly with a model-picker suffix).
     current_key = st.session_state.get("chat_yaml_path", "")
     base_key = f"uploaded:{name}"
-    if current_key.startswith(base_key) and "chat_config" in st.session_state:
+    if (
+        current_key == base_key or current_key.startswith(f"{base_key}:")
+    ) and "chat_config" in st.session_state:
         return
 
     if not _validate_config(config):

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -496,9 +496,9 @@ def _render_agent_output(node_name: str, state_update: Dict[str, Any]) -> None:
 
 def _render_stored_turn(turn: Dict[str, Any]) -> None:
     """Re-render a previously completed turn from chat_history."""
-    with st.chat_message("user"):
+    with st.chat_message("👤"):
         st.markdown(turn["content"])
-    with st.chat_message("assistant"):
+    with st.chat_message("🤖"):
         if "error" in turn:
             st.error(f"Execution failed: {turn['error']}")
         agent_trace = turn.get("agent_trace", [])
@@ -538,11 +538,11 @@ def _run_turn(user_input: str) -> None:
         "agent_trace": [],
     }
 
-    with st.chat_message("user"):
+    with st.chat_message("👤"):
         st.markdown(user_input)
 
     agent_trace: List[Dict[str, Any]] = []
-    with st.chat_message("assistant"):
+    with st.chat_message("🤖"):
         with st.status("Running MAS...", expanded=True) as status:
             try:
                 for node_name, state_update in executor.run_streaming(

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -109,6 +109,17 @@ def _active_messages() -> List[Dict]:
     )
 
 
+def _active_messages_or_empty() -> List[Dict]:
+    """Return the active thread's messages or an empty list when no thread exists.
+
+    Safe for read-only call sites (iteration, length checks) where no active
+    thread is a valid state (e.g. before the first message is sent).
+    """
+    thread_id = st.session_state.get("chat_thread_id")
+    threads = st.session_state.get("chat_threads", {})
+    return threads.get(thread_id, {}).get("messages", []) if thread_id else []
+
+
 def _new_thread(mas_id: str) -> str:
     """Create a new thread, set it active, and return the new thread ID."""
     now = datetime.now(timezone.utc)
@@ -177,7 +188,7 @@ def _render_thread_list() -> None:
         is_active = tid == active_id
 
         if editing_id == tid:
-            c1, c2 = st.columns([4, 1])
+            c1, c2, c3 = st.columns([4, 1, 1])
             with c1:
                 new_name = st.text_input(
                     "Rename thread",
@@ -190,6 +201,10 @@ def _render_thread_list() -> None:
                     threads[tid]["name"] = new_name
                     st.session_state.pop("chat_editing_thread", None)
                     st.rerun()
+            with c3:
+                if st.button("✕", key=f"chat_rename_cancel_{tid}", help="Cancel"):
+                    st.session_state.pop("chat_editing_thread", None)
+                    st.rerun()
         else:
             c1, c2, c3 = st.columns([5, 1, 1])
             with c1:
@@ -200,6 +215,7 @@ def _render_thread_list() -> None:
                     use_container_width=True,
                     type=btn_type,
                 ):
+                    st.session_state.pop("chat_editing_thread", None)
                     if not is_active:
                         st.session_state.chat_thread_id = tid
                         st.rerun()
@@ -537,7 +553,7 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
         _new_thread(config.mas_id)
         st.rerun()
 
-    chat_history = _active_messages()
+    chat_history = _active_messages_or_empty()
     thread_id = st.session_state.get("chat_thread_id", "")
     if chat_history:
         export = {
@@ -719,7 +735,7 @@ def _render_chat_area() -> None:
     if config.description:
         st.caption(config.description)
 
-    for turn in _active_messages():
+    for turn in _active_messages_or_empty():
         _render_stored_turn(turn)
 
     user_input = st.chat_input("Send a message to the MAS...")

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -410,6 +410,54 @@ def _render_sidebar() -> None:
     render_sidebar_content()
 
 
+def _extract_content(output: Dict[str, Any]) -> str:
+    """Extract a readable content string from a serialized agent output dict.
+
+    Mirrors the display priority of ``_render_agent_panel`` but returns a plain
+    string suitable for text-based exports.
+    """
+    agent_outputs: Dict[str, Any] = output.get("agent_outputs", {})
+    for inner in agent_outputs.values():
+        if inner.get("status") == "stub":
+            return inner.get("message", str(inner))
+        parts = [f"{k}: {v}" for k, v in inner.items() if k != "agent_id"]
+        if parts:
+            return " | ".join(parts)
+    messages: List[Any] = output.get("messages", [])
+    if messages:
+        last = messages[-1]
+        if isinstance(last, dict):
+            return last.get("content", str(last))
+        return getattr(last, "content", str(last))
+    return str(output)
+
+
+def _build_markdown_export(
+    config: "MASConfig", thread_id: str, chat_history: List[Dict]
+) -> str:
+    """Build a Markdown export string for the active conversation."""
+    lines = [
+        f"# Conversation — {config.mas_id}",
+        f"Thread: {thread_id}",
+        f"Exported: {datetime.now(timezone.utc).isoformat()}",
+        "",
+    ]
+    for i, turn in enumerate(chat_history, 1):
+        lines += [
+            f"## Turn {i}",
+            "",
+            f"**User:** {turn['content']}",
+            "",
+            "**MAS Response:**",
+            "",
+        ]
+        for agent_out in turn.get("agent_trace", []):
+            content = _extract_content(agent_out.get("output", {}))
+            lines.append(f"> **{agent_out['agent_id']}:** {content}")
+        lines.append("")
+    return "\n".join(lines)
+
+
 def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     """Render the chat sidebar controls — config selector, upload, and buttons.
 
@@ -566,19 +614,32 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     chat_history = _active_messages_or_empty()
     thread_id = st.session_state.get("chat_thread_id", "")
     if chat_history:
-        export = {
+        export_json = {
             "mas_id": config.mas_id,
             "thread_id": thread_id,
             "exported_at": datetime.now(timezone.utc).isoformat(),
-            "turns": chat_history,
+            "turns": [
+                {**turn, "agent_trace": turn.get("agent_trace", [])}
+                for turn in chat_history
+            ],
         }
-        st.download_button(
-            "Export Conversation",
-            data=json.dumps(export, indent=2),
-            file_name=f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}.json",
-            mime="application/json",
-            use_container_width=True,
-        )
+        col_json, col_md = st.columns(2)
+        with col_json:
+            st.download_button(
+                "Export JSON",
+                data=json.dumps(export_json, indent=2),
+                file_name=f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}.json",
+                mime="application/json",
+                use_container_width=True,
+            )
+        with col_md:
+            st.download_button(
+                "Export Markdown",
+                data=_build_markdown_export(config, thread_id, chat_history),
+                file_name=f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}.md",
+                mime="text/markdown",
+                use_container_width=True,
+            )
 
     _render_thread_list()
 


### PR DESCRIPTION
### This PR introduces the following changes

* Adds a **Model Picker** to the Chat sidebar — a searchable selectbox populated from `LLM_MODELS` (74 models across all configured providers) that lets users switch a loaded MAS config to any available LLM without editing YAML
* Adds an **"Apply to all"** button that patches every agent in the loaded config with the selected model in-memory, re-runs structural validation, and reinitialises the executor — conversation history is cleared on reinit
* Adds a **"Stub mode"** button that clears `model_name` from all agents, reverting to stub execution (no LLM calls), with the same validate → reinit flow
* Introduces `chat_config_base` session state key to preserve the original YAML-loaded config across picker operations — "Apply to all" and "Stub mode" always patch from the clean base so the operations are idempotent and reversible
* Uses a cache key suffix convention (`":model={model_id}"` / `":stub"`) to force executor reinit on model changes while avoiding redundant reinits when the same model is applied twice
* Adds `_build_chat_model_options()` — a `@st.cache_data` helper that lazy-imports `LLM_MODELS` and returns `(display_list, model_id_list)`; deliberately independent of `graph_viewer.py` to avoid pulling in the `streamlit-flow` dependency when `chat_app.py` is used standalone
* Stores `chat_config_base` in both `_load_config()` (built-in YAML selector) and `_load_uploaded_config()` (file uploader + Send-to-Chat from Visualizer) so the picker works regardless of how the config was loaded

### Steps to Review

1. Checkout the `110-task-12-model-picker-stub---live-toggle` branch on your local machine
2. Start the development container: `./scripts/development/start-container`
3. In a second terminal, attach to the container: `./scripts/development/attach-container`
4. Inside the container, install the new dependency: `/app/bili-core/venv/bin/pip install streamlit-flow-component --ignore-installed blinker`
5. Ensure langgraph is up to date: `/app/bili-core/venv/bin/pip install --upgrade --force-reinstall "langgraph~=1.0.2"`
6. Launch the AETHER app: `streamlit run bili/aether/ui/app.py`
7. Load **Simple Chain** from the Visualizer, click **"Send to Chat →"** — verify the Chat page opens and the stub mode indicator (`⚙️ Stub mode — no LLM calls will be made.`) appears in the sidebar
8. In the Chat sidebar, select any model from the **Model Settings** selectbox (e.g. `[OpenAI] GPT-4o`) and click **"Apply to all"** — verify the spinner appears, stub mode indicator disappears, and conversation history is cleared
9. Send a message — verify a real LLM call is attempted (or an appropriate API key error is shown, not a stub response)
10. Click **"Stub mode"** — verify the stub mode indicator reappears and history is cleared again
11. Click **"Apply to all"** once more with the same model selected — verify the spinner does **not** appear (cache hit, no reinit)
12. Switch to a different config in the selectbox — verify the model picker state resets correctly (new base config loaded, cache key changes)
13. Upload a deliberately malformed YAML — verify validation errors appear and the executor is **not** reinitialised
14. Switch to the Chat page directly (without using Send-to-Chat) and load a config via the built-in selector — verify the model picker works the same way
