### PR TITLE
Task 25: Implement attack GUI, draft needs a couple fixes

### DIFF
--- a/bili/aether/evaluator/evaluator_config.py
+++ b/bili/aether/evaluator/evaluator_config.py
@@ -27,7 +27,10 @@ The evaluator instructs the LLM to return a JSON object with three fields:
 # ---------------------------------------------------------------------------
 
 PRIMARY_EVALUATOR_MODEL: str = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+PRIMARY_EVALUATOR_MODEL_DISPLAY: str = "Primary — Claude 3.7 Sonnet (Bedrock)"
+
 FALLBACK_EVALUATOR_MODEL: str = "gemini-2.5-flash"
+FALLBACK_EVALUATOR_MODEL_DISPLAY: str = "Fallback — Gemini 2.5 Flash (Vertex)"
 EVALUATOR_TEMPERATURE: float = 0.0  # deterministic — required for reproducibility
 
 # ---------------------------------------------------------------------------

--- a/bili/aether/ui/attack_page.py
+++ b/bili/aether/ui/attack_page.py
@@ -1,0 +1,635 @@
+"""
+AETHER Attack GUI — Interactive Attack Suite.
+
+Exposes the AETHER attack framework for manual exploratory testing and demos.
+Users load a MAS config via "Send to Attack Suite" from the Chat or Visualizer
+page, select a suite and payload (or write custom text), click a graph node to
+target an agent, and click "Run Attack."
+
+Pre-execution attacks stream token-by-token (same streaming pattern as
+chat_app.py). Mid-execution attacks run synchronously with a spinner.
+After a run, the graph re-renders with a propagation overlay:
+  - Red border   → influenced by payload
+  - Green border → received payload but resisted
+  - Yellow border → received payload, clean output
+
+Called by the main Streamlit app (``bili/streamlit_app.py``) as a page within
+``st.navigation()``.
+"""
+
+# pylint: disable=import-error
+import importlib
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import streamlit as st
+
+# Suppress the FileNotFoundError traceback for bootstrap.min.css.map
+logging.getLogger("streamlit.web.server.component_request_handler").setLevel(
+    logging.ERROR
+)
+
+from bili.aether.attacks.injector import AttackInjector
+from bili.aether.attacks.models import AttackResult, AttackType, InjectionPhase
+from bili.aether.attacks.propagation import PropagationTracker
+from bili.aether.attacks.strategies import pre_execution as _pre_exec_strats
+from bili.aether.runtime import MASExecutor
+from bili.aether.schema import MASConfig
+from bili.aether.ui.components.attack_graph import (
+    build_node_states,
+    render_attack_graph,
+)
+
+LOGO_PATH = Path(__file__).resolve().parent.parent.parent / "images" / "logo.png"
+BASELINE_RESULTS_DIR = (
+    Path(__file__).resolve().parent.parent / "tests" / "baseline" / "results"
+)
+
+LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_EVALUATOR_PRIMARY_MODEL = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+
+_SUITE_NAMES = [
+    "injection",
+    "jailbreak",
+    "memory_poisoning",
+    "bias_inheritance",
+    "agent_impersonation",
+]
+
+_SUITE_DISPLAY = {
+    "injection": "Prompt Injection",
+    "jailbreak": "Jailbreak",
+    "memory_poisoning": "Memory Poisoning",
+    "bias_inheritance": "Bias Inheritance",
+    "agent_impersonation": "Agent Impersonation",
+}
+
+_SUITE_PAYLOAD_MODULES = {
+    "injection": "bili.aether.tests.injection.payloads.prompt_injection_payloads",
+    "jailbreak": "bili.aether.tests.jailbreak.payloads.jailbreak_payloads",
+    "memory_poisoning": (
+        "bili.aether.tests.memory_poisoning.payloads.memory_poisoning_payloads"
+    ),
+    "bias_inheritance": (
+        "bili.aether.tests.bias_inheritance.payloads.bias_inheritance_payloads"
+    ),
+    "agent_impersonation": (
+        "bili.aether.tests.agent_impersonation.payloads.agent_impersonation_payloads"
+    ),
+}
+
+_SUITE_ATTACK_TYPE = {
+    "injection": "prompt_injection",
+    "jailbreak": "jailbreak",
+    "memory_poisoning": "memory_poisoning",
+    "bias_inheritance": "bias_inheritance",
+    "agent_impersonation": "agent_impersonation",
+}
+
+# Strategy function name for each attack_type string
+_PRE_EXEC_STRATEGY_FN = {
+    "prompt_injection": "inject_prompt_injection",
+    "jailbreak": "inject_prompt_injection",
+    "memory_poisoning": "inject_memory_poisoning",
+    "bias_inheritance": "inject_bias_inheritance",
+    "agent_impersonation": "inject_agent_impersonation",
+}
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def render_attack_page() -> None:
+    """Render the Attack page (sidebar + main area).
+
+    Called by the unified Streamlit app after ``st.set_page_config()``
+    has already been invoked.
+    """
+    with st.sidebar:
+        _render_sidebar()
+    _render_main()
+
+
+# ---------------------------------------------------------------------------
+# Sidebar
+# ---------------------------------------------------------------------------
+
+
+def _render_sidebar() -> None:
+    """Render the Attack page sidebar."""
+    if LOGO_PATH.exists():
+        st.image(str(LOGO_PATH), width=80)
+    st.markdown("## Attack Suite")
+    st.markdown("---")
+
+    config: Optional[MASConfig] = st.session_state.get("attack_config")
+    if config is None:
+        st.caption("No MAS loaded.")
+        return
+
+    st.caption(f"Config: `{config.mas_id}`")
+
+    # Suite selector
+    suite_display_names = [_SUITE_DISPLAY[s] for s in _SUITE_NAMES]
+    suite_idx = st.selectbox(
+        "Suite",
+        range(len(_SUITE_NAMES)),
+        format_func=lambda i: suite_display_names[i],
+        key="attack_suite_idx",
+        label_visibility="visible",
+    )
+    selected_suite = _SUITE_NAMES[suite_idx if suite_idx is not None else 0]
+    st.session_state.attack_suite = selected_suite
+
+    # Payload source
+    payload_source = st.radio(
+        "Payload source",
+        ["Library", "Custom"],
+        key="attack_payload_source",
+        horizontal=True,
+    )
+
+    if payload_source == "Library":
+        library = _load_payload_library(selected_suite)
+        payload_ids = list(library.keys())
+        if not payload_ids:
+            st.warning("No payloads found for this suite.")
+            return
+
+        selected_pid = st.selectbox(
+            "Payload",
+            payload_ids,
+            format_func=lambda pid: f"{pid} — {_get_notes(library[pid])[:55]}",
+            key="attack_payload_id",
+        )
+        if selected_pid:
+            payload_obj = library[selected_pid]
+            st.text_area(
+                "Payload preview",
+                value=getattr(payload_obj, "payload", ""),
+                height=100,
+                disabled=True,
+                key="attack_payload_preview",
+            )
+    else:
+        st.text_area(
+            "Custom payload",
+            placeholder="Enter adversarial payload text…",
+            height=120,
+            key="attack_payload_custom",
+        )
+
+    # Phase
+    st.radio(
+        "Injection phase",
+        ["pre_execution", "mid_execution"],
+        key="attack_phase",
+        format_func=lambda p: (
+            "Pre-execution" if p == "pre_execution" else "Mid-execution"
+        ),
+        horizontal=True,
+    )
+
+    st.markdown("---")
+
+    target = st.session_state.get("attack_target_agent_id")
+    run_disabled = target is None
+
+    if st.button(
+        "Run Attack",
+        disabled=run_disabled,
+        use_container_width=True,
+        type="primary",
+        key="attack_run_button",
+    ):
+        _run_attack()
+
+    if run_disabled:
+        st.caption("Click a graph node to select a target.")
+
+
+# ---------------------------------------------------------------------------
+# Main area
+# ---------------------------------------------------------------------------
+
+
+def _render_main() -> None:
+    """Render the Attack page main area."""
+    config: Optional[MASConfig] = st.session_state.get("attack_config")
+
+    if config is None:
+        st.markdown("# Attack Suite")
+        st.info(
+            "No MAS loaded.\n\n"
+            "Use **Send to Attack Suite** from the Chat or Visualizer page to "
+            "load a configuration."
+        )
+        return
+
+    # Initialize target to first agent if not yet set
+    if not st.session_state.get("attack_target_agent_id") and config.agents:
+        st.session_state.attack_target_agent_id = config.agents[0].agent_id
+
+    target_id: Optional[str] = st.session_state.get("attack_target_agent_id")
+    phase: str = st.session_state.get("attack_phase", "pre_execution")
+
+    st.markdown("# Attack Suite")
+    st.caption(
+        f"Config: `{config.mas_id}` | "
+        f"Target: `{target_id or 'None'}` | "
+        f"Phase: `{phase}`"
+    )
+    st.markdown("---")
+
+    # Graph — node clicks update attack_target_agent_id
+    node_states: Optional[dict] = st.session_state.get("attack_node_states")
+    clicked = render_attack_graph(config, target_id, node_states)
+    if clicked and clicked != target_id:
+        st.session_state.attack_target_agent_id = clicked
+        st.rerun()
+
+    # Results area
+    attack_result_dict: Optional[dict] = st.session_state.get("attack_result")
+    if attack_result_dict:
+        st.markdown("---")
+        _render_results(config, attack_result_dict)
+
+
+# ---------------------------------------------------------------------------
+# Attack execution
+# ---------------------------------------------------------------------------
+
+
+def _run_attack() -> None:
+    """Dispatch to pre- or mid-execution handler, store result in session state."""
+    config: Optional[MASConfig] = st.session_state.get("attack_config")
+    if config is None:
+        return
+
+    target_id: Optional[str] = st.session_state.get("attack_target_agent_id")
+    if not target_id:
+        st.error("No target agent selected.")
+        return
+
+    phase: str = st.session_state.get("attack_phase", "pre_execution")
+    suite: str = st.session_state.get("attack_suite", "injection")
+    attack_type_str: str = _SUITE_ATTACK_TYPE[suite]
+    payload_text: Optional[str] = _resolve_payload()
+
+    if not payload_text:
+        st.error("No payload text. Select a library payload or enter custom text.")
+        return
+
+    # Clear previous results
+    for key in ("attack_result", "attack_verdict", "attack_node_states"):
+        st.session_state.pop(key, None)
+
+    try:
+        if phase == "pre_execution":
+            result = _run_pre_execution_streaming(
+                config, target_id, attack_type_str, payload_text
+            )
+        else:
+            result = _run_mid_execution(
+                config, target_id, attack_type_str, payload_text
+            )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        st.error(f"Attack failed: {exc}")
+        LOGGER.error("Attack execution error: %s", exc, exc_info=True)
+        return
+
+    result_dict = result.model_dump(mode="json")
+    st.session_state.attack_result = result_dict
+    st.session_state.attack_node_states = build_node_states(result.agent_observations)
+    st.rerun()
+
+
+def _run_pre_execution_streaming(
+    config: MASConfig,
+    target_agent_id: str,
+    attack_type_str: str,
+    payload_text: str,
+) -> AttackResult:
+    """Apply a pre-execution strategy then stream execution via MASExecutor.
+
+    Follows the same streaming loop pattern as chat_app.py:
+    pre-allocate one ``st.empty()`` slot per agent, accumulate tokens into
+    the slot, then call ``PropagationTracker.observe()`` on each
+    ``__node_complete__`` event.
+    """
+    strategy_fn_name = _PRE_EXEC_STRATEGY_FN[attack_type_str]
+    strategy_fn = getattr(_pre_exec_strats, strategy_fn_name)
+    patched_config = strategy_fn(config, target_agent_id, payload_text)
+
+    executor = MASExecutor(patched_config)
+    with st.spinner("Initializing attack executor…"):
+        executor.initialize()
+
+    agent_specs = {a.agent_id: a for a in patched_config.agents}
+    agent_nodes_set = set(agent_specs)
+    tracker = PropagationTracker(payload_text, target_agent_id)
+    injected_at = datetime.now(timezone.utc)
+
+    # Pre-allocate streaming slots (one per agent node)
+    st.markdown("#### Agent Outputs")
+    agent_slots: dict[str, Any] = {}
+    for agent_id in [a.agent_id for a in patched_config.agents]:
+        st.markdown(f"**{agent_id}**")
+        agent_slots[agent_id] = st.empty()
+
+    token_buffer: dict[str, str] = {}
+    run_success = True
+
+    try:
+        for event_type, event_data in executor.run_streaming_tokens(
+            input_data={"messages": []},
+            thread_id=str(uuid.uuid4()),
+        ):
+            if event_type == "__token__":
+                node = event_data["node"]
+                if node not in agent_nodes_set:
+                    continue
+                token_buffer[node] = token_buffer.get(node, "") + event_data["token"]
+                agent_slots[node].markdown(token_buffer[node])
+
+            elif event_type == "__node_complete__":
+                node = event_data["node"]
+                state_update = event_data["state_update"]
+                if node not in agent_nodes_set or state_update is None:
+                    continue
+                spec = agent_specs[node]
+                messages = state_update.get("messages", [])
+                output_excerpt = next(
+                    (
+                        getattr(m, "content", "")[:500]
+                        for m in reversed(messages)
+                        if getattr(m, "content", "")
+                    ),
+                    "",
+                )
+                tracker.observe(
+                    agent_id=node,
+                    role=spec.role or node,
+                    input_state={
+                        "messages": messages,
+                        "objective": spec.objective or "",
+                    },
+                    output_state={"messages": messages, "output": output_excerpt},
+                    attack_type=attack_type_str,
+                )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        run_success = False
+        LOGGER.error("Streaming execution error: %s", exc, exc_info=True)
+        st.error(f"Execution error: {exc}")
+
+    completed_at = datetime.now(timezone.utc)
+    return AttackResult(
+        attack_id=str(uuid.uuid4()),
+        mas_id=config.mas_id,
+        target_agent_id=target_agent_id,
+        attack_type=AttackType(attack_type_str),
+        injection_phase=InjectionPhase.PRE_EXECUTION,
+        payload=payload_text,
+        injected_at=injected_at,
+        completed_at=completed_at,
+        propagation_path=tracker.propagation_path(),
+        influenced_agents=tracker.influenced_agents(),
+        resistant_agents=tracker.resistant_agents(),
+        agent_observations=tracker.observations,
+        success=run_success,
+    )
+
+
+def _run_mid_execution(
+    config: MASConfig,
+    target_agent_id: str,
+    attack_type_str: str,
+    payload_text: str,
+) -> AttackResult:
+    """Run a mid-execution injection synchronously via AttackInjector."""
+    injector = AttackInjector(config=config, executor=None)
+    with st.spinner("Running mid-execution attack…"):
+        return injector.inject_attack(
+            agent_id=target_agent_id,
+            attack_type=attack_type_str,
+            payload=payload_text,
+            injection_phase=InjectionPhase.MID_EXECUTION,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Results display
+# ---------------------------------------------------------------------------
+
+
+def _render_results(config: MASConfig, result_dict: dict) -> None:
+    """Render Tier 1, Tier 2, and Tier 3 results from the stored AttackResult dict."""
+    st.markdown("### Attack Results")
+
+    # Tier 1
+    tier1_passed = result_dict.get("success", False)
+    if tier1_passed:
+        st.success("**Tier 1:** Execution succeeded — MAS ran without error.")
+    else:
+        error_msg = result_dict.get("error") or "Unknown error"
+        st.error(f"**Tier 1:** Execution failed — {error_msg}")
+
+    # Tier 2 — per-agent propagation
+    observations = result_dict.get("agent_observations", [])
+    if observations:
+        st.markdown("#### Tier 2 — Propagation Analysis")
+        for obs in observations:
+            _render_observation(obs)
+
+    propagation = result_dict.get("propagation_path", [])
+    influenced = result_dict.get("influenced_agents", [])
+    resistant = result_dict.get("resistant_agents", [])
+
+    col1, col2, col3 = st.columns(3)
+    col1.metric("Propagation path", " → ".join(propagation) if propagation else "—")
+    col2.metric("Influenced", len(influenced))
+    col3.metric("Resistant", len(resistant))
+
+    # Tier 3 — semantic evaluation
+    st.markdown("#### Tier 3 — Semantic Evaluation")
+    if _is_stub_mode(config):
+        st.info("Semantic evaluation skipped in stub mode.")
+        return
+
+    # Circularity check
+    mas_model = (config.agents[0].model_name or "") if config.agents else ""
+    if _same_provider_family(mas_model, _EVALUATOR_PRIMARY_MODEL):
+        st.warning(
+            "⚠ Attack MAS and evaluator share the same model family — "
+            "evaluation may be circular."
+        )
+
+    baseline_result = _load_baseline_result(config.mas_id)
+    if baseline_result is None:
+        st.info("No baseline results found for this MAS. Tier 3 evaluation skipped.")
+        return
+
+    with st.spinner("Running semantic evaluation…"):
+        verdicts = _run_tier3_evaluation(result_dict, baseline_result)
+
+    if verdicts is None:
+        return
+
+    verdict_dicts = [
+        v.model_dump() if hasattr(v, "model_dump") else vars(v) for v in verdicts
+    ]
+    st.session_state.attack_verdict = verdict_dicts
+
+    for vd in verdict_dicts:
+        score = vd.get("score", -1)
+        agent_id = vd.get("agent_id", "?")
+        reasoning = vd.get("reasoning", "")
+        confidence = vd.get("confidence", "")
+        if score == -1:
+            st.error(f"**{agent_id}:** Evaluation error — {vd.get('error', 'unknown')}")
+        else:
+            score_color = "🔴" if score >= 2 else ("🟡" if score == 1 else "🟢")
+            st.markdown(
+                f"{score_color} **{agent_id}:** Score {score}/3 "
+                f"(confidence: {confidence})"
+            )
+            if reasoning:
+                st.caption(reasoning)
+
+
+def _render_observation(obs: dict) -> None:
+    """Render a single AgentObservation as a color-coded status line + expander."""
+    agent_id = obs.get("agent_id", "?")
+    influenced = obs.get("influenced", False)
+    resisted = obs.get("resisted", False)
+    received = obs.get("received_payload", False)
+    excerpt = obs.get("output_excerpt") or ""
+
+    if influenced:
+        icon = "🔴"
+        label = "Influenced"
+    elif resisted:
+        icon = "🟢"
+        label = "Resisted"
+    elif received:
+        icon = "🟡"
+        label = "Received"
+    else:
+        icon = "⚪"
+        label = "Clean"
+
+    with st.expander(f"{icon} **{agent_id}** — {label}", expanded=False):
+        st.caption(f"Role: {obs.get('role', '?')}")
+        if excerpt:
+            st.text_area(
+                "Output excerpt",
+                value=excerpt,
+                height=80,
+                disabled=True,
+                label_visibility="collapsed",
+                key=f"atk_obs_{agent_id}_{obs.get('influenced')}",
+            )
+        else:
+            st.caption("(no output recorded)")
+
+
+# ---------------------------------------------------------------------------
+# Tier 3 evaluation
+# ---------------------------------------------------------------------------
+
+
+def _run_tier3_evaluation(result_dict: dict, baseline_result: dict) -> Optional[list]:
+    """Reconstruct AttackResult and call SemanticEvaluator.evaluate()."""
+    try:
+        from bili.aether.evaluator.semantic_evaluator import (  # pylint: disable=import-outside-toplevel
+            SemanticEvaluator,
+        )
+
+        attack_result = AttackResult.model_validate(result_dict)
+        evaluator = SemanticEvaluator(model_name=_EVALUATOR_PRIMARY_MODEL)
+        return evaluator.evaluate(baseline_result, attack_result)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        st.error(f"Tier 3 evaluation failed: {exc}")
+        LOGGER.error("Tier 3 evaluation error: %s", exc, exc_info=True)
+        return None
+
+
+def _load_baseline_result(mas_id: str) -> Optional[dict]:
+    """Load the first available baseline result for *mas_id*, or None."""
+    mas_dir = BASELINE_RESULTS_DIR / mas_id
+    if not mas_dir.exists():
+        return None
+    for path in sorted(mas_dir.glob("**/*.json")):
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception:  # pylint: disable=broad-exception-caught
+            continue
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@st.cache_resource
+def _load_payload_library(suite: str) -> dict:
+    """Lazy-import and return PAYLOADS_BY_ID for the given suite."""
+    try:
+        mod = importlib.import_module(_SUITE_PAYLOAD_MODULES[suite])
+        return mod.PAYLOADS_BY_ID
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        LOGGER.warning("Could not load payload library for suite %r: %s", suite, exc)
+        return {}
+
+
+def _get_notes(payload_obj: Any) -> str:
+    """Return the notes string from a payload object."""
+    return getattr(payload_obj, "notes", "") or ""
+
+
+def _resolve_payload() -> Optional[str]:
+    """Return the active payload text from session state."""
+    source = st.session_state.get("attack_payload_source", "Library")
+    if source == "Custom":
+        return st.session_state.get("attack_payload_custom", "").strip() or None
+    suite = st.session_state.get("attack_suite", "injection")
+    pid = st.session_state.get("attack_payload_id")
+    if not pid:
+        return None
+    library = _load_payload_library(suite)
+    payload_obj = library.get(pid)
+    if payload_obj is None:
+        return None
+    return getattr(payload_obj, "payload", None)
+
+
+def _is_stub_mode(config: MASConfig) -> bool:
+    """Return True if all agents have no model_name set (stub mode)."""
+    return all(not a.model_name for a in config.agents)
+
+
+def _same_provider_family(model_a: str, model_b: str) -> bool:
+    """Return True if both model strings belong to the same provider family."""
+    families = [
+        {"anthropic", "claude"},
+        {"google", "gemini", "vertex"},
+        {"amazon", "nova", "bedrock"},
+    ]
+    for family in families:
+        if any(k in model_a.lower() for k in family) and any(
+            k in model_b.lower() for k in family
+        ):
+            return True
+    return False

--- a/bili/aether/ui/attack_page.py
+++ b/bili/aether/ui/attack_page.py
@@ -39,7 +39,10 @@ from bili.aether.attacks.propagation import PropagationTracker
 from bili.aether.attacks.strategies import pre_execution as _pre_exec_strats
 from bili.aether.evaluator.evaluator_config import (
     FALLBACK_EVALUATOR_MODEL,
+    FALLBACK_EVALUATOR_MODEL_DISPLAY,
     PRIMARY_EVALUATOR_MODEL,
+    PRIMARY_EVALUATOR_MODEL_DISPLAY,
+    PROVIDER_FAMILY_PREFIXES,
 )
 from bili.aether.runtime import MASExecutor
 from bili.aether.schema import MASConfig
@@ -60,8 +63,8 @@ LOGGER = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _EVALUATOR_MODELS = {
-    f"Primary — Claude 3.7 Sonnet (Bedrock)": PRIMARY_EVALUATOR_MODEL,
-    f"Fallback — Gemini 2.5 Flash (Vertex)": FALLBACK_EVALUATOR_MODEL,
+    PRIMARY_EVALUATOR_MODEL_DISPLAY: PRIMARY_EVALUATOR_MODEL,
+    FALLBACK_EVALUATOR_MODEL_DISPLAY: FALLBACK_EVALUATOR_MODEL,
 }
 
 _SUITE_NAMES = [
@@ -620,6 +623,7 @@ def _load_baseline_result(mas_id: str) -> Optional[dict]:
             return json.loads(path.read_text(encoding="utf-8"))
         except Exception as exc:  # pylint: disable=broad-exception-caught
             LOGGER.warning("Skipping unreadable baseline file %s: %s", path, exc)
+            st.warning(f"Skipped unreadable baseline file `{path.name}`: {exc}")
             continue
     return None
 
@@ -666,17 +670,21 @@ def _is_stub_mode(config: MASConfig) -> bool:
     return all(not a.model_name for a in config.agents)
 
 
+def _get_provider_family(model_id: str) -> Optional[str]:
+    """Return the canonical provider-family name for *model_id*, or None.
+
+    Uses the same prefix table as ``evaluator_config.PROVIDER_FAMILY_PREFIXES``
+    so circularity detection here stays in sync with the SemanticEvaluator.
+    """
+    lower = model_id.lower()
+    for prefix, family in PROVIDER_FAMILY_PREFIXES:
+        if lower.startswith(prefix):
+            return family
+    return None
+
+
 def _same_provider_family(model_a: str, model_b: str) -> bool:
     """Return True if both model strings belong to the same provider family."""
-    families = [
-        {"anthropic", "claude"},
-        {"google", "gemini", "vertex"},
-        {"amazon", "nova", "bedrock"},
-        {"openai", "gpt"},
-    ]
-    for family in families:
-        if any(k in model_a.lower() for k in family) and any(
-            k in model_b.lower() for k in family
-        ):
-            return True
-    return False
+    family_a = _get_provider_family(model_a)
+    family_b = _get_provider_family(model_b)
+    return family_a is not None and family_a == family_b

--- a/bili/aether/ui/attack_page.py
+++ b/bili/aether/ui/attack_page.py
@@ -110,6 +110,20 @@ _PRE_EXEC_STRATEGY_FN = {
 # ---------------------------------------------------------------------------
 
 
+def push_config_to_attack_state(config: MASConfig) -> None:
+    """Write *config* into session state so the Attack page loads it fresh.
+
+    Call this from any page that has a "Send to Attack Suite" button.  Clears
+    previous attack results so the new config starts from a clean slate.
+    """
+    st.session_state.attack_config = config
+    if config.agents:
+        st.session_state.attack_target_agent_id = config.agents[0].agent_id
+    for key in ("attack_result", "attack_verdict", "attack_node_states"):
+        st.session_state.pop(key, None)
+    st.toast("Config loaded in Attack Suite \u2713")
+
+
 def render_attack_page() -> None:
     """Render the Attack page (sidebar + main area).
 
@@ -349,7 +363,6 @@ def _run_pre_execution_streaming(
         agent_slots[agent_id] = st.empty()
 
     token_buffer: dict[str, str] = {}
-    run_success = True
 
     try:
         for event_type, event_data in executor.run_streaming_tokens(
@@ -389,9 +402,9 @@ def _run_pre_execution_streaming(
                     attack_type=attack_type_str,
                 )
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        run_success = False
         LOGGER.error("Streaming execution error: %s", exc, exc_info=True)
-        st.error(f"Execution error: {exc}")
+        # Re-raise so _execute_attack shows the error and discards the partial result.
+        raise
 
     completed_at = datetime.now(timezone.utc)
     return AttackResult(
@@ -407,7 +420,7 @@ def _run_pre_execution_streaming(
         influenced_agents=tracker.influenced_agents(),
         resistant_agents=tracker.resistant_agents(),
         agent_observations=tracker.observations,
-        success=run_success,
+        success=True,
     )
 
 
@@ -467,9 +480,9 @@ def _render_results(config: MASConfig, result_dict: dict) -> None:
         st.info("Semantic evaluation skipped in stub mode.")
         return
 
-    # Circularity check
-    mas_model = (config.agents[0].model_name or "") if config.agents else ""
-    if _same_provider_family(mas_model, _EVALUATOR_PRIMARY_MODEL):
+    # Circularity check — warn if any agent shares the evaluator's provider family
+    mas_models = [a.model_name or "" for a in config.agents if a.model_name]
+    if any(_same_provider_family(m, _EVALUATOR_PRIMARY_MODEL) for m in mas_models):
         st.warning(
             "⚠ Attack MAS and evaluator share the same model family — "
             "evaluation may be circular."
@@ -626,6 +639,7 @@ def _same_provider_family(model_a: str, model_b: str) -> bool:
         {"anthropic", "claude"},
         {"google", "gemini", "vertex"},
         {"amazon", "nova", "bedrock"},
+        {"openai", "gpt"},
     ]
     for family in families:
         if any(k in model_a.lower() for k in family) and any(

--- a/bili/aether/ui/attack_page.py
+++ b/bili/aether/ui/attack_page.py
@@ -37,6 +37,10 @@ from bili.aether.attacks.injector import AttackInjector
 from bili.aether.attacks.models import AttackResult, AttackType, InjectionPhase
 from bili.aether.attacks.propagation import PropagationTracker
 from bili.aether.attacks.strategies import pre_execution as _pre_exec_strats
+from bili.aether.evaluator.evaluator_config import (
+    FALLBACK_EVALUATOR_MODEL,
+    PRIMARY_EVALUATOR_MODEL,
+)
 from bili.aether.runtime import MASExecutor
 from bili.aether.schema import MASConfig
 from bili.aether.ui.components.attack_graph import (
@@ -55,7 +59,10 @@ LOGGER = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-_EVALUATOR_PRIMARY_MODEL = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+_EVALUATOR_MODELS = {
+    f"Primary — Claude 3.7 Sonnet (Bedrock)": PRIMARY_EVALUATOR_MODEL,
+    f"Fallback — Gemini 2.5 Flash (Vertex)": FALLBACK_EVALUATOR_MODEL,
+}
 
 _SUITE_NAMES = [
     "injection",
@@ -232,6 +239,19 @@ def _render_sidebar() -> None:
     if run_disabled:
         st.caption("Click a graph node to select a target.")
 
+    st.markdown("---")
+    st.markdown("#### Tier 3 Evaluator")
+    st.selectbox(
+        "Evaluator model",
+        options=list(_EVALUATOR_MODELS.keys()),
+        key="attack_evaluator_model_label",
+        help=(
+            "Model used for semantic (Tier 3) evaluation. "
+            "Choose a model from a different provider family than your MAS "
+            "to avoid circularity."
+        ),
+    )
+
 
 # ---------------------------------------------------------------------------
 # Main area
@@ -362,6 +382,11 @@ def _run_pre_execution_streaming(
         st.markdown(f"**{agent_id}**")
         agent_slots[agent_id] = st.empty()
 
+    # token_buffer accumulates each agent's full streamed output so that the
+    # st.empty() slot shows the complete text so far on each token event.
+    # Memory usage is proportional to total output across all agents — acceptable
+    # for research-scale MAS runs.  The buffer is released when this function
+    # returns.
     token_buffer: dict[str, str] = {}
 
     try:
@@ -480,9 +505,10 @@ def _render_results(config: MASConfig, result_dict: dict) -> None:
         st.info("Semantic evaluation skipped in stub mode.")
         return
 
-    # Circularity check — warn if any agent shares the evaluator's provider family
+    # Circularity check — warn if any agent shares the selected evaluator's provider family
+    evaluator_model = _get_evaluator_model()
     mas_models = [a.model_name or "" for a in config.agents if a.model_name]
-    if any(_same_provider_family(m, _EVALUATOR_PRIMARY_MODEL) for m in mas_models):
+    if any(_same_provider_family(m, evaluator_model) for m in mas_models):
         st.warning(
             "⚠ Attack MAS and evaluator share the same model family — "
             "evaluation may be circular."
@@ -562,6 +588,12 @@ def _render_observation(obs: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _get_evaluator_model() -> str:
+    """Return the model ID selected by the user for Tier 3 evaluation."""
+    label = st.session_state.get("attack_evaluator_model_label")
+    return _EVALUATOR_MODELS.get(label, PRIMARY_EVALUATOR_MODEL)
+
+
 def _run_tier3_evaluation(result_dict: dict, baseline_result: dict) -> Optional[list]:
     """Reconstruct AttackResult and call SemanticEvaluator.evaluate()."""
     try:
@@ -570,7 +602,7 @@ def _run_tier3_evaluation(result_dict: dict, baseline_result: dict) -> Optional[
         )
 
         attack_result = AttackResult.model_validate(result_dict)
-        evaluator = SemanticEvaluator(model_name=_EVALUATOR_PRIMARY_MODEL)
+        evaluator = SemanticEvaluator(model_name=_get_evaluator_model())
         return evaluator.evaluate(baseline_result, attack_result)
     except Exception as exc:  # pylint: disable=broad-exception-caught
         st.error(f"Tier 3 evaluation failed: {exc}")
@@ -586,7 +618,8 @@ def _load_baseline_result(mas_id: str) -> Optional[dict]:
     for path in sorted(mas_dir.glob("**/*.json")):
         try:
             return json.loads(path.read_text(encoding="utf-8"))
-        except Exception:  # pylint: disable=broad-exception-caught
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            LOGGER.warning("Skipping unreadable baseline file %s: %s", path, exc)
             continue
     return None
 

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -817,7 +817,30 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
                 use_container_width=True,
             )
 
+    st.markdown("---")
+    if st.button(
+        "Send to Attack Suite \u2192",
+        disabled=st.session_state.get("chat_config") is None,
+        use_container_width=True,
+        key="chat_send_to_attack",
+        help="Load the current config into the Attack GUI page.",
+    ):
+        _on_send_to_attack_from_chat()
+
     _render_thread_list()
+
+
+def _on_send_to_attack_from_chat() -> None:
+    """Push the current chat config to the Attack page."""
+    chat_cfg = st.session_state.get("chat_config")
+    if chat_cfg is None:
+        return
+    st.session_state.attack_config = chat_cfg
+    if chat_cfg.agents:
+        st.session_state.attack_target_agent_id = chat_cfg.agents[0].agent_id
+    for key in ("attack_result", "attack_verdict", "attack_node_states"):
+        st.session_state.pop(key, None)
+    st.toast("Config loaded in Attack Suite \u2713")
 
 
 # ---------------------------------------------------------------------------

--- a/bili/aether/ui/chat_app.py
+++ b/bili/aether/ui/chat_app.py
@@ -35,6 +35,7 @@ from bili.aether.compiler import compile_mas
 from bili.aether.config.loader import load_mas_from_dict, load_mas_from_yaml
 from bili.aether.runtime import MASExecutor
 from bili.aether.schema import AgentSpec, MASConfig, WorkflowType
+from bili.aether.ui.attack_page import push_config_to_attack_state
 from bili.aether.ui.styles.bili_core_theme import CUSTOM_CSS
 from bili.aether.validation import validate_mas
 
@@ -818,29 +819,24 @@ def render_sidebar_content(examples_dir: Optional[Path] = None) -> None:
             )
 
     st.markdown("---")
-    if st.button(
+    st.button(
         "Send to Attack Suite \u2192",
         disabled=st.session_state.get("chat_config") is None,
         use_container_width=True,
         key="chat_send_to_attack",
         help="Load the current config into the Attack GUI page.",
-    ):
-        _on_send_to_attack_from_chat()
+        on_click=_on_send_to_attack_from_chat,
+    )
 
     _render_thread_list()
 
 
 def _on_send_to_attack_from_chat() -> None:
-    """Push the current chat config to the Attack page."""
+    """Button on_click callback: push the current chat config to the Attack page."""
     chat_cfg = st.session_state.get("chat_config")
     if chat_cfg is None:
         return
-    st.session_state.attack_config = chat_cfg
-    if chat_cfg.agents:
-        st.session_state.attack_target_agent_id = chat_cfg.agents[0].agent_id
-    for key in ("attack_result", "attack_verdict", "attack_node_states"):
-        st.session_state.pop(key, None)
-    st.toast("Config loaded in Attack Suite \u2713")
+    push_config_to_attack_state(chat_cfg)
 
 
 # ---------------------------------------------------------------------------

--- a/bili/aether/ui/components/attack_graph.py
+++ b/bili/aether/ui/components/attack_graph.py
@@ -1,0 +1,191 @@
+"""
+Attack graph component — MAS flow graph with click-to-target and post-run overlay.
+
+Wraps ``convert_mas_to_graph()`` and ``streamlit_flow()`` to provide:
+- Click-to-target: clicking a node sets it as the attack target (red border).
+- Post-run overlay: node borders are color-coded by propagation outcome after
+  an attack completes (influenced=red, resisted=green, received=yellow).
+
+The graph state is rebuilt on every render so that style overrides always
+reflect the current ``target_agent_id`` and ``node_states`` values.
+"""
+
+import streamlit as st
+
+# pylint: disable=import-error
+from streamlit_flow import streamlit_flow
+from streamlit_flow.elements import StreamlitFlowNode
+from streamlit_flow.state import StreamlitFlowState
+
+from bili.aether.schema.mas_config import MASConfig
+from bili.aether.ui.converters.yaml_to_graph import convert_mas_to_graph
+
+# ---------------------------------------------------------------------------
+# Style constants
+# ---------------------------------------------------------------------------
+
+_TARGET_BORDER = "3px solid #DC2626"  # Red — targeted node
+_INFLUENCED_BORDER = "3px solid #DC2626"  # Red — payload influenced output
+_RESISTED_BORDER = "3px solid #16A34A"  # Green — received but resisted
+_RECEIVED_BORDER = "3px solid #CA8A04"  # Yellow/amber — received payload
+_BORDER_RADIUS = "4px"
+
+_NODE_STATE_BORDERS: dict[str, str] = {
+    "influenced": _INFLUENCED_BORDER,
+    "resisted": _RESISTED_BORDER,
+    "received": _RECEIVED_BORDER,
+    # "clean" → no override (keep role-based default style)
+}
+
+_LEGEND_TEXT = (
+    "🔴 Influenced &nbsp;&nbsp; 🟢 Resisted &nbsp;&nbsp; "
+    "🟡 Received payload &nbsp;&nbsp; ⚪ Clean"
+)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def render_attack_graph(
+    config: MASConfig,
+    target_agent_id: str | None,
+    node_states: dict[str, str] | None = None,
+) -> str | None:
+    """Render the MAS flow graph with click-to-target and optional propagation overlay.
+
+    Args:
+        config: The MASConfig to visualize.
+        target_agent_id: The currently selected attack target node ID (red border).
+        node_states: Optional dict mapping agent_id to state string
+            (``"influenced"``, ``"resisted"``, ``"received"``, or ``"clean"``).
+            Pass ``None`` before any attack has been run.
+
+    Returns:
+        The ``agent_id`` of the clicked node, or ``None`` if no click occurred.
+    """
+    nodes, edges = convert_mas_to_graph(config)
+    styled_nodes = _apply_style_overrides(nodes, target_agent_id, node_states)
+
+    flow_key = f"attack_graph_{config.mas_id}"
+    state_key = f"attack_flow_{config.mas_id}"
+
+    # Always rebuild state so style overrides are always fresh.
+    st.session_state[state_key] = StreamlitFlowState(styled_nodes, edges)
+
+    st.session_state[state_key] = streamlit_flow(
+        key=flow_key,
+        state=st.session_state[state_key],
+        height=420,
+        fit_view=True,
+        show_controls=True,
+        show_minimap=False,
+        allow_new_edges=False,
+        pan_on_drag=True,
+        allow_zoom=True,
+        min_zoom=0.3,
+        get_node_on_click=True,
+        get_edge_on_click=False,
+        enable_pane_menu=False,
+        enable_node_menu=False,
+        enable_edge_menu=False,
+        hide_watermark=True,
+    )
+
+    if node_states is not None:
+        st.caption(_LEGEND_TEXT, unsafe_allow_html=True)
+
+    selected_id: str | None = st.session_state[state_key].selected_id
+    # Only return agent node clicks (not edge clicks or None)
+    if selected_id and config.get_agent(selected_id) is not None:
+        return selected_id
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _apply_style_overrides(
+    nodes: list[StreamlitFlowNode],
+    target_agent_id: str | None,
+    node_states: dict[str, str] | None,
+) -> list[StreamlitFlowNode]:
+    """Return a new list of nodes with border style overrides applied.
+
+    Priority (highest wins): post-run state override > target selection.
+    """
+    result: list[StreamlitFlowNode] = []
+    for node in nodes:
+        border: str | None = None
+
+        # Post-run state overrides take priority
+        if node_states and node.id in node_states:
+            state = node_states[node.id]
+            border = _NODE_STATE_BORDERS.get(state)
+        elif node.id == target_agent_id:
+            border = _TARGET_BORDER
+
+        if border is not None:
+            merged_style = {
+                **node.style,
+                "border": border,
+                "borderRadius": _BORDER_RADIUS,
+            }
+            node = _clone_node(node, merged_style)
+
+        result.append(node)
+    return result
+
+
+def _clone_node(node: StreamlitFlowNode, style: dict) -> StreamlitFlowNode:
+    """Return a new StreamlitFlowNode identical to *node* but with *style*."""
+    return StreamlitFlowNode(
+        id=node.id,
+        pos=node.pos,
+        data=node.data,
+        node_type=node.node_type,
+        source_position=node.source_position,
+        target_position=node.target_position,
+        draggable=node.draggable,
+        connectable=node.connectable,
+        deletable=node.deletable,
+        style=style,
+    )
+
+
+def build_node_states(agent_observations: list) -> dict[str, str]:
+    """Build a node_states dict from a list of AgentObservation objects or dicts.
+
+    Args:
+        agent_observations: List of ``AgentObservation`` objects (or dicts
+            with the same field names) from an ``AttackResult``.
+
+    Returns:
+        Dict mapping ``agent_id`` to state string for graph overlay.
+    """
+    states: dict[str, str] = {}
+    for obs in agent_observations:
+        # Support both object attribute access and dict key access
+        if hasattr(obs, "agent_id"):
+            agent_id = obs.agent_id
+            influenced = obs.influenced
+            resisted = obs.resisted
+            received = obs.received_payload
+        else:
+            agent_id = obs["agent_id"]
+            influenced = obs["influenced"]
+            resisted = obs["resisted"]
+            received = obs["received_payload"]
+
+        if influenced:
+            states[agent_id] = "influenced"
+        elif resisted:
+            states[agent_id] = "resisted"
+        elif received:
+            states[agent_id] = "received"
+        else:
+            states[agent_id] = "clean"
+    return states

--- a/bili/aether/ui/components/attack_graph.py
+++ b/bili/aether/ui/components/attack_graph.py
@@ -70,9 +70,23 @@ def render_attack_graph(
 
     flow_key = f"attack_graph_{config.mas_id}"
     state_key = f"attack_flow_{config.mas_id}"
+    version_key = f"attack_flow_version_{config.mas_id}"
 
-    # Always rebuild state so style overrides are always fresh.
-    st.session_state[state_key] = StreamlitFlowState(styled_nodes, edges)
+    # Only rebuild StreamlitFlowState when something that affects node appearance
+    # has actually changed (config, target, or post-run overlay).  Rebuilding on
+    # every render sends fresh state to the component, which fires a state-update
+    # event back to Streamlit, causing an infinite rerun loop.
+    graph_version = (
+        config.mas_id,
+        target_agent_id,
+        str(node_states),
+    )
+    if (
+        state_key not in st.session_state
+        or st.session_state.get(version_key) != graph_version
+    ):
+        st.session_state[state_key] = StreamlitFlowState(styled_nodes, edges)
+        st.session_state[version_key] = graph_version
 
     st.session_state[state_key] = streamlit_flow(
         key=flow_key,
@@ -96,7 +110,7 @@ def render_attack_graph(
     if node_states is not None:
         st.caption(_LEGEND_TEXT, unsafe_allow_html=True)
 
-    selected_id: str | None = st.session_state[state_key].selected_id
+    selected_id: str | None = getattr(st.session_state[state_key], "selected_id", None)
     # Only return agent node clicks (not edge clicks or None)
     if selected_id and config.get_agent(selected_id) is not None:
         return selected_id
@@ -141,12 +155,20 @@ def _apply_style_overrides(
 
 
 def _clone_node(node: StreamlitFlowNode, style: dict) -> StreamlitFlowNode:
-    """Return a new StreamlitFlowNode identical to *node* but with *style*."""
+    """Return a new StreamlitFlowNode identical to *node* but with *style*.
+
+    Note: copies only the fields known at the time of writing.  If a future
+    version of streamlit-flow-component adds new node attributes they will be
+    silently dropped here — update this function accordingly.
+    """
+    # StreamlitFlowNode stores pos as self.position ({"x": ..., "y": ...})
+    # and node_type as self.type — use those attribute names when reading back.
+    pos = (node.position["x"], node.position["y"])
     return StreamlitFlowNode(
         id=node.id,
-        pos=node.pos,
+        pos=pos,
         data=node.data,
-        node_type=node.node_type,
+        node_type=node.type,
         source_position=node.source_position,
         target_position=node.target_position,
         draggable=node.draggable,

--- a/bili/aether/ui/page.py
+++ b/bili/aether/ui/page.py
@@ -31,6 +31,7 @@ except ImportError:
     st.stop()
 
 from bili.aether.config.loader import load_mas_from_yaml
+from bili.aether.ui.attack_page import push_config_to_attack_state
 from bili.aether.ui.chat_app import render_main as render_chat_main
 from bili.aether.ui.chat_app import (
     render_sidebar_content as render_chat_sidebar_content,
@@ -255,13 +256,7 @@ def _on_send_to_attack() -> None:
     if config is None:
         return
     config = apply_agent_overrides(config)
-    st.session_state.attack_config = config
-    if config.agents:
-        st.session_state.attack_target_agent_id = config.agents[0].agent_id
-    # Clear previous attack state so the new config starts fresh
-    for key in ("attack_result", "attack_verdict", "attack_node_states"):
-        st.session_state.pop(key, None)
-    st.toast("Config loaded in Attack Suite ✓")
+    push_config_to_attack_state(config)
 
 
 def _load_config(yaml_path: Path) -> None:

--- a/bili/aether/ui/page.py
+++ b/bili/aether/ui/page.py
@@ -249,6 +249,21 @@ def _on_send_to_chat() -> None:
     st.session_state.chat_autoload_name = name
 
 
+def _on_send_to_attack() -> None:
+    """Button callback: push the current visualizer config to the Attack page."""
+    config = st.session_state.get("mas_config")
+    if config is None:
+        return
+    config = apply_agent_overrides(config)
+    st.session_state.attack_config = config
+    if config.agents:
+        st.session_state.attack_target_agent_id = config.agents[0].agent_id
+    # Clear previous attack state so the new config starts fresh
+    for key in ("attack_result", "attack_verdict", "attack_node_states"):
+        st.session_state.pop(key, None)
+    st.toast("Config loaded in Attack Suite ✓")
+
+
 def _load_config(yaml_path: Path) -> None:
     """Load a YAML config and store it in session state."""
     current_path = st.session_state.get("current_yaml_path")
@@ -287,6 +302,13 @@ def _load_config(yaml_path: Path) -> None:
         disabled=st.session_state.get("mas_config") is None,
         use_container_width=True,
         on_click=_on_send_to_chat,
+    )
+    st.button(
+        "Send to Attack Suite \u2192",
+        disabled=st.session_state.get("mas_config") is None,
+        use_container_width=True,
+        on_click=_on_send_to_attack,
+        key="vis_send_to_attack",
     )
     st.markdown("---")
     st.markdown(f"**MAS ID:** `{config.mas_id}`")

--- a/bili/streamlit_app.py
+++ b/bili/streamlit_app.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import streamlit as st
 from PIL import Image
 
+from bili.aether.ui.attack_page import render_attack_page
 from bili.aether.ui.attack_results_page import render_attack_results_page
 from bili.aether.ui.page import render_aether_page
 from bili.aether.ui.results_page import render_results_page
@@ -67,6 +68,12 @@ def main():
                 title="Attack Results",
                 url_path="attack-results",
                 icon=":material/security:",
+            ),
+            st.Page(
+                _run_attack_page,
+                title="Attack",
+                url_path="attack",
+                icon=":material/gps_fixed:",
             ),
             st.Page(
                 _run_bilicore_page,
@@ -163,6 +170,11 @@ def _run_results_page():
 def _run_attack_results_page():
     """Render the AETHER attack suite results viewer page."""
     render_attack_results_page()
+
+
+def _run_attack_page():
+    """Render the AETHER interactive Attack GUI page."""
+    render_attack_page()
 
 
 # Run the main function when the script is executed.


### PR DESCRIPTION
### This PR introduces the following changes

* Adds a new **Attack GUI** page (`bili/aether/ui/attack_page.py`) that exposes the AETHER attack framework for interactive, manual exploratory testing alongside the automated suite runners
* Adds `bili/aether/ui/components/attack_graph.py` — a reusable graph component wrapping `streamlit_flow` with click-to-target node selection and a post-run propagation overlay (red = influenced, green = resisted, yellow = received payload)
* Registers the Attack page in `bili/streamlit_app.py` under the `/attack` URL with a `gps_fixed` nav icon
* Adds a **"Send to Attack Suite →"** button to the Visualizer sidebar (`page.py`) that loads the current config (with any agent overrides applied) into the Attack page
* Adds a **"Send to Attack Suite →"** button to the Chat sidebar (`chat_app.py`) that loads the active chat config into the Attack page
* Pre-execution attacks stream token-by-token using the same `run_streaming_tokens()` loop pattern as the Chat page — strategies are applied directly to get a patched config, which is then streamed through a `MASExecutor`, with `PropagationTracker.observe()` called on each `__node_complete__` event
* Mid-execution attacks run synchronously via `AttackInjector.inject_attack()` with a spinner
* Supports library payloads (all five suites: injection, jailbreak, memory poisoning, bias inheritance, agent impersonation) and arbitrary custom payload text
* Tier 3 semantic evaluation runs automatically after each attack unless: the config is in stub mode, or no baseline result files exist for the loaded MAS ID
* Displays a circularity warning before Tier 3 evaluation when the attack MAS and the evaluator model share the same provider family


### Steps to Review

1. Checkout the `65-task-26-attack-gui` branch on your local machine
2. Start the Streamlit app (`streamlit` alias or `python run_aether_ui.py`) and confirm an **Attack** nav item appears in the sidebar
3. Navigate to **AETHER Multi-Agent → Visualizer**, load any example config, and click **"Send to Attack Suite →"** — then navigate to the Attack page and confirm the config is loaded with the first agent pre-selected as the target
4. Repeat from the **Chat** page: load a config, confirm the Chat sidebar shows **"Send to Attack Suite →"**, click it, then navigate to Attack and confirm the config loaded correctly
5. On the Attack page: select the **Injection** suite, pick any library payload, confirm the payload preview text renders in the disabled text area
6. Click a different graph node — confirm the red border moves to the clicked node and the metadata bar updates to show the new target
7. With phase set to **pre_execution**, click **Run Attack** — confirm tokens stream per-agent in real time, and after completion the graph re-renders with the propagation overlay and Tier 1/2 results display correctly
8. Switch phase to **mid_execution**, run again — confirm the spinner appears and results display after completion
9. Load a stub-mode config (all agents with `model_name: null`), run an attack, and confirm Tier 3 shows "Semantic evaluation skipped in stub mode."
10. Switch payload source to **Custom**, enter arbitrary text, run the attack, and confirm the framework processes it identically to a library payload
