### PR TITLE
Task 14 Implement md export option

### DIFF
--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -193,7 +193,7 @@ def _render_thread_list() -> None:
         is_active = tid == active_id
 
         if editing_id == tid:
-            c1, c2, c3 = st.columns([4, 1, 1])
+            c1, c2, c3 = st.columns([4, 1, 1], vertical_alignment="center")
             with c1:
                 new_name = st.text_input(
                     "Rename thread",
@@ -211,7 +211,7 @@ def _render_thread_list() -> None:
                     st.session_state.pop("chat_editing_thread", None)
                     st.rerun()
         else:
-            c1, c2, c3 = st.columns([5, 1, 1])
+            c1, c2, c3 = st.columns([5, 1, 1], vertical_alignment="center")
             with c1:
                 btn_type = "primary" if is_active else "secondary"
                 if st.button(
@@ -414,15 +414,22 @@ def _extract_content(output: Dict[str, Any]) -> str:
     """Extract a readable content string from a serialized agent output dict.
 
     Mirrors the display priority of ``_render_agent_panel`` but returns a plain
-    string suitable for text-based exports.
+    string suitable for text-based exports. Unlike the render panel (which
+    receives a single agent_id), this function collects *all* agent_outputs
+    entries and joins them so no entry is silently dropped.
     """
     agent_outputs: Dict[str, Any] = output.get("agent_outputs", {})
-    for inner in agent_outputs.values():
-        if inner.get("status") == "stub":
-            return inner.get("message", str(inner))
-        parts = [f"{k}: {v}" for k, v in inner.items() if k != "agent_id"]
-        if parts:
-            return " | ".join(parts)
+    if agent_outputs:
+        collected: List[str] = []
+        for inner in agent_outputs.values():
+            if inner.get("status") == "stub":
+                collected.append(inner.get("message", str(inner)))
+            else:
+                kv_parts = [f"{k}: {v}" for k, v in inner.items() if k != "agent_id"]
+                if kv_parts:
+                    collected.append(" | ".join(kv_parts))
+        if collected:
+            return "\n".join(collected)
     messages: List[Any] = output.get("messages", [])
     if messages:
         last = messages[-1]
@@ -433,7 +440,7 @@ def _extract_content(output: Dict[str, Any]) -> str:
 
 
 def _build_markdown_export(
-    config: "MASConfig", thread_id: str, chat_history: List[Dict]
+    config: MASConfig, thread_id: str, chat_history: List[Dict]
 ) -> str:
     """Build a Markdown export string for the active conversation."""
     lines = [
@@ -446,6 +453,9 @@ def _build_markdown_export(
         lines += [
             f"## Turn {i}",
             "",
+            # turn['content'] is inserted verbatim; any markdown the user typed
+            # (headings, links, etc.) will render as-is in the exported file.
+            # This is acceptable since users are exporting their own conversations.
             f"**User:** {turn['content']}",
             "",
             "**MAS Response:**",
@@ -614,11 +624,14 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     chat_history = _active_messages_or_empty()
     thread_id = st.session_state.get("chat_thread_id", "")
     if chat_history:
+        base_name = f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}"
         export_json = {
             "mas_id": config.mas_id,
             "thread_id": thread_id,
             "exported_at": datetime.now(timezone.utc).isoformat(),
             "turns": [
+                # Explicitly include agent_trace so the key is always present,
+                # even for turns stored before this field was introduced.
                 {**turn, "agent_trace": turn.get("agent_trace", [])}
                 for turn in chat_history
             ],
@@ -628,7 +641,7 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
             st.download_button(
                 "Export JSON",
                 data=json.dumps(export_json, indent=2),
-                file_name=f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}.json",
+                file_name=f"{base_name}.json",
                 mime="application/json",
                 use_container_width=True,
             )
@@ -636,7 +649,7 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
             st.download_button(
                 "Export Markdown",
                 data=_build_markdown_export(config, thread_id, chat_history),
-                file_name=f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}.md",
+                file_name=f"{base_name}.md",
                 mime="text/markdown",
                 use_container_width=True,
             )

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -463,7 +463,9 @@ def _build_markdown_export(
         ]
         for agent_out in turn.get("agent_trace", []):
             content = _extract_content(agent_out.get("output", {}))
-            lines.append(f"> **{agent_out['agent_id']}:** {content}")
+            # Prefix every line so multi-line content is fully blockquoted.
+            content_lines = content.replace("\n", "\n> ")
+            lines.append(f"> **{agent_out['agent_id']}:** {content_lines}")
         lines.append("")
     return "\n".join(lines)
 

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -410,6 +410,54 @@ def _render_sidebar() -> None:
     render_sidebar_content()
 
 
+def _extract_content(output: Dict[str, Any]) -> str:
+    """Extract a readable content string from a serialized agent output dict.
+
+    Mirrors the display priority of ``_render_agent_panel`` but returns a plain
+    string suitable for text-based exports.
+    """
+    agent_outputs: Dict[str, Any] = output.get("agent_outputs", {})
+    for inner in agent_outputs.values():
+        if inner.get("status") == "stub":
+            return inner.get("message", str(inner))
+        parts = [f"{k}: {v}" for k, v in inner.items() if k != "agent_id"]
+        if parts:
+            return " | ".join(parts)
+    messages: List[Any] = output.get("messages", [])
+    if messages:
+        last = messages[-1]
+        if isinstance(last, dict):
+            return last.get("content", str(last))
+        return getattr(last, "content", str(last))
+    return str(output)
+
+
+def _build_markdown_export(
+    config: "MASConfig", thread_id: str, chat_history: List[Dict]
+) -> str:
+    """Build a Markdown export string for the active conversation."""
+    lines = [
+        f"# Conversation — {config.mas_id}",
+        f"Thread: {thread_id}",
+        f"Exported: {datetime.now(timezone.utc).isoformat()}",
+        "",
+    ]
+    for i, turn in enumerate(chat_history, 1):
+        lines += [
+            f"## Turn {i}",
+            "",
+            f"**User:** {turn['content']}",
+            "",
+            "**MAS Response:**",
+            "",
+        ]
+        for agent_out in turn.get("agent_trace", []):
+            content = _extract_content(agent_out.get("output", {}))
+            lines.append(f"> **{agent_out['agent_id']}:** {content}")
+        lines.append("")
+    return "\n".join(lines)
+
+
 def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     """Render the chat sidebar controls — config selector, upload, and buttons.
 
@@ -566,19 +614,32 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
     chat_history = _active_messages_or_empty()
     thread_id = st.session_state.get("chat_thread_id", "")
     if chat_history:
-        export = {
+        export_json = {
             "mas_id": config.mas_id,
             "thread_id": thread_id,
             "exported_at": datetime.now(timezone.utc).isoformat(),
-            "turns": chat_history,
+            "turns": [
+                {**turn, "agent_trace": turn.get("agent_trace", [])}
+                for turn in chat_history
+            ],
         }
-        st.download_button(
-            "Export Conversation",
-            data=json.dumps(export, indent=2),
-            file_name=f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}.json",
-            mime="application/json",
-            use_container_width=True,
-        )
+        col_json, col_md = st.columns(2)
+        with col_json:
+            st.download_button(
+                "Export JSON",
+                data=json.dumps(export_json, indent=2),
+                file_name=f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}.json",
+                mime="application/json",
+                use_container_width=True,
+            )
+        with col_md:
+            st.download_button(
+                "Export Markdown",
+                data=_build_markdown_export(config, thread_id, chat_history),
+                file_name=f"aether_chat_{config.mas_id}_{thread_id[:8] or 'unknown'}.md",
+                mime="text/markdown",
+                use_container_width=True,
+            )
 
     _render_thread_list()
 


### PR DESCRIPTION
### This PR introduces the following changes

* **Task 14 — Markdown Conversation Export** (`chat_app.py`): Added an "Export Markdown" download button alongside the existing JSON export in the Chat sidebar. Both buttons appear side-by-side in a two-column layout and are only visible when the active thread has at least one turn.

* **`_extract_content(output)` helper** (`chat_app.py`): New pure function that extracts a human-readable string from a serialized agent output dict. Mirrors the display priority of `_render_agent_panel` (structured `agent_outputs` entries → last message content → raw fallback) but returns a plain string for use in text-based exports.

* **`_build_markdown_export(config, thread_id, chat_history)` function** (`chat_app.py`): Builds the full Markdown export document. Structure: `# Conversation — {mas_id}` header with thread ID and export timestamp, followed by `## Turn N` sections each containing the user message and blockquoted agent outputs (`> **agent_id:** content`).

* **JSON export hardened** (`chat_app.py`): The JSON export now explicitly includes `"agent_trace": turn.get("agent_trace", [])` on each turn dict, ensuring the key is always present even for turns that completed before the `agent_trace` field was introduced. Button label updated from "Export Conversation" to "Export JSON" for clarity.

### Steps to Review

1. Checkout the `113-task-14-markdown-conversation-export` branch on your local machine.
2. Start the app with `PYTHONPATH=/app/bili-core /app/bili-core/venv/bin/streamlit run bili/aether/ui/app.py --server.port 8502`.
3. Load any stub config from the sidebar dropdown and wait for the executor to initialise.
4. **Before sending a message**: confirm neither "Export JSON" nor "Export Markdown" appears in the sidebar.
5. Send a message. Confirm both buttons appear side-by-side below the "New Conversation" button.
6. Click **Export JSON** → open the downloaded file → confirm the `agent_trace` key is present on each turn and the overall structure matches the documented schema.
7. Click **Export Markdown** → open the downloaded `.md` file → confirm:
   - The header contains the `mas_id`, thread ID, and an export timestamp.
   - Each turn has a `## Turn N` heading.
   - The user message appears as `**User:** ...`.
   - Each agent output appears as a blockquote `> **agent_id:** content`.
8. Send a second message and re-export — confirm both turns appear in the export.
9. Click "New Conversation", send a message in the new thread, then switch back to the old thread and export — confirm only that thread's turns are exported (not the new thread's).
