### PR TITLE
Task 23: Implement baseline results viewer

### DIFF
--- a/bili/aether/ui/results_page.py
+++ b/bili/aether/ui/results_page.py
@@ -254,23 +254,24 @@ def _render_detail_panel(results: list[dict], df_filtered: pd.DataFrame) -> None
     visible.sort(key=lambda r: (cat_rank.get(r["prompt_category"], 99), r["prompt_id"]))
 
     for r in visible:
-        status_icon = "✅" if r["execution"]["success"] else "❌"
-        cat_icon = _CATEGORY_ICON.get(r["prompt_category"], "⚪")
+        execution = r.get("execution", {})
+        run_metadata = r.get("run_metadata", {})
+        status_icon = "✅" if execution.get("success") else "❌"
+        cat_icon = _CATEGORY_ICON.get(r.get("prompt_category", ""), "⚪")
+        duration = execution.get("duration_ms", 0.0)
         label = (
             f"{status_icon} {cat_icon} "
-            f"`{r['prompt_id']}` — `{r['mas_id']}` "
-            f"({r['execution']['duration_ms']:.0f} ms)"
+            f"`{r.get('prompt_id', '?')}` — `{r.get('mas_id', '?')}` "
+            f"({duration:.0f} ms)"
         )
         with st.expander(label, expanded=False):
-            st.markdown(f"**Prompt:** {r['prompt_text']}")
+            st.markdown(f"**Prompt:** {r.get('prompt_text', '(no prompt text)')}")
 
             c1, c2, c3 = st.columns(3)
-            c1.markdown(f"**Category:** `{r['prompt_category']}`")
-            c2.markdown(
-                f"**Stub:** {'Yes' if r['run_metadata']['stub_mode'] else 'No'}"
-            )
-            c3.markdown(f"**Agents:** {r['execution']['agent_count']}")
-            st.caption(f"Run at {r['run_metadata']['timestamp']}")
+            c1.markdown(f"**Category:** `{r.get('prompt_category', '?')}`")
+            c2.markdown(f"**Stub:** {'Yes' if run_metadata.get('stub_mode') else 'No'}")
+            c3.markdown(f"**Agents:** {execution.get('agent_count', '?')}")
+            st.caption(f"Run at {run_metadata.get('timestamp', 'unknown')}")
 
             agent_outputs = r.get("agent_outputs", {})
             if agent_outputs:

--- a/bili/aether/ui/results_page.py
+++ b/bili/aether/ui/results_page.py
@@ -1,0 +1,269 @@
+"""
+AETHER Results page — Baseline Results Viewer.
+
+Loads JSON result files written by the baseline runner and renders an
+interactive summary matrix, category breakdowns, and per-result detail panels.
+
+Called by the main Streamlit app (``bili/streamlit_app.py``) as a page within
+``st.navigation()``.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+LOGGER = logging.getLogger(__name__)
+
+BASELINE_RESULTS_DIR = (
+    Path(__file__).resolve().parent.parent / "tests" / "baseline" / "results"
+)
+LOGO_PATH = Path(__file__).resolve().parent.parent.parent / "images" / "logo.png"
+
+_CATEGORY_ICON = {
+    "benign": "🟢",
+    "violating": "🔴",
+    "edge_case": "🟡",
+}
+
+_CATEGORY_ORDER = ["benign", "edge_case", "violating"]
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+
+def _load_baseline_results() -> list[dict]:
+    """Return all parsed JSON result dicts from the baseline results directory."""
+    results: list[dict] = []
+    for path in sorted(BASELINE_RESULTS_DIR.glob("**/*.json")):
+        try:
+            results.append(json.loads(path.read_text(encoding="utf-8")))
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            LOGGER.warning("Could not parse %s: %s", path, exc)
+    return results
+
+
+def _build_dataframe(results: list[dict]) -> pd.DataFrame:
+    """Flatten result dicts into a tidy DataFrame."""
+    rows = []
+    for r in results:
+        rows.append(
+            {
+                "mas_id": r["mas_id"],
+                "prompt_id": r["prompt_id"],
+                "category": r["prompt_category"],
+                "success": r["execution"]["success"],
+                "duration_ms": r["execution"]["duration_ms"],
+                "agent_count": r["execution"]["agent_count"],
+                "stub_mode": r["run_metadata"]["stub_mode"],
+                "timestamp": r["run_metadata"]["timestamp"],
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Page entry point
+# ---------------------------------------------------------------------------
+
+
+def render_results_page() -> None:
+    """Render the Results page (sidebar + main area).
+
+    Called by the unified Streamlit app after ``st.set_page_config()``
+    has already been invoked.
+    """
+    with st.sidebar:
+        _render_sidebar()
+    _render_main()
+
+
+# ---------------------------------------------------------------------------
+# Sidebar
+# ---------------------------------------------------------------------------
+
+
+def _render_sidebar() -> None:
+    if LOGO_PATH.exists():
+        st.image(str(LOGO_PATH), width=80)
+    st.markdown("## AETHER Results")
+    st.markdown("---")
+    st.caption("Baseline Evaluation Viewer")
+    st.markdown(
+        "Generate results by running the baseline suite:\n\n"
+        "```\n# Stub mode (no LLM calls)\n"
+        "python bili/aether/tests/baseline/run_baseline.py --stub\n\n"
+        "# Full run (requires API credentials)\n"
+        "python bili/aether/tests/baseline/run_baseline.py\n```"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main area
+# ---------------------------------------------------------------------------
+
+
+def _render_main() -> None:
+    st.markdown("# Baseline Results")
+    st.markdown(
+        "Structured outputs from the AETHER baseline evaluation suite. "
+        "Each cell represents one prompt run against one MAS configuration."
+    )
+    st.markdown("---")
+
+    results = _load_baseline_results()
+
+    if not results:
+        st.info(
+            "No baseline results found.\n\n"
+            "Run the baseline suite to populate this view:\n\n"
+            "```\npython bili/aether/tests/baseline/run_baseline.py --stub\n```"
+        )
+        return
+
+    df = _build_dataframe(results)
+    _render_summary_metrics(df)
+    st.markdown("---")
+    df_filtered = _render_filters(df)
+    st.markdown("---")
+    _render_matrix(df_filtered)
+    st.markdown("---")
+    _render_detail_panel(results, df_filtered)
+
+
+# ---------------------------------------------------------------------------
+# Sub-components
+# ---------------------------------------------------------------------------
+
+
+def _render_summary_metrics(df: pd.DataFrame) -> None:
+    total = len(df)
+    passed = int(df["success"].sum())
+    cols = st.columns(5)
+    cols[0].metric("Configs", df["mas_id"].nunique())
+    cols[1].metric("Prompts", df["prompt_id"].nunique())
+    cols[2].metric("Total Runs", total)
+    cols[3].metric("Passed", passed)
+    cols[4].metric("Success Rate", f"{passed / total * 100:.0f}%")
+
+
+def _render_filters(df: pd.DataFrame) -> pd.DataFrame:
+    """Render filter controls and return the filtered DataFrame."""
+    col1, col2, col3 = st.columns(3)
+    with col1:
+        configs = st.multiselect(
+            "MAS Config",
+            options=sorted(df["mas_id"].unique()),
+            default=sorted(df["mas_id"].unique()),
+            key="baseline_filter_configs",
+        )
+    with col2:
+        categories = st.multiselect(
+            "Category",
+            options=sorted(df["category"].unique()),
+            default=sorted(df["category"].unique()),
+            key="baseline_filter_categories",
+        )
+    with col3:
+        status = st.selectbox(
+            "Status",
+            options=["All", "Passed", "Failed"],
+            key="baseline_filter_status",
+        )
+
+    filtered = df[df["mas_id"].isin(configs) & df["category"].isin(categories)]
+    if status == "Passed":
+        filtered = filtered[filtered["success"]]
+    elif status == "Failed":
+        filtered = filtered[~filtered["success"]]
+
+    st.caption(f"{len(filtered)} result(s) shown")
+    return filtered
+
+
+def _render_matrix(df: pd.DataFrame) -> None:
+    """Render a colour-coded prompt × config matrix."""
+    st.markdown("### Results Matrix")
+    st.caption("✓ = passed  ✗ = failed  — = not run")
+
+    if df.empty:
+        st.info("No results match the current filters.")
+        return
+
+    pivot = df.pivot_table(
+        index="prompt_id",
+        columns="mas_id",
+        values="success",
+        aggfunc="first",
+    )
+
+    display = pivot.map(lambda v: "✓" if v is True else ("✗" if v is False else "—"))
+
+    def _cell_style(val: str) -> str:
+        if val == "✓":
+            return "background-color: #28a745; color: white; text-align: center"
+        if val == "✗":
+            return "background-color: #dc3545; color: white; text-align: center"
+        return "background-color: #6c757d; color: white; text-align: center"
+
+    st.dataframe(
+        display.style.map(_cell_style),
+        use_container_width=True,
+    )
+
+
+def _render_detail_panel(results: list[dict], df_filtered: pd.DataFrame) -> None:
+    """Render per-result expandable detail panels."""
+    st.markdown("### Run Details")
+
+    if df_filtered.empty:
+        return
+
+    visible_keys = set(zip(df_filtered["mas_id"], df_filtered["prompt_id"]))
+    visible = [r for r in results if (r["mas_id"], r["prompt_id"]) in visible_keys]
+
+    cat_rank = {c: i for i, c in enumerate(_CATEGORY_ORDER)}
+    visible.sort(key=lambda r: (cat_rank.get(r["prompt_category"], 99), r["prompt_id"]))
+
+    for r in visible:
+        status_icon = "✅" if r["execution"]["success"] else "❌"
+        cat_icon = _CATEGORY_ICON.get(r["prompt_category"], "⚪")
+        label = (
+            f"{status_icon} {cat_icon} "
+            f"`{r['prompt_id']}` — `{r['mas_id']}` "
+            f"({r['execution']['duration_ms']:.0f} ms)"
+        )
+        with st.expander(label, expanded=False):
+            st.markdown(f"**Prompt:** {r['prompt_text']}")
+
+            c1, c2, c3 = st.columns(3)
+            c1.markdown(f"**Category:** `{r['prompt_category']}`")
+            c2.markdown(
+                f"**Stub:** {'Yes' if r['run_metadata']['stub_mode'] else 'No'}"
+            )
+            c3.markdown(f"**Agents:** {r['execution']['agent_count']}")
+            st.caption(f"Run at {r['run_metadata']['timestamp']}")
+
+            agent_outputs = r.get("agent_outputs", {})
+            if agent_outputs:
+                st.markdown("**Agent Outputs:**")
+                for agent_id, output in agent_outputs.items():
+                    raw = (output.get("raw") or "").strip()
+                    st.markdown(f"*{agent_id}*")
+                    if raw:
+                        st.text_area(
+                            agent_id,
+                            value=raw,
+                            height=80,
+                            disabled=True,
+                            label_visibility="collapsed",
+                            key=f"detail_{r['mas_id']}_{r['prompt_id']}_{agent_id}",
+                        )
+                    else:
+                        st.caption("(no output)")
+            else:
+                st.caption("No agent outputs recorded.")

--- a/bili/aether/ui/results_page.py
+++ b/bili/aether/ui/results_page.py
@@ -36,8 +36,13 @@ _CATEGORY_ORDER = ["benign", "edge_case", "violating"]
 # ---------------------------------------------------------------------------
 
 
+@st.cache_data(ttl=30)
 def _load_baseline_results() -> list[dict]:
-    """Return all parsed JSON result dicts from the baseline results directory."""
+    """Return all parsed JSON result dicts from the baseline results directory.
+
+    Cached with a 30-second TTL so new result files appear promptly without
+    re-reading disk on every filter interaction or expander toggle.
+    """
     results: list[dict] = []
     for path in sorted(BASELINE_RESULTS_DIR.glob("**/*.json")):
         try:
@@ -48,21 +53,33 @@ def _load_baseline_results() -> list[dict]:
 
 
 def _build_dataframe(results: list[dict]) -> pd.DataFrame:
-    """Flatten result dicts into a tidy DataFrame."""
+    """Flatten result dicts into a tidy DataFrame.
+
+    Rows with missing or unexpected keys are skipped with a warning so a
+    single malformed file cannot crash the page.
+    """
     rows = []
     for r in results:
-        rows.append(
-            {
-                "mas_id": r["mas_id"],
-                "prompt_id": r["prompt_id"],
-                "category": r["prompt_category"],
-                "success": r["execution"]["success"],
-                "duration_ms": r["execution"]["duration_ms"],
-                "agent_count": r["execution"]["agent_count"],
-                "stub_mode": r["run_metadata"]["stub_mode"],
-                "timestamp": r["run_metadata"]["timestamp"],
-            }
-        )
+        try:
+            rows.append(
+                {
+                    "mas_id": r["mas_id"],
+                    "prompt_id": r["prompt_id"],
+                    "category": r["prompt_category"],
+                    "success": r["execution"]["success"],
+                    "duration_ms": r["execution"]["duration_ms"],
+                    "agent_count": r["execution"]["agent_count"],
+                    "stub_mode": r["run_metadata"]["stub_mode"],
+                    "timestamp": r["run_metadata"]["timestamp"],
+                }
+            )
+        except (KeyError, TypeError) as exc:
+            LOGGER.warning(
+                "Skipping malformed result (mas_id=%s, prompt_id=%s): %s",
+                r.get("mas_id", "?"),
+                r.get("prompt_id", "?"),
+                exc,
+            )
     return pd.DataFrame(rows)
 
 
@@ -148,7 +165,7 @@ def _render_summary_metrics(df: pd.DataFrame) -> None:
     cols[1].metric("Prompts", df["prompt_id"].nunique())
     cols[2].metric("Total Runs", total)
     cols[3].metric("Passed", passed)
-    cols[4].metric("Success Rate", f"{passed / total * 100:.0f}%")
+    cols[4].metric("Success Rate", f"{passed / total * 100:.0f}%" if total else "N/A")
 
 
 def _render_filters(df: pd.DataFrame) -> pd.DataFrame:
@@ -162,10 +179,15 @@ def _render_filters(df: pd.DataFrame) -> pd.DataFrame:
             key="baseline_filter_configs",
         )
     with col2:
+        # Respect _CATEGORY_ORDER so options always appear benign → edge_case → violating
+        present = set(df["category"].unique())
+        ordered_cats = [c for c in _CATEGORY_ORDER if c in present] + sorted(
+            present - set(_CATEGORY_ORDER)
+        )
         categories = st.multiselect(
             "Category",
-            options=sorted(df["category"].unique()),
-            default=sorted(df["category"].unique()),
+            options=ordered_cats,
+            default=ordered_cats,
             key="baseline_filter_categories",
         )
     with col3:
@@ -194,11 +216,13 @@ def _render_matrix(df: pd.DataFrame) -> None:
         st.info("No results match the current filters.")
         return
 
+    # aggfunc="last" shows the most recent run when duplicates exist (results
+    # are sorted by filename, which is chronological for the baseline runner).
     pivot = df.pivot_table(
         index="prompt_id",
         columns="mas_id",
         values="success",
-        aggfunc="first",
+        aggfunc="last",
     )
 
     display = pivot.map(lambda v: "✓" if v is True else ("✗" if v is False else "—"))

--- a/bili/streamlit_app.py
+++ b/bili/streamlit_app.py
@@ -16,6 +16,7 @@ import streamlit as st
 from PIL import Image
 
 from bili.aether.ui.page import render_aether_page
+from bili.aether.ui.results_page import render_results_page
 from bili.aether.ui.styles.bili_core_theme import CUSTOM_CSS
 from bili.checkpointers.checkpointer_functions import get_checkpointer
 from bili.streamlit_ui.ui.auth_ui import check_auth, initialize_auth_manager
@@ -53,6 +54,12 @@ def main():
                 url_path="aether",
                 icon=":material/hub:",
                 default=True,
+            ),
+            st.Page(
+                _run_results_page,
+                title="Results",
+                url_path="results",
+                icon=":material/bar_chart:",
             ),
             st.Page(
                 _run_bilicore_page,
@@ -139,6 +146,11 @@ def _run_bilicore_page():
 def _run_aether_page():
     """Render the AETHER multi-agent system page."""
     render_aether_page()
+
+
+def _run_results_page():
+    """Render the AETHER baseline results viewer page."""
+    render_results_page()
 
 
 # Run the main function when the script is executed.


### PR DESCRIPTION
### This PR introduces the following changes

* Adds a new **Results** page (`bili/aether/ui/results_page.py`) to the Streamlit app, accessible at `/results` in the top-level navigation
* The Results page loads all JSON result files from `bili/aether/tests/baseline/results/**/*.json` and renders an interactive baseline evaluation viewer
* Summary metrics bar shows total configs, prompts, runs, pass count, and success rate at a glance
* Filter controls allow narrowing results by MAS config, prompt category (benign / edge_case / violating), and pass/fail status
* Color-coded results matrix renders a pivot table of prompt × config with green ✓ (passed), red ✗ (failed), and grey — (not run) cells
* Collapsible run detail panels display the full prompt text, metadata, and per-agent outputs sorted by category then prompt ID
* Graceful empty state shown when no result files exist, with instructions for running the baseline suite
* Registers the Results page in `bili/streamlit_app.py` between AETHER Multi-Agent and Single-Agent RAG with a `bar_chart` icon


### Steps to Review

1. Checkout the `131-task-23-baseline-results-viewer` branch on your local machine
2. Start the Streamlit app and verify a **Results** nav item appears in the top navigation bar between AETHER Multi-Agent and Single-Agent RAG
3. Navigate to the Results page and confirm the empty-state message is shown with baseline runner instructions (no result files exist yet)
4. Generate stub results to populate the view:
    ```bash
    python bili/aether/tests/baseline/run_baseline.py --stub
    ```
5. Refresh the Results page and verify the summary metrics, filter controls, and results matrix render correctly
6. Use the MAS Config, Category, and Status filters to confirm the matrix and detail panels update accordingly
7. Expand individual run detail panels and verify prompt text, metadata (category, stub mode, agent count, timestamp), and agent outputs display correctly
8. Confirm the page handles partial results gracefully (e.g. only some configs or prompts have been run)
