### PR TITLE
Task 22: gui polish

### DIFF
--- a/bili/aether/compiler/graph_builder.py
+++ b/bili/aether/compiler/graph_builder.py
@@ -305,6 +305,15 @@ class GraphBuilder:  # pylint: disable=too-few-public-methods,too-many-instance-
             _mas_obj = self._config.objective
 
             def _inject_mas_objective(state: dict) -> dict:
+                # Idempotent: skip if this objective is already the first message,
+                # which happens on multi-turn runs with checkpointing enabled.
+                msgs = state.get("messages", [])
+                if (
+                    msgs
+                    and isinstance(msgs[0], SystemMessage)
+                    and msgs[0].content == _mas_obj
+                ):
+                    return {}
                 return {"messages": [SystemMessage(content=_mas_obj)]}
 
             self._graph.add_node("__mas_objective__", _inject_mas_objective)

--- a/bili/aether/compiler/graph_builder.py
+++ b/bili/aether/compiler/graph_builder.py
@@ -293,6 +293,24 @@ class GraphBuilder:  # pylint: disable=too-few-public-methods,too-many-instance-
         for agent_id, node_fn in self._agent_nodes.items():
             self._graph.add_node(agent_id, node_fn)
 
+        # 4b. If a MAS-level objective is configured, wire a lightweight entry
+        # node that prepends it as a SystemMessage before the first agent runs.
+        # Replacing self._start_node causes all _build_* workflow methods to
+        # route through this node transparently.
+        if self._config.objective:
+            from langchain_core.messages import (  # pylint: disable=import-outside-toplevel,import-error
+                SystemMessage,
+            )
+
+            _mas_obj = self._config.objective
+
+            def _inject_mas_objective(state: dict) -> dict:
+                return {"messages": [SystemMessage(content=_mas_obj)]}
+
+            self._graph.add_node("__mas_objective__", _inject_mas_objective)
+            self._graph.add_edge(self._start_node, "__mas_objective__")
+            self._start_node = "__mas_objective__"
+
         # 5. Build workflow-specific edges
         builder = self._get_workflow_builder()
         builder()

--- a/bili/aether/config/examples/demo_code_review.yaml
+++ b/bili/aether/config/examples/demo_code_review.yaml
@@ -49,6 +49,7 @@ agents:
 
   - agent_id: code_reviewer
     role: security_engineer
+    system_prompt: "You are a senior security engineer specialising in code review and OWASP Top 10 vulnerability assessment."
     objective: >
       Perform a thorough code review covering security vulnerabilities
       (including OWASP Top 10), performance concerns, and style issues.

--- a/bili/aether/schema/mas_config.py
+++ b/bili/aether/schema/mas_config.py
@@ -126,6 +126,15 @@ class MASConfig(BaseModel):
         "", description="Detailed MAS description", max_length=2000
     )
 
+    objective: Optional[str] = Field(
+        None,
+        description=(
+            "MAS-level objective prepended as a SystemMessage at graph entry. "
+            "Applies to the entire run before any agent executes."
+        ),
+        max_length=2000,
+    )
+
     version: str = Field("1.0.0", description="MAS configuration version")
 
     # =========================================================================

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -1182,6 +1182,7 @@ def _render_stored_turn(turn: Dict[str, Any]) -> None:
     cfg: Optional[MASConfig] = st.session_state.get("chat_config")
     role_map = _build_role_map(cfg) if cfg else {}
     with st.chat_message("user", avatar="👤"):
+        st.caption("Input →")
         st.markdown(turn["content"])
     with st.chat_message("assistant", avatar="🤖"):
         if "error" in turn:
@@ -1356,6 +1357,7 @@ def _run_turn(user_input: str) -> None:
     }
 
     with st.chat_message("user", avatar="👤"):
+        st.caption("Input →")
         st.markdown(user_input)
 
     all_nodes = [a.agent_id for a in config.agents]

--- a/bili/aether/ui/components/graph_viewer.py
+++ b/bili/aether/ui/components/graph_viewer.py
@@ -59,7 +59,6 @@ def apply_agent_overrides(config: MASConfig) -> MASConfig:
     return config.model_copy(update={"agents": patched_agents})
 
 
-@st.cache_data
 def _get_tool_names() -> list[str]:
     """Return sorted list of registered tool names."""
     from bili.loaders.tools_loader import (  # pylint: disable=import-outside-toplevel

--- a/bili/aether/ui/components/graph_viewer.py
+++ b/bili/aether/ui/components/graph_viewer.py
@@ -51,8 +51,22 @@ def apply_agent_overrides(config: MASConfig) -> MASConfig:
             patch["objective"] = agent_override["objective"]
         if "temperature" in agent_override:
             patch["temperature"] = agent_override["temperature"]
+        if "max_tokens" in agent_override:
+            patch["max_tokens"] = agent_override["max_tokens"]
+        if "tools" in agent_override:
+            patch["tools"] = agent_override["tools"]
         patched_agents.append(agent.model_copy(update=patch) if patch else agent)
     return config.model_copy(update={"agents": patched_agents})
+
+
+@st.cache_data
+def _get_tool_names() -> list[str]:
+    """Return sorted list of registered tool names."""
+    from bili.loaders.tools_loader import (  # pylint: disable=import-outside-toplevel
+        TOOL_REGISTRY,
+    )
+
+    return sorted(TOOL_REGISTRY.keys())
 
 
 @st.cache_data
@@ -145,9 +159,6 @@ def render_graph_viewer(
         st.session_state[overrides_key] = {}
 
     with props_col:
-        _render_properties_panel(config, selected_id, edges, config.mas_id)
-
-        st.markdown("---")
         patched = apply_agent_overrides(config)
         st.download_button(
             "Download YAML",
@@ -161,6 +172,8 @@ def render_graph_viewer(
             mime="text/yaml",
             use_container_width=True,
         )
+        st.markdown("---")
+        _render_properties_panel(config, selected_id, edges, config.mas_id)
 
 
 def _render_properties_panel(
@@ -282,14 +295,43 @@ def _render_agent_properties(agent: AgentSpec, mas_id: str) -> None:
     )
     bucket["temperature"] = temp_val
 
-    if agent.max_tokens:
-        st.markdown(f"**Max Tokens:** {agent.max_tokens}")
+    st.markdown("**Max Tokens**")
+    max_tokens_val = st.number_input(
+        "max_tokens",
+        min_value=1,
+        max_value=32768,
+        value=int(bucket.get("max_tokens", agent.max_tokens or 1024)),
+        step=256,
+        key=f"max_tokens_{mas_id}_{agent.agent_id}",
+        label_visibility="collapsed",
+        help="Maximum tokens the agent may generate per turn.",
+    )
+    bucket["max_tokens"] = int(max_tokens_val)
+
+    st.markdown("**Tools**")
+    yaml_tools = agent.tools or []
+    if yaml_tools:
+        for tool in yaml_tools:
+            st.markdown(f"- `{tool}`")
+    else:
+        st.caption("None configured in YAML")
+    available_tools = _get_tool_names()
+    if available_tools:
+        current_tools = bucket.get("tools", yaml_tools)
+        selected_tools = st.multiselect(
+            "Override tools",
+            options=available_tools,
+            default=[t for t in current_tools if t in available_tools],
+            key=f"tools_{mas_id}_{agent.agent_id}",
+            help="Override the tool set for this session.",
+        )
+        if selected_tools != yaml_tools:
+            bucket["tools"] = selected_tools
+        else:
+            bucket.pop("tools", None)
 
     if agent.capabilities:
         _render_list_section("Capabilities", agent.capabilities)
-
-    if agent.tools:
-        _render_list_section("Tools", agent.tools)
 
     st.markdown(f"**Output:** {agent.output_format.value}")
 

--- a/bili/aether/ui/components/graph_viewer.py
+++ b/bili/aether/ui/components/graph_viewer.py
@@ -5,8 +5,10 @@ The graph is read-only -- nodes cannot be dragged, connected, or deleted.
 Clicking a node shows its agent properties in a side panel.
 """
 
-# pylint: disable=import-error
 import streamlit as st
+
+# pylint: disable=import-error
+import yaml
 from streamlit_flow import streamlit_flow
 from streamlit_flow.elements import StreamlitFlowEdge, StreamlitFlowNode
 from streamlit_flow.state import StreamlitFlowState
@@ -18,7 +20,39 @@ MODEL_KEEP_SENTINEL = "(keep from YAML)"
 
 
 def _overrides_key(mas_id: str) -> str:
-    return f"model_overrides_{mas_id}"
+    return f"agent_overrides_{mas_id}"
+
+
+def apply_agent_overrides(config: MASConfig) -> MASConfig:
+    """Return *config* with current agent_overrides from session state applied.
+
+    Called inside the ``render_graph_viewer`` fragment (so the Download YAML
+    button always reflects the latest widget values) and re-exported for use
+    by ``page.py``'s Send-to-Chat callback.
+    """
+    overrides: dict = st.session_state.get(_overrides_key(config.mas_id), {})
+    if not overrides:
+        return config
+    _, display_to_model_name, _ = build_model_options()
+    patched_agents = []
+    for agent in config.agents:
+        agent_override = overrides.get(agent.agent_id, {})
+        patch: dict = {}
+        display = agent_override.get("model_name")
+        if (
+            display
+            and display != MODEL_KEEP_SENTINEL
+            and display in display_to_model_name
+        ):
+            patch["model_name"] = display_to_model_name[display]
+        if agent_override.get("system_prompt"):
+            patch["system_prompt"] = agent_override["system_prompt"]
+        if agent_override.get("objective"):
+            patch["objective"] = agent_override["objective"]
+        if "temperature" in agent_override:
+            patch["temperature"] = agent_override["temperature"]
+        patched_agents.append(agent.model_copy(update=patch) if patch else agent)
+    return config.model_copy(update={"agents": patched_agents})
 
 
 @st.cache_data
@@ -94,15 +128,39 @@ def render_graph_viewer(
             hide_watermark=True,
         )
 
-        selected_id = st.session_state[state_key].selected_id
+        raw_selected = st.session_state[state_key].selected_id
 
-    # Initialize model override dict for this MAS
+        # Persist the last real click across fragment reruns.  Widget changes
+        # (slider, text_area) cause the fragment to rerun with selected_id=None
+        # even though the user hasn't deselected anything — without this, the
+        # properties panel collapses every time a field is edited.
+        persist_key = f"selected_node_{config.mas_id}"
+        if raw_selected is not None:
+            st.session_state[persist_key] = raw_selected
+        selected_id = st.session_state.get(persist_key)
+
+    # Initialize agent override dict for this MAS
     overrides_key = _overrides_key(config.mas_id)
     if overrides_key not in st.session_state:
         st.session_state[overrides_key] = {}
 
     with props_col:
         _render_properties_panel(config, selected_id, edges, config.mas_id)
+
+        st.markdown("---")
+        patched = apply_agent_overrides(config)
+        st.download_button(
+            "Download YAML",
+            data=yaml.dump(
+                patched.model_dump(mode="json"),
+                default_flow_style=False,
+                allow_unicode=True,
+                sort_keys=False,
+            ),
+            file_name=f"{patched.mas_id}.yaml",
+            mime="text/yaml",
+            use_container_width=True,
+        )
 
 
 def _render_properties_panel(
@@ -145,9 +203,11 @@ def _render_model_selector(agent: AgentSpec, mas_id: str) -> None:
     options, _, model_lookup = build_model_options()
     overrides = st.session_state[_overrides_key(mas_id)]
 
-    current_override = overrides.get(agent.agent_id)
-    if current_override and current_override in options:
-        start_index = options.index(current_override) + 1  # +1 for sentinel
+    # agent_overrides stores a dict per agent; read the model_name sub-key.
+    agent_override = overrides.get(agent.agent_id, {})
+    current_model_display = agent_override.get("model_name")
+    if current_model_display and current_model_display in options:
+        start_index = options.index(current_model_display) + 1  # +1 for sentinel
     else:
         yaml_display = model_lookup.get(agent.model_name)
         start_index = (
@@ -164,24 +224,64 @@ def _render_model_selector(agent: AgentSpec, mas_id: str) -> None:
         label_visibility="collapsed",
     )
 
+    bucket = overrides.setdefault(agent.agent_id, {})
     if selected == MODEL_KEEP_SENTINEL:
-        overrides.pop(agent.agent_id, None)
+        bucket.pop("model_name", None)
     else:
-        overrides[agent.agent_id] = selected
+        bucket["model_name"] = selected
 
 
 def _render_agent_properties(agent: AgentSpec, mas_id: str) -> None:
-    """Render detailed agent properties."""
+    """Render detailed agent properties with editable override fields."""
     st.markdown(f"**{agent.get_display_name()}**")
     st.caption(f"`{agent.agent_id}`")
 
     st.markdown("---")
     st.markdown(f"**Role:** {agent.role}")
-    st.markdown(f"**Objective:** {agent.objective}")
+
+    overrides = st.session_state[_overrides_key(mas_id)]
+    bucket = overrides.setdefault(agent.agent_id, {})
+
+    st.markdown("**Objective**")
+    obj_val = st.text_area(
+        "objective",
+        value=bucket.get("objective", agent.objective),
+        key=f"obj_{mas_id}_{agent.agent_id}",
+        label_visibility="collapsed",
+        height=100,
+        help="Override this agent's objective for this session.",
+    )
+    bucket["objective"] = obj_val
+
     _render_model_selector(agent, mas_id)
 
-    if agent.temperature is not None:
-        st.markdown(f"**Temperature:** {agent.temperature}")
+    st.markdown("**System Prompt**")
+    sp_val = st.text_area(
+        "system_prompt",
+        value=bucket.get("system_prompt", agent.system_prompt or ""),
+        key=f"sp_{mas_id}_{agent.agent_id}",
+        label_visibility="collapsed",
+        height=80,
+        help="Override this agent's system prompt for this session.",
+    )
+    if sp_val:
+        bucket["system_prompt"] = sp_val
+    else:
+        bucket.pop("system_prompt", None)
+
+    st.markdown("**Temperature**")
+    default_temp = float(agent.temperature if agent.temperature is not None else 0.7)
+    temp_val = st.slider(
+        "temperature",
+        min_value=0.0,
+        max_value=2.0,
+        value=float(bucket.get("temperature", default_temp)),
+        step=0.1,
+        key=f"temp_{mas_id}_{agent.agent_id}",
+        label_visibility="collapsed",
+    )
+    bucket["temperature"] = temp_val
+
     if agent.max_tokens:
         st.markdown(f"**Max Tokens:** {agent.max_tokens}")
 

--- a/bili/aether/ui/components/graph_viewer.py
+++ b/bili/aether/ui/components/graph_viewer.py
@@ -264,7 +264,10 @@ def _render_agent_properties(agent: AgentSpec, mas_id: str) -> None:
         height=100,
         help="Override this agent's objective for this session.",
     )
-    bucket["objective"] = obj_val
+    if obj_val:
+        bucket["objective"] = obj_val
+    else:
+        bucket.pop("objective", None)
 
     _render_model_selector(agent, mas_id)
 
@@ -293,20 +296,27 @@ def _render_agent_properties(agent: AgentSpec, mas_id: str) -> None:
         key=f"temp_{mas_id}_{agent.agent_id}",
         label_visibility="collapsed",
     )
-    bucket["temperature"] = temp_val
+    if temp_val != default_temp:
+        bucket["temperature"] = temp_val
+    else:
+        bucket.pop("temperature", None)
 
     st.markdown("**Max Tokens**")
+    default_max_tokens = agent.max_tokens or 1024
     max_tokens_val = st.number_input(
         "max_tokens",
         min_value=1,
         max_value=32768,
-        value=int(bucket.get("max_tokens", agent.max_tokens or 1024)),
+        value=int(bucket.get("max_tokens", default_max_tokens)),
         step=256,
         key=f"max_tokens_{mas_id}_{agent.agent_id}",
         label_visibility="collapsed",
         help="Maximum tokens the agent may generate per turn.",
     )
-    bucket["max_tokens"] = int(max_tokens_val)
+    if int(max_tokens_val) != default_max_tokens:
+        bucket["max_tokens"] = int(max_tokens_val)
+    else:
+        bucket.pop("max_tokens", None)
 
     st.markdown("**Tools**")
     yaml_tools = agent.tools or []

--- a/bili/aether/ui/page.py
+++ b/bili/aether/ui/page.py
@@ -36,8 +36,7 @@ from bili.aether.ui.chat_app import (
     render_sidebar_content as render_chat_sidebar_content,
 )
 from bili.aether.ui.components.graph_viewer import (
-    MODEL_KEEP_SENTINEL,
-    build_model_options,
+    apply_agent_overrides,
     render_graph_viewer,
     render_metadata_bar,
 )
@@ -231,7 +230,7 @@ def _render_visualizer_main() -> None:
 def _on_send_to_chat() -> None:
     """Button callback: push the current visualizer config to the Chat page.
 
-    Applies any model overrides selected in the Visualizer before sending.
+    Applies any agent overrides selected in the Visualizer before sending.
     Runs before the next render cycle so ``aether_page`` can be written
     safely without conflicting with the already-instantiated radio widget.
     """
@@ -239,22 +238,7 @@ def _on_send_to_chat() -> None:
     if config is None:
         return
 
-    # Apply model overrides from the Visualizer properties panel
-    overrides: dict = st.session_state.get(f"model_overrides_{config.mas_id}", {})
-    if overrides:
-        _, display_to_model_name, _ = build_model_options()
-        patched_agents = []
-        for agent in config.agents:
-            display = overrides.get(agent.agent_id)
-            patched = (
-                agent.model_copy(update={"model_name": display_to_model_name[display]})
-                if display
-                and display != MODEL_KEEP_SENTINEL
-                and display in display_to_model_name
-                else agent
-            )
-            patched_agents.append(patched)
-        config = config.model_copy(update={"agents": patched_agents})
+    config = apply_agent_overrides(config)
 
     name = st.session_state.get("current_yaml_path", "visualizer_config")
     if "chat_uploaded_configs" not in st.session_state:
@@ -274,13 +258,14 @@ def _load_config(yaml_path: Path) -> None:
             config = load_mas_from_yaml(yaml_path)
             st.session_state.mas_config = config
             st.session_state.current_yaml_path = str(yaml_path)
-            # Clear any previous flow state, model overrides, and widget state
+            # Clear any previous flow state, agent overrides, and widget state
             keys_to_clear = [
                 k
                 for k in st.session_state
                 if k.startswith("flow_state_")
-                or k.startswith("model_overrides_")
+                or k.startswith("agent_overrides_")
                 or k.startswith("model_select_")
+                or k.startswith("selected_node_")
             ]
             for k in keys_to_clear:
                 del st.session_state[k]

--- a/bili/aether/ui/page.py
+++ b/bili/aether/ui/page.py
@@ -269,6 +269,9 @@ def _load_config(yaml_path: Path) -> None:
                 or k.startswith("selected_node_")
                 or k.startswith("max_tokens_")
                 or k.startswith("tools_")
+                or k.startswith("obj_")
+                or k.startswith("sp_")
+                or k.startswith("temp_")
             ]
             for k in keys_to_clear:
                 del st.session_state[k]

--- a/bili/aether/ui/page.py
+++ b/bili/aether/ui/page.py
@@ -82,9 +82,10 @@ def _render_sidebar() -> str:
         label_visibility="collapsed",
         horizontal=True,
     )
-    st.markdown("---")
 
     page: str = st.session_state.get("aether_page", _DEFAULT_PAGE)
+
+    st.markdown("---")
     if page == "Chat":
         render_chat_sidebar_content(examples_dir=EXAMPLES_DIR)
     else:
@@ -266,6 +267,8 @@ def _load_config(yaml_path: Path) -> None:
                 or k.startswith("agent_overrides_")
                 or k.startswith("model_select_")
                 or k.startswith("selected_node_")
+                or k.startswith("max_tokens_")
+                or k.startswith("tools_")
             ]
             for k in keys_to_clear:
                 del st.session_state[k]
@@ -275,6 +278,13 @@ def _load_config(yaml_path: Path) -> None:
             return
 
     # Show summary in sidebar
+    st.markdown("---")
+    st.button(
+        "Send to Chat \u2192",
+        disabled=st.session_state.get("mas_config") is None,
+        use_container_width=True,
+        on_click=_on_send_to_chat,
+    )
     st.markdown("---")
     st.markdown(f"**MAS ID:** `{config.mas_id}`")
     st.markdown(f"**Version:** {config.version}")
@@ -286,14 +296,6 @@ def _load_config(yaml_path: Path) -> None:
         st.markdown(f"**Consensus:** {config.consensus_threshold}")
     if config.human_in_loop:
         st.warning("Human-in-loop enabled")
-
-    st.markdown("---")
-    st.button(
-        "Send to Chat \u2192",
-        disabled=st.session_state.get("mas_config") is None,
-        use_container_width=True,
-        on_click=_on_send_to_chat,
-    )
 
 
 def _render_legend() -> None:

--- a/bili/aether/ui/results_page.py
+++ b/bili/aether/ui/results_page.py
@@ -254,23 +254,24 @@ def _render_detail_panel(results: list[dict], df_filtered: pd.DataFrame) -> None
     visible.sort(key=lambda r: (cat_rank.get(r["prompt_category"], 99), r["prompt_id"]))
 
     for r in visible:
-        status_icon = "✅" if r["execution"]["success"] else "❌"
-        cat_icon = _CATEGORY_ICON.get(r["prompt_category"], "⚪")
+        execution = r.get("execution", {})
+        run_metadata = r.get("run_metadata", {})
+        status_icon = "✅" if execution.get("success") else "❌"
+        cat_icon = _CATEGORY_ICON.get(r.get("prompt_category", ""), "⚪")
+        duration = execution.get("duration_ms", 0.0)
         label = (
             f"{status_icon} {cat_icon} "
-            f"`{r['prompt_id']}` — `{r['mas_id']}` "
-            f"({r['execution']['duration_ms']:.0f} ms)"
+            f"`{r.get('prompt_id', '?')}` — `{r.get('mas_id', '?')}` "
+            f"({duration:.0f} ms)"
         )
         with st.expander(label, expanded=False):
-            st.markdown(f"**Prompt:** {r['prompt_text']}")
+            st.markdown(f"**Prompt:** {r.get('prompt_text', '(no prompt text)')}")
 
             c1, c2, c3 = st.columns(3)
-            c1.markdown(f"**Category:** `{r['prompt_category']}`")
-            c2.markdown(
-                f"**Stub:** {'Yes' if r['run_metadata']['stub_mode'] else 'No'}"
-            )
-            c3.markdown(f"**Agents:** {r['execution']['agent_count']}")
-            st.caption(f"Run at {r['run_metadata']['timestamp']}")
+            c1.markdown(f"**Category:** `{r.get('prompt_category', '?')}`")
+            c2.markdown(f"**Stub:** {'Yes' if run_metadata.get('stub_mode') else 'No'}")
+            c3.markdown(f"**Agents:** {execution.get('agent_count', '?')}")
+            st.caption(f"Run at {run_metadata.get('timestamp', 'unknown')}")
 
             agent_outputs = r.get("agent_outputs", {})
             if agent_outputs:

--- a/bili/aether/ui/results_page.py
+++ b/bili/aether/ui/results_page.py
@@ -1,0 +1,269 @@
+"""
+AETHER Results page — Baseline Results Viewer.
+
+Loads JSON result files written by the baseline runner and renders an
+interactive summary matrix, category breakdowns, and per-result detail panels.
+
+Called by the main Streamlit app (``bili/streamlit_app.py``) as a page within
+``st.navigation()``.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+LOGGER = logging.getLogger(__name__)
+
+BASELINE_RESULTS_DIR = (
+    Path(__file__).resolve().parent.parent / "tests" / "baseline" / "results"
+)
+LOGO_PATH = Path(__file__).resolve().parent.parent.parent / "images" / "logo.png"
+
+_CATEGORY_ICON = {
+    "benign": "🟢",
+    "violating": "🔴",
+    "edge_case": "🟡",
+}
+
+_CATEGORY_ORDER = ["benign", "edge_case", "violating"]
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+
+def _load_baseline_results() -> list[dict]:
+    """Return all parsed JSON result dicts from the baseline results directory."""
+    results: list[dict] = []
+    for path in sorted(BASELINE_RESULTS_DIR.glob("**/*.json")):
+        try:
+            results.append(json.loads(path.read_text(encoding="utf-8")))
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            LOGGER.warning("Could not parse %s: %s", path, exc)
+    return results
+
+
+def _build_dataframe(results: list[dict]) -> pd.DataFrame:
+    """Flatten result dicts into a tidy DataFrame."""
+    rows = []
+    for r in results:
+        rows.append(
+            {
+                "mas_id": r["mas_id"],
+                "prompt_id": r["prompt_id"],
+                "category": r["prompt_category"],
+                "success": r["execution"]["success"],
+                "duration_ms": r["execution"]["duration_ms"],
+                "agent_count": r["execution"]["agent_count"],
+                "stub_mode": r["run_metadata"]["stub_mode"],
+                "timestamp": r["run_metadata"]["timestamp"],
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Page entry point
+# ---------------------------------------------------------------------------
+
+
+def render_results_page() -> None:
+    """Render the Results page (sidebar + main area).
+
+    Called by the unified Streamlit app after ``st.set_page_config()``
+    has already been invoked.
+    """
+    with st.sidebar:
+        _render_sidebar()
+    _render_main()
+
+
+# ---------------------------------------------------------------------------
+# Sidebar
+# ---------------------------------------------------------------------------
+
+
+def _render_sidebar() -> None:
+    if LOGO_PATH.exists():
+        st.image(str(LOGO_PATH), width=80)
+    st.markdown("## AETHER Results")
+    st.markdown("---")
+    st.caption("Baseline Evaluation Viewer")
+    st.markdown(
+        "Generate results by running the baseline suite:\n\n"
+        "```\n# Stub mode (no LLM calls)\n"
+        "python bili/aether/tests/baseline/run_baseline.py --stub\n\n"
+        "# Full run (requires API credentials)\n"
+        "python bili/aether/tests/baseline/run_baseline.py\n```"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main area
+# ---------------------------------------------------------------------------
+
+
+def _render_main() -> None:
+    st.markdown("# Baseline Results")
+    st.markdown(
+        "Structured outputs from the AETHER baseline evaluation suite. "
+        "Each cell represents one prompt run against one MAS configuration."
+    )
+    st.markdown("---")
+
+    results = _load_baseline_results()
+
+    if not results:
+        st.info(
+            "No baseline results found.\n\n"
+            "Run the baseline suite to populate this view:\n\n"
+            "```\npython bili/aether/tests/baseline/run_baseline.py --stub\n```"
+        )
+        return
+
+    df = _build_dataframe(results)
+    _render_summary_metrics(df)
+    st.markdown("---")
+    df_filtered = _render_filters(df)
+    st.markdown("---")
+    _render_matrix(df_filtered)
+    st.markdown("---")
+    _render_detail_panel(results, df_filtered)
+
+
+# ---------------------------------------------------------------------------
+# Sub-components
+# ---------------------------------------------------------------------------
+
+
+def _render_summary_metrics(df: pd.DataFrame) -> None:
+    total = len(df)
+    passed = int(df["success"].sum())
+    cols = st.columns(5)
+    cols[0].metric("Configs", df["mas_id"].nunique())
+    cols[1].metric("Prompts", df["prompt_id"].nunique())
+    cols[2].metric("Total Runs", total)
+    cols[3].metric("Passed", passed)
+    cols[4].metric("Success Rate", f"{passed / total * 100:.0f}%")
+
+
+def _render_filters(df: pd.DataFrame) -> pd.DataFrame:
+    """Render filter controls and return the filtered DataFrame."""
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        configs = st.multiselect(
+            "MAS Config",
+            options=sorted(df["mas_id"].unique()),
+            default=sorted(df["mas_id"].unique()),
+            key="baseline_filter_configs",
+        )
+    with col2:
+        categories = st.multiselect(
+            "Category",
+            options=sorted(df["category"].unique()),
+            default=sorted(df["category"].unique()),
+            key="baseline_filter_categories",
+        )
+    with col3:
+        status = st.selectbox(
+            "Status",
+            options=["All", "Passed", "Failed"],
+            key="baseline_filter_status",
+        )
+
+    filtered = df[df["mas_id"].isin(configs) & df["category"].isin(categories)]
+    if status == "Passed":
+        filtered = filtered[filtered["success"]]
+    elif status == "Failed":
+        filtered = filtered[~filtered["success"]]
+
+    st.caption(f"{len(filtered)} result(s) shown")
+    return filtered
+
+
+def _render_matrix(df: pd.DataFrame) -> None:
+    """Render a colour-coded prompt × config matrix."""
+    st.markdown("### Results Matrix")
+    st.caption("✓ = passed  ✗ = failed  — = not run")
+
+    if df.empty:
+        st.info("No results match the current filters.")
+        return
+
+    pivot = df.pivot_table(
+        index="prompt_id",
+        columns="mas_id",
+        values="success",
+        aggfunc="first",
+    )
+
+    display = pivot.map(lambda v: "✓" if v is True else ("✗" if v is False else "—"))
+
+    def _cell_style(val: str) -> str:
+        if val == "✓":
+            return "background-color: #28a745; color: white; text-align: center"
+        if val == "✗":
+            return "background-color: #dc3545; color: white; text-align: center"
+        return "background-color: #6c757d; color: white; text-align: center"
+
+    st.dataframe(
+        display.style.map(_cell_style),
+        use_container_width=True,
+    )
+
+
+def _render_detail_panel(results: list[dict], df_filtered: pd.DataFrame) -> None:
+    """Render per-result expandable detail panels."""
+    st.markdown("### Run Details")
+
+    if df_filtered.empty:
+        return
+
+    visible_keys = set(zip(df_filtered["mas_id"], df_filtered["prompt_id"]))
+    visible = [r for r in results if (r["mas_id"], r["prompt_id"]) in visible_keys]
+
+    cat_rank = {c: i for i, c in enumerate(_CATEGORY_ORDER)}
+    visible.sort(key=lambda r: (cat_rank.get(r["prompt_category"], 99), r["prompt_id"]))
+
+    for r in visible:
+        status_icon = "✅" if r["execution"]["success"] else "❌"
+        cat_icon = _CATEGORY_ICON.get(r["prompt_category"], "⚪")
+        label = (
+            f"{status_icon} {cat_icon} "
+            f"`{r['prompt_id']}` — `{r['mas_id']}` "
+            f"({r['execution']['duration_ms']:.0f} ms)"
+        )
+        with st.expander(label, expanded=False):
+            st.markdown(f"**Prompt:** {r['prompt_text']}")
+
+            c1, c2, c3 = st.columns(3)
+            c1.markdown(f"**Category:** `{r['prompt_category']}`")
+            c2.markdown(
+                f"**Stub:** {'Yes' if r['run_metadata']['stub_mode'] else 'No'}"
+            )
+            c3.markdown(f"**Agents:** {r['execution']['agent_count']}")
+            st.caption(f"Run at {r['run_metadata']['timestamp']}")
+
+            agent_outputs = r.get("agent_outputs", {})
+            if agent_outputs:
+                st.markdown("**Agent Outputs:**")
+                for agent_id, output in agent_outputs.items():
+                    raw = (output.get("raw") or "").strip()
+                    st.markdown(f"*{agent_id}*")
+                    if raw:
+                        st.text_area(
+                            agent_id,
+                            value=raw,
+                            height=80,
+                            disabled=True,
+                            label_visibility="collapsed",
+                            key=f"detail_{r['mas_id']}_{r['prompt_id']}_{agent_id}",
+                        )
+                    else:
+                        st.caption("(no output)")
+            else:
+                st.caption("No agent outputs recorded.")

--- a/bili/aether/ui/results_page.py
+++ b/bili/aether/ui/results_page.py
@@ -36,8 +36,13 @@ _CATEGORY_ORDER = ["benign", "edge_case", "violating"]
 # ---------------------------------------------------------------------------
 
 
+@st.cache_data(ttl=30)
 def _load_baseline_results() -> list[dict]:
-    """Return all parsed JSON result dicts from the baseline results directory."""
+    """Return all parsed JSON result dicts from the baseline results directory.
+
+    Cached with a 30-second TTL so new result files appear promptly without
+    re-reading disk on every filter interaction or expander toggle.
+    """
     results: list[dict] = []
     for path in sorted(BASELINE_RESULTS_DIR.glob("**/*.json")):
         try:
@@ -48,21 +53,33 @@ def _load_baseline_results() -> list[dict]:
 
 
 def _build_dataframe(results: list[dict]) -> pd.DataFrame:
-    """Flatten result dicts into a tidy DataFrame."""
+    """Flatten result dicts into a tidy DataFrame.
+
+    Rows with missing or unexpected keys are skipped with a warning so a
+    single malformed file cannot crash the page.
+    """
     rows = []
     for r in results:
-        rows.append(
-            {
-                "mas_id": r["mas_id"],
-                "prompt_id": r["prompt_id"],
-                "category": r["prompt_category"],
-                "success": r["execution"]["success"],
-                "duration_ms": r["execution"]["duration_ms"],
-                "agent_count": r["execution"]["agent_count"],
-                "stub_mode": r["run_metadata"]["stub_mode"],
-                "timestamp": r["run_metadata"]["timestamp"],
-            }
-        )
+        try:
+            rows.append(
+                {
+                    "mas_id": r["mas_id"],
+                    "prompt_id": r["prompt_id"],
+                    "category": r["prompt_category"],
+                    "success": r["execution"]["success"],
+                    "duration_ms": r["execution"]["duration_ms"],
+                    "agent_count": r["execution"]["agent_count"],
+                    "stub_mode": r["run_metadata"]["stub_mode"],
+                    "timestamp": r["run_metadata"]["timestamp"],
+                }
+            )
+        except (KeyError, TypeError) as exc:
+            LOGGER.warning(
+                "Skipping malformed result (mas_id=%s, prompt_id=%s): %s",
+                r.get("mas_id", "?"),
+                r.get("prompt_id", "?"),
+                exc,
+            )
     return pd.DataFrame(rows)
 
 
@@ -148,7 +165,7 @@ def _render_summary_metrics(df: pd.DataFrame) -> None:
     cols[1].metric("Prompts", df["prompt_id"].nunique())
     cols[2].metric("Total Runs", total)
     cols[3].metric("Passed", passed)
-    cols[4].metric("Success Rate", f"{passed / total * 100:.0f}%")
+    cols[4].metric("Success Rate", f"{passed / total * 100:.0f}%" if total else "N/A")
 
 
 def _render_filters(df: pd.DataFrame) -> pd.DataFrame:
@@ -162,10 +179,15 @@ def _render_filters(df: pd.DataFrame) -> pd.DataFrame:
             key="baseline_filter_configs",
         )
     with col2:
+        # Respect _CATEGORY_ORDER so options always appear benign → edge_case → violating
+        present = set(df["category"].unique())
+        ordered_cats = [c for c in _CATEGORY_ORDER if c in present] + sorted(
+            present - set(_CATEGORY_ORDER)
+        )
         categories = st.multiselect(
             "Category",
-            options=sorted(df["category"].unique()),
-            default=sorted(df["category"].unique()),
+            options=ordered_cats,
+            default=ordered_cats,
             key="baseline_filter_categories",
         )
     with col3:
@@ -194,11 +216,13 @@ def _render_matrix(df: pd.DataFrame) -> None:
         st.info("No results match the current filters.")
         return
 
+    # aggfunc="last" shows the most recent run when duplicates exist (results
+    # are sorted by filename, which is chronological for the baseline runner).
     pivot = df.pivot_table(
         index="prompt_id",
         columns="mas_id",
         values="success",
-        aggfunc="first",
+        aggfunc="last",
     )
 
     display = pivot.map(lambda v: "✓" if v is True else ("✗" if v is False else "—"))

--- a/bili/streamlit_app.py
+++ b/bili/streamlit_app.py
@@ -16,6 +16,7 @@ import streamlit as st
 from PIL import Image
 
 from bili.aether.ui.page import render_aether_page
+from bili.aether.ui.results_page import render_results_page
 from bili.aether.ui.styles.bili_core_theme import CUSTOM_CSS
 from bili.checkpointers.checkpointer_functions import get_checkpointer
 from bili.streamlit_ui.ui.auth_ui import check_auth, initialize_auth_manager
@@ -53,6 +54,12 @@ def main():
                 url_path="aether",
                 icon=":material/hub:",
                 default=True,
+            ),
+            st.Page(
+                _run_results_page,
+                title="Results",
+                url_path="results",
+                icon=":material/bar_chart:",
             ),
             st.Page(
                 _run_bilicore_page,
@@ -139,6 +146,11 @@ def _run_bilicore_page():
 def _run_aether_page():
     """Render the AETHER multi-agent system page."""
     render_aether_page()
+
+
+def _run_results_page():
+    """Render the AETHER baseline results viewer page."""
+    render_results_page()
 
 
 # Run the main function when the script is executed.


### PR DESCRIPTION
### This PR introduces the following changes

* Renames the Visualizer properties panel session state key from `model_overrides_{mas_id}` to `agent_overrides_{mas_id}`, and expands its value from a flat `{agent_id: display_string}` dict to a nested `{agent_id: {model_name, system_prompt, objective, temperature}}` dict — enabling all four fields to be overridden per agent in one place
* Adds editable **Objective**, **System Prompt**, and **Temperature** widgets to the agent properties panel in the Visualizer (`_render_agent_properties()`) — previously only the model selector was editable; objective and temperature were read-only labels
* Updates `_on_send_to_chat()` in `page.py` to apply all four override fields (`model_name`, `system_prompt`, `objective`, `temperature`) via a single `model_copy(update=patch)` per agent when pushing a config from the Visualizer to the Chat page
* Adds a **Download YAML** button to the Visualizer sidebar that serializes the currently loaded `MASConfig` (with any in-memory overrides baked in) to a clean YAML file via `yaml.dump(config.model_dump(mode="json"))`
* Adds `objective: Optional[str]` to `MASConfig` — a MAS-level instruction field that, when set in YAML, is prepended as a `SystemMessage` before the first agent executes; implemented via a lightweight `__mas_objective__` entry node in `GraphBuilder.build()` that replaces `self._start_node`, so all seven workflow types wire through it transparently
* Adds an **"Input →"** caption above user message bubbles in the Chat UI for both stored turns and live streaming turns, clarifying the input/output boundary in the conversation view
* Adds a `system_prompt` example to `demo_code_review.yaml` on the `code_reviewer` agent to demonstrate per-agent system prompt configuration


### Steps to Review

1. Checkout the `130-task-22-gui-polish` branch on your local machine
2. Run the AETHER Visualizer: `streamlit run bili/aether/ui/chat_app.py` (or via the container `streamlit` alias), navigate to the Visualizer tab, and load any example config
3. Click an agent node in the graph — verify the properties panel now shows editable **Objective**, **Model**, **System Prompt**, and **Temperature** fields instead of read-only labels
4. Edit the objective or system prompt for one agent, then click **Send to Chat →** — verify the Chat page loads the config with the edited values applied to the correct agent
5. Click **Download YAML** in the Visualizer sidebar — verify a valid `.yaml` file is downloaded with the correct `mas_id` filename
6. Load `demo_code_review.yaml` and confirm the `code_reviewer` agent displays its `system_prompt` value in the System Prompt field
7. Load a YAML with `objective: "..."` set at the MAS level (add it manually to any example config) — run a chat turn in stub mode and confirm a `SystemMessage` from the MAS objective appears at the start of the message trace
8. Send a message in the Chat page — verify the user bubble shows an **"Input →"** caption above the message text for both new messages and previously stored turns