### PR TITLE
143 update to allow user selection of which prompts to run for baseline and attack suites

### DIFF
--- a/bili/aegis/attacks/injector.py
+++ b/bili/aegis/attacks/injector.py
@@ -236,6 +236,7 @@ class AttackInjector:
             propagation_path=tracker.propagation_path() if tracker else [],
             influenced_agents=tracker.influenced_agents() if tracker else [],
             resistant_agents=tracker.resistant_agents() if tracker else [],
+            agent_observations=tracker.observations if tracker else [],
             success=error is None,
             error=error,
         )

--- a/bili/aegis/evaluator/evaluator_config.py
+++ b/bili/aegis/evaluator/evaluator_config.py
@@ -1,6 +1,6 @@
 """Configuration constants for the AETHER SemanticEvaluator.
 
-Primary model:  Claude 3.7 Sonnet (Bedrock cross-region profile) — deterministic at temperature 0.0
+Primary model:  Claude Sonnet 4 (Bedrock cross-region profile) — deterministic at temperature 0.0
 Fallback model: Gemini 2.5 Flash (Vertex)   — deterministic at temperature 0.0
 
 Both models are intentionally from different provider families so that

--- a/bili/aegis/evaluator/evaluator_config.py
+++ b/bili/aegis/evaluator/evaluator_config.py
@@ -26,8 +26,8 @@ The evaluator instructs the LLM to return a JSON object with three fields:
 # Evaluator models
 # ---------------------------------------------------------------------------
 
-PRIMARY_EVALUATOR_MODEL: str = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
-PRIMARY_EVALUATOR_MODEL_DISPLAY: str = "Primary — Claude 3.7 Sonnet (Bedrock)"
+PRIMARY_EVALUATOR_MODEL: str = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+PRIMARY_EVALUATOR_MODEL_DISPLAY: str = "Primary — Claude Sonnet 4 (Bedrock)"
 
 FALLBACK_EVALUATOR_MODEL: str = "gemini-2.5-flash"
 FALLBACK_EVALUATOR_MODEL_DISPLAY: str = "Fallback — Gemini 2.5 Flash (Vertex)"

--- a/bili/aegis/evaluator/semantic_evaluator.py
+++ b/bili/aegis/evaluator/semantic_evaluator.py
@@ -283,6 +283,7 @@ class SemanticEvaluator:
                 "SemanticEvaluator: evaluation failed for agent '%s': %s",
                 agent_id,
                 exc,
+                exc_info=True,
             )
             return VerdictResult(
                 agent_id=agent_id,

--- a/bili/aegis/suites/_helpers.py
+++ b/bili/aegis/suites/_helpers.py
@@ -130,3 +130,47 @@ def model_id_safe(model_id: str | None) -> str:
         .replace("-", "_")
         .lower()
     )
+
+
+def next_run_dir(base_dir: Path) -> Path:
+    """Return the next run directory path (``run_001``, ``run_002``, …) under *base_dir*.
+
+    Creates *base_dir* if it does not exist.  Does **not** create the run
+    directory itself — the caller is responsible for creating it when the
+    first result is written.
+
+    Args:
+        base_dir: The ``mas_id``-level results directory.
+
+    Returns:
+        Path to the next run directory, e.g. ``base_dir / "run_003"``.
+    """
+    base_dir.mkdir(parents=True, exist_ok=True)
+    existing = sorted(
+        d
+        for d in base_dir.iterdir()
+        if d.is_dir() and d.name.startswith("run_") and d.name[4:].isdigit()
+    )
+    return base_dir / f"run_{len(existing) + 1:03d}"
+
+
+def latest_run_dir(base_dir: Path) -> "Path | None":
+    """Return the most recent run directory under *base_dir*, or ``None``.
+
+    Returns ``None`` when *base_dir* does not exist or contains no
+    ``run_NNN`` subdirectories (i.e. the flat legacy structure is in use).
+
+    Args:
+        base_dir: The ``mas_id``-level results directory.
+
+    Returns:
+        Path to the most recent ``run_NNN`` directory, or ``None``.
+    """
+    if not base_dir.exists():
+        return None
+    existing = sorted(
+        d
+        for d in base_dir.iterdir()
+        if d.is_dir() and d.name.startswith("run_") and d.name[4:].isdigit()
+    )
+    return existing[-1] if existing else None

--- a/bili/aegis/suites/_helpers.py
+++ b/bili/aegis/suites/_helpers.py
@@ -33,6 +33,12 @@ CONFIG_PATHS: list[str] = [
     "bili/aether/config/examples/custom_escalation.yaml",
 ]
 
+#: Default path to the baseline results directory, relative to the repo root.
+#: Used by all attack suite runners as the default value for ``--baseline-results``
+#: so that Tier 3 semantic evaluation runs automatically in real mode without
+#: requiring the flag to be passed explicitly.
+DEFAULT_BASELINE_RESULTS_DIR: str = "bili/aegis/suites/baseline/results"
+
 
 def find_repo_root() -> Path:
     """Walk up from this file until a ``.git`` directory is found.

--- a/bili/aegis/suites/_suite_runner.py
+++ b/bili/aegis/suites/_suite_runner.py
@@ -229,8 +229,7 @@ def _run_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-
     full_path = repo_root / yaml_path
     if not full_path.exists():
         print(f"  Config not found, skipping: {yaml_path}", file=sys.stderr)
-        fallback_dir = results_dir / Path(yaml_path).stem / "run_000"
-        return [], fallback_dir
+        return [], None
 
     config = load_mas_from_yaml(str(full_path))
     if stub_mode:
@@ -432,7 +431,7 @@ def run_suite(  # pylint: disable=too-many-arguments,too-many-positional-argumen
             attack_type=attack_type,
         )
         all_matrix_rows.extend(rows)
-        if first_run_dir_name is None:
+        if first_run_dir_name is None and run_dir is not None:
             first_run_dir_name = run_dir.name
 
     if all_matrix_rows:

--- a/bili/aegis/suites/_suite_runner.py
+++ b/bili/aegis/suites/_suite_runner.py
@@ -23,6 +23,7 @@ from bili.aegis.attacks.models import InjectionPhase
 from bili.aegis.security.detector import SecurityEventDetector
 from bili.aegis.security.logger import SecurityEventLogger
 from bili.aegis.suites._helpers import config_fingerprint as _config_fingerprint_helper
+from bili.aegis.suites._helpers import latest_run_dir, next_run_dir
 from bili.aether.config.loader import load_mas_from_yaml
 from bili.aether.runtime.executor import MASExecutor
 
@@ -127,9 +128,16 @@ def _build_result_dict(
     }
 
 
-def _write_result(result_dict: dict, results_dir: Path) -> Path:
-    """Write one result JSON to results_dir/{mas_id}/{payload_id}_{phase}.json."""
-    out_dir = results_dir / result_dict["mas_id"]
+def _write_result(
+    result_dict: dict, results_dir: Path, run_dir: Path | None = None
+) -> Path:
+    """Write one result JSON to run_dir/{payload_id}_{phase}.json.
+
+    When *run_dir* is provided it is used directly (versioned layout).
+    Falls back to the legacy ``results_dir/{mas_id}/`` flat layout when
+    *run_dir* is ``None`` so existing callers continue to work unchanged.
+    """
+    out_dir = run_dir if run_dir is not None else (results_dir / result_dict["mas_id"])
     out_dir.mkdir(parents=True, exist_ok=True)
     filename = f"{result_dict['payload_id']}_{result_dict['injection_phase']}.json"
     out_path = out_dir / filename
@@ -174,15 +182,22 @@ def _load_baseline(
 ) -> dict | None:
     """Try to load a baseline result for Tier 3 comparison.
 
+    Prefers the most recent ``run_NNN`` subdirectory under
+    ``baseline_results_dir / mas_id``; falls back to the flat legacy layout
+    when no versioned run directories exist.
+
     Returns the first available baseline result for this config
-    (alphabetically), or ``None`` if no baseline is available.
+    (alphabetically within the resolved directory), or ``None`` if no
+    baseline is available.
     """
     if baseline_results_dir is None:
         return None
     config_baseline_dir = baseline_results_dir / mas_id
-    if not config_baseline_dir.exists():
+    run_dir = latest_run_dir(config_baseline_dir)
+    search_dir = run_dir if run_dir is not None else config_baseline_dir
+    if not search_dir.exists():
         return None
-    result_files = sorted(config_baseline_dir.glob("*.json"))
+    result_files = sorted(search_dir.glob("*.json"))
     if not result_files:
         return None
     try:
@@ -203,15 +218,17 @@ def _run_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-
     repo_root: Path,
     attack_suite: str,
     attack_type: str,
-) -> list[dict]:
+) -> tuple[list[dict], Path]:
     """Run all payloads × phases for one MAS config.
 
-    Returns a list of CSV matrix row dicts.
+    Returns a ``(matrix_rows, run_dir)`` tuple.  *run_dir* is the versioned
+    ``run_NNN`` directory created for this run's result files.
     """
     full_path = repo_root / yaml_path
     if not full_path.exists():
         print(f"  Config not found, skipping: {yaml_path}", file=sys.stderr)
-        return []
+        fallback_dir = results_dir / Path(yaml_path).stem / "run_000"
+        return [], fallback_dir
 
     config = load_mas_from_yaml(str(full_path))
     if stub_mode:
@@ -222,9 +239,10 @@ def _run_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-
     target_id = _target_agent_id(config)
 
     config_results_dir = results_dir / mas_id
-    config_results_dir.mkdir(parents=True, exist_ok=True)
-    attack_log_path = config_results_dir / "attack_log.ndjson"
-    sec_log_path = config_results_dir / "security_events.ndjson"
+    run_dir = next_run_dir(config_results_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    attack_log_path = run_dir / "attack_log.ndjson"
+    sec_log_path = run_dir / "security_events.ndjson"
 
     sec_logger = SecurityEventLogger(log_path=sec_log_path)
     detector = SecurityEventDetector(
@@ -323,7 +341,7 @@ def _run_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-
                     repo_root=repo_root,
                 )
 
-                out_path = _write_result(result_dict, results_dir)
+                out_path = _write_result(result_dict, results_dir, run_dir=run_dir)
                 status = "ok" if attack_result.success else "FAIL"
                 influenced_count = len(attack_result.influenced_agents)
                 print(f"{status}  (influenced={influenced_count}) → {out_path.name}")
@@ -353,7 +371,7 @@ def _run_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-
                     }
                 )
 
-    return matrix_rows
+    return matrix_rows, run_dir
 
 
 # ---------------------------------------------------------------------------
@@ -396,8 +414,9 @@ def run_suite(  # pylint: disable=too-many-arguments,too-many-positional-argumen
         baseline_results_dir: Path to baseline results for Tier 3 comparison.
     """
     all_matrix_rows: list[dict] = []
+    first_run_dir_name: str | None = None
     for yaml_path in config_paths:
-        rows = _run_config(
+        rows, run_dir = _run_config(
             yaml_path=yaml_path,
             payloads=payloads,
             phases=phases,
@@ -410,9 +429,13 @@ def run_suite(  # pylint: disable=too-many-arguments,too-many-positional-argumen
             attack_type=attack_type,
         )
         all_matrix_rows.extend(rows)
+        if first_run_dir_name is None:
+            first_run_dir_name = run_dir.name
 
     if all_matrix_rows:
-        csv_path = _write_csv(all_matrix_rows, results_dir, csv_filename)
+        csv_stem = Path(csv_filename).stem
+        versioned_csv = f"{csv_stem}_{first_run_dir_name}.csv"
+        csv_path = _write_csv(all_matrix_rows, results_dir, versioned_csv)
         _print_summary(all_matrix_rows, suite_name)
         print(f"Results matrix written to: {csv_path}")
 

--- a/bili/aegis/suites/_suite_runner.py
+++ b/bili/aegis/suites/_suite_runner.py
@@ -120,7 +120,9 @@ def _build_result_dict(
         "run_metadata": {
             "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             "stub_mode": stub_mode,
-            "semantic_tier": "skipped" if stub_mode else "evaluated",
+            "semantic_tier": (
+                "skipped" if (stub_mode or tier3_rows is None) else "evaluated"
+            ),
             "tier3_score": tier3_score,
             "tier3_confidence": tier3_confidence,
             "tier3_reasoning": tier3_reasoning,
@@ -322,11 +324,12 @@ def _run_config(  # pylint: disable=too-many-locals,too-many-arguments,too-many-
                         except (
                             Exception
                         ) as t3_exc:  # pylint: disable=broad-exception-caught
-                            LOGGER.warning(
+                            LOGGER.error(
                                 "SemanticEvaluator failed for %s/%s: %s",
                                 ip.payload_id,
                                 phase,
                                 t3_exc,
+                                exc_info=True,
                             )
 
                 result_dict = _build_result_dict(

--- a/bili/aegis/suites/agent_impersonation/run_agent_impersonation_suite.py
+++ b/bili/aegis/suites/agent_impersonation/run_agent_impersonation_suite.py
@@ -75,6 +75,7 @@ from bili.aegis.attacks.models import (  # noqa: E402  pylint: disable=wrong-imp
 )
 from bili.aegis.suites._helpers import (  # noqa: E402  pylint: disable=wrong-import-position
     CONFIG_PATHS,
+    DEFAULT_BASELINE_RESULTS_DIR,
 )
 from bili.aegis.suites._suite_runner import (  # noqa: E402  pylint: disable=wrong-import-position
     run_suite,
@@ -137,12 +138,12 @@ def main() -> None:
     )
     parser.add_argument(
         "--baseline-results",
-        default=None,
+        default=DEFAULT_BASELINE_RESULTS_DIR,
         metavar="DIR",
         help=(
-            "Path to baseline results directory for Tier 3 comparison "
-            "(e.g. bili/aegis/suites/baseline/results). "
-            "Required for real-mode Tier 3 evaluation."
+            "Path to baseline results directory for Tier 3 comparison. "
+            f"Defaults to '{DEFAULT_BASELINE_RESULTS_DIR}'. "
+            "Pass an explicit path to override."
         ),
     )
     parser.add_argument(

--- a/bili/aegis/suites/analysis/generate_stats.py
+++ b/bili/aegis/suites/analysis/generate_stats.py
@@ -45,21 +45,34 @@ except StopIteration as exc:
         f"in parents of {_SCRIPT_DIR}"
     ) from exc
 
+_SUITES_BASE = _REPO_ROOT / "bili" / "aegis" / "suites"
+
 _SUITE_DIRS = {
-    "injection": _REPO_ROOT / "bili" / "aether" / "tests" / "injection" / "results",
-    "jailbreak": _REPO_ROOT / "bili" / "aether" / "tests" / "jailbreak" / "results",
-    "memory_poisoning": (
-        _REPO_ROOT / "bili" / "aether" / "tests" / "memory_poisoning" / "results"
-    ),
-    "bias_inheritance": (
-        _REPO_ROOT / "bili" / "aether" / "tests" / "bias_inheritance" / "results"
-    ),
-    "agent_impersonation": (
-        _REPO_ROOT / "bili" / "aether" / "tests" / "agent_impersonation" / "results"
-    ),
-    "persistence": _REPO_ROOT / "bili" / "aether" / "tests" / "persistence" / "results",
-    "cross_model": _REPO_ROOT / "bili" / "aether" / "tests" / "cross_model" / "results",
+    "injection": _SUITES_BASE / "injection" / "results",
+    "jailbreak": _SUITES_BASE / "jailbreak" / "results",
+    "memory_poisoning": _SUITES_BASE / "memory_poisoning" / "results",
+    "bias_inheritance": _SUITES_BASE / "bias_inheritance" / "results",
+    "agent_impersonation": _SUITES_BASE / "agent_impersonation" / "results",
+    "persistence": _SUITES_BASE / "persistence" / "results",
+    "cross_model": _SUITES_BASE / "cross_model" / "results",
 }
+
+
+# ---------------------------------------------------------------------------
+# Run-dir utilities (inlined — this script has no bili imports)
+# ---------------------------------------------------------------------------
+
+
+def _latest_run_dir(base_dir: Path) -> "Path | None":
+    """Return the most recent run_NNN directory under *base_dir*, or None."""
+    if not base_dir.exists():
+        return None
+    existing = sorted(
+        d
+        for d in base_dir.iterdir()
+        if d.is_dir() and d.name.startswith("run_") and d.name[4:].isdigit()
+    )
+    return existing[-1] if existing else None
 
 
 # ---------------------------------------------------------------------------
@@ -67,16 +80,71 @@ _SUITE_DIRS = {
 # ---------------------------------------------------------------------------
 
 
-def _load_suite(suite_dir: Path) -> list[dict]:
-    """Load all ``*.json`` result files from *suite_dir* recursively."""
+def _load_suite(
+    suite_dir: Path,
+    run: "str | None" = None,
+    all_runs: bool = False,
+) -> list[dict]:
+    """Load ``*.json`` result files from *suite_dir*.
+
+    By default loads from the latest ``run_NNN`` directory under each
+    ``mas_id`` subdirectory, falling back to the flat legacy layout when no
+    versioned directories exist.
+
+    Args:
+        suite_dir:  Root results directory for one suite.
+        run:        Specific run dir name to load (e.g. ``"run_001"``).
+                    Applied per-mas_id; skips quietly when not present.
+        all_runs:   Load from ALL run directories (and flat legacy files).
+                    Overrides *run*.  Useful for cross-run aggregation.
+
+    Returns:
+        List of parsed result dicts.  Each dict gets a ``run_id`` key
+        injected with the source run directory name (``"run_000 (legacy)"``
+        for flat legacy files).
+    """
     results: list[dict] = []
     if not suite_dir.exists():
         return results
-    for path in sorted(suite_dir.glob("**/*.json")):
-        try:
-            results.append(json.loads(path.read_text(encoding="utf-8")))
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            LOGGER.warning("Could not parse %s: %s", path, exc)
+
+    for mas_dir in sorted(suite_dir.iterdir()):
+        if not mas_dir.is_dir():
+            continue
+
+        run_dirs = sorted(
+            d
+            for d in mas_dir.iterdir()
+            if d.is_dir() and d.name.startswith("run_") and d.name[4:].isdigit()
+        )
+
+        if all_runs:
+            search_dirs = run_dirs if run_dirs else [mas_dir]
+            run_id_map = {d: d.name for d in run_dirs}
+            if not run_dirs:
+                run_id_map[mas_dir] = "run_000 (legacy)"
+        elif run:
+            target = mas_dir / run
+            search_dirs = [target] if target.exists() else []
+            run_id_map = {target: run}
+        else:
+            latest = run_dirs[-1] if run_dirs else None
+            if latest is not None:
+                search_dirs = [latest]
+                run_id_map = {latest: latest.name}
+            else:
+                search_dirs = [mas_dir]
+                run_id_map = {mas_dir: "run_000 (legacy)"}
+
+        for search_dir in search_dirs:
+            rid = run_id_map.get(search_dir, "run_000 (legacy)")
+            for path in sorted(search_dir.glob("**/*.json")):
+                try:
+                    raw = json.loads(path.read_text(encoding="utf-8"))
+                    raw["run_id"] = rid
+                    results.append(raw)
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    LOGGER.warning("Could not parse %s: %s", path, exc)
+
     return results
 
 
@@ -367,13 +435,32 @@ def main() -> None:
             "Excluded by default for thesis-quality analysis."
         ),
     )
+    parser.add_argument(
+        "--run",
+        metavar="RUN_DIR",
+        default=None,
+        help=(
+            "Load results from a specific run directory (e.g. run_003). "
+            "Applied per-mas_id; silently skipped for mas_ids that lack that run. "
+            "Defaults to the latest run per mas_id."
+        ),
+    )
+    parser.add_argument(
+        "--all-runs",
+        action="store_true",
+        default=False,
+        help=(
+            "Aggregate results from ALL run directories (adds run_id field to stats). "
+            "Overrides --run.  Useful for cross-run trend analysis."
+        ),
+    )
     args = parser.parse_args()
 
     all_stats: dict = {}
     total_stub_excluded = 0
 
     for suite_name, suite_dir in _SUITE_DIRS.items():
-        results = _load_suite(suite_dir)
+        results = _load_suite(suite_dir, run=args.run, all_runs=args.all_runs)
         if not args.include_stub:
             real = [
                 r for r in results if not r.get("run_metadata", {}).get("stub_mode")

--- a/bili/aegis/suites/baseline/run_baseline.py
+++ b/bili/aegis/suites/baseline/run_baseline.py
@@ -58,6 +58,7 @@ from langchain_core.messages import (  # noqa: E402  pylint: disable=wrong-impor
 from bili.aegis.suites._helpers import (  # noqa: E402  pylint: disable=wrong-import-position
     config_fingerprint as _config_fingerprint_helper,
 )
+from bili.aegis.suites._helpers import next_run_dir
 from bili.aegis.suites.baseline.prompts.baseline_prompts import (  # noqa: E402  pylint: disable=wrong-import-position
     BASELINE_PROMPTS,
     BaselinePrompt,
@@ -140,9 +141,13 @@ def run_one(config, yaml_path: str, prompt: BaselinePrompt, stub_mode: bool) -> 
     }
 
 
-def write_result(result_dict: dict) -> Path:
-    """Write result dict to results/{mas_id}/{prompt_id}.json."""
-    out_dir = _RESULTS_DIR / result_dict["mas_id"]
+def write_result(result_dict: dict, run_dir: Path | None = None) -> Path:
+    """Write result dict to run_dir/{prompt_id}.json.
+
+    Falls back to the legacy flat layout ``results/{mas_id}/`` when
+    *run_dir* is ``None`` so direct callers continue to work unchanged.
+    """
+    out_dir = run_dir if run_dir is not None else (_RESULTS_DIR / result_dict["mas_id"])
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / f"{result_dict['prompt_id']}.json"
     out_path.write_text(json.dumps(result_dict, indent=2), encoding="utf-8")
@@ -238,13 +243,17 @@ def main() -> None:
             for agent in config.agents:
                 agent.model_name = None
         config_ids.append(config.mas_id)
-        print(f"\n[{config.mas_id}] Running {len(prompts)} prompts...")
+        run_dir = next_run_dir(_RESULTS_DIR / config.mas_id)
+        run_dir.mkdir(parents=True, exist_ok=True)
+        print(
+            f"\n[{config.mas_id}] Running {len(prompts)} prompts... (saving to {run_dir.name})"
+        )
 
         for prompt in prompts:
             print(f"  {prompt.prompt_id} ... ", end="", flush=True)
             try:
                 result = run_one(config, yaml_path, prompt, stub_mode=args.stub)
-                out_path = write_result(result)
+                out_path = write_result(result, run_dir=run_dir)
                 status = "ok" if result["execution"]["success"] else "FAIL"
                 print(
                     f"{status}  ({result['execution']['duration_ms']:.0f} ms) → {out_path}"
@@ -276,7 +285,7 @@ def main() -> None:
                         "semantic_tier": "skipped",
                     },
                 }
-                write_result(failed)
+                write_result(failed, run_dir=run_dir)
                 all_results.append(failed)
                 continue
 

--- a/bili/aegis/suites/bias_inheritance/run_bias_inheritance_suite.py
+++ b/bili/aegis/suites/bias_inheritance/run_bias_inheritance_suite.py
@@ -81,6 +81,7 @@ from bili.aegis.attacks.models import (  # noqa: E402  pylint: disable=wrong-imp
 )
 from bili.aegis.suites._helpers import (  # noqa: E402  pylint: disable=wrong-import-position
     CONFIG_PATHS,
+    DEFAULT_BASELINE_RESULTS_DIR,
 )
 from bili.aegis.suites._suite_runner import (  # noqa: E402  pylint: disable=wrong-import-position
     run_suite,
@@ -143,12 +144,12 @@ def main() -> None:
     )
     parser.add_argument(
         "--baseline-results",
-        default=None,
+        default=DEFAULT_BASELINE_RESULTS_DIR,
         metavar="DIR",
         help=(
-            "Path to baseline results directory for Tier 3 comparison "
-            "(e.g. bili/aegis/suites/baseline/results). "
-            "Required for real-mode Tier 3 evaluation."
+            "Path to baseline results directory for Tier 3 comparison. "
+            f"Defaults to '{DEFAULT_BASELINE_RESULTS_DIR}'. "
+            "Pass an explicit path to override."
         ),
     )
     parser.add_argument(

--- a/bili/aegis/suites/cross_model/run_cross_model_suite.py
+++ b/bili/aegis/suites/cross_model/run_cross_model_suite.py
@@ -120,7 +120,9 @@ from bili.aegis.suites._helpers import CONFIG_PATHS
 from bili.aegis.suites._helpers import (  # noqa: E402  pylint: disable=wrong-import-position
     config_fingerprint as _config_fingerprint_helper,
 )
+from bili.aegis.suites._helpers import latest_run_dir as _latest_run_dir
 from bili.aegis.suites._helpers import model_id_safe as _model_id_safe
+from bili.aegis.suites._helpers import next_run_dir as _next_run_dir
 from bili.aegis.suites.injection.payloads.prompt_injection_payloads import (  # noqa: E402  pylint: disable=wrong-import-position
     INJECTION_PAYLOADS,
 )
@@ -231,10 +233,19 @@ def _patch_config_model(config: Any, model_id: str | None) -> Any:
     return config.model_copy(update={"agents": patched_agents})
 
 
-def _write_result(result_dict: dict, results_dir: Path) -> Path:
-    """Write one result JSON to results_dir/{mas_id}/{model_id_safe}/{payload_id}_{phase}.json."""
+def _write_result(
+    result_dict: dict, results_dir: Path, run_dir: Path | None = None
+) -> Path:
+    """Write one result JSON to {run_dir}/{model_id_safe}/{payload_id}_{phase}.json.
+
+    Falls back to the legacy ``results_dir/{mas_id}/{model_id_safe}/`` flat layout
+    when *run_dir* is ``None`` so existing callers continue to work unchanged.
+    """
     model_safe = _model_id_safe(result_dict.get("model_id"))
-    out_dir = results_dir / result_dict["mas_id"] / model_safe
+    if run_dir is not None:
+        out_dir = run_dir / model_safe
+    else:
+        out_dir = results_dir / result_dict["mas_id"] / model_safe
     out_dir.mkdir(parents=True, exist_ok=True)
     filename = f"{result_dict['payload_id']}_{result_dict['injection_phase']}.json"
     out_path = out_dir / filename
@@ -242,10 +253,10 @@ def _write_result(result_dict: dict, results_dir: Path) -> Path:
     return out_path
 
 
-def _write_csv(rows: list[dict], results_dir: Path) -> Path:
-    """Write the cross-model results matrix CSV."""
+def _write_csv(rows: list[dict], results_dir: Path, csv_filename: str) -> Path:
+    """Write the cross-model results matrix CSV to results_dir/{csv_filename}."""
     results_dir.mkdir(parents=True, exist_ok=True)
-    csv_path = results_dir / "cross_model_matrix.csv"
+    csv_path = results_dir / csv_filename
     with csv_path.open("w", newline="", encoding="utf-8") as fh:
         writer = csv.DictWriter(fh, fieldnames=_CSV_COLUMNS)
         writer.writeheader()
@@ -254,13 +265,19 @@ def _write_csv(rows: list[dict], results_dir: Path) -> Path:
 
 
 def _load_baseline(baseline_results_dir: Path | None, mas_id: str) -> dict | None:
-    """Try to load a baseline result for Tier 3 comparison."""
+    """Try to load a baseline result for Tier 3 comparison.
+
+    Prefers the most recent ``run_NNN`` subdirectory; falls back to the flat
+    legacy layout when no versioned run directories exist.
+    """
     if baseline_results_dir is None:
         return None
     config_baseline_dir = baseline_results_dir / mas_id
-    if not config_baseline_dir.exists():
+    run_dir = _latest_run_dir(config_baseline_dir)
+    search_dir = run_dir if run_dir is not None else config_baseline_dir
+    if not search_dir.exists():
         return None
-    result_files = sorted(config_baseline_dir.glob("*.json"))
+    result_files = sorted(search_dir.glob("*.json"))
     if not result_files:
         return None
     try:
@@ -319,29 +336,32 @@ def _run_config_for_model(  # pylint: disable=too-many-locals,too-many-arguments
     baseline_results_dir: Path | None,
     results_dir: Path,
     repo_root: Path,
-) -> list[dict]:
+) -> tuple[list[dict], Path | None]:
     """Run all payloads × phases for one MAS config under one model.
 
     Returns:
-        List of CSV row dicts (one per payload × phase).  Skips with a warning
-        if the config file is not found.  Individual injection failures produce
-        a skip row rather than aborting the whole model run.
+        ``(matrix_rows, run_dir)`` tuple.  *run_dir* is the versioned
+        ``run_NNN`` directory created for this run's result files, or ``None``
+        when the config was not found and nothing was written.
     """
     full_path = repo_root / yaml_path
     if not full_path.exists():
         print(f"  Config not found, skipping: {yaml_path}", file=sys.stderr)
-        return []
+        return [], None
 
     base_config = load_mas_from_yaml(str(full_path))
     config = _patch_config_model(base_config, model_id)
     mas_id = config.mas_id
 
     model_safe = _model_id_safe(model_id)
-    config_results_dir = results_dir / mas_id / model_safe
-    config_results_dir.mkdir(parents=True, exist_ok=True)
+    run_dir = _next_run_dir(results_dir / mas_id)
+    run_dir.mkdir(parents=True, exist_ok=True)
 
-    attack_log_path = config_results_dir / "attack_log.ndjson"
-    sec_log_path = config_results_dir / "security_events.ndjson"
+    model_run_dir = run_dir / model_safe
+    model_run_dir.mkdir(parents=True, exist_ok=True)
+
+    attack_log_path = model_run_dir / "attack_log.ndjson"
+    sec_log_path = model_run_dir / "security_events.ndjson"
 
     sec_logger = SecurityEventLogger(log_path=sec_log_path)
     detector = SecurityEventDetector(
@@ -480,7 +500,7 @@ def _run_config_for_model(  # pylint: disable=too-many-locals,too-many-arguments
                         "tier3_reasoning": tier3_reasoning,
                     },
                 }
-                out_path = _write_result(result_dict, results_dir)
+                out_path = _write_result(result_dict, results_dir, run_dir=run_dir)
                 status = "ok" if attack_result.success else "FAIL"
                 influenced_count = len(attack_result.influenced_agents)
                 print(f"{status}  (influenced={influenced_count}) → {out_path.name}")
@@ -510,7 +530,7 @@ def _run_config_for_model(  # pylint: disable=too-many-locals,too-many-arguments
                     }
                 )
 
-    return matrix_rows
+    return matrix_rows, run_dir
 
 
 # ---------------------------------------------------------------------------
@@ -647,6 +667,7 @@ def main() -> None:
 
     # Run: outer loop = models, inner = configs × payloads × phases
     all_matrix_rows: list[dict] = []
+    first_run_dir_name: str | None = None
     for model_id, model_display_name in model_matrix:
         print(f"\n{'=' * 60}")
         print(f"Model: {model_display_name}")
@@ -654,7 +675,7 @@ def main() -> None:
             print(f"  model_id: {model_id}")
         print(f"{'=' * 60}")
         for yaml_path in args.configs:
-            rows = _run_config_for_model(
+            rows, run_dir = _run_config_for_model(
                 yaml_path=yaml_path,
                 model_id=model_id,
                 model_display_name=model_display_name,
@@ -667,9 +688,16 @@ def main() -> None:
                 repo_root=_REPO_ROOT,
             )
             all_matrix_rows.extend(rows)
+            if first_run_dir_name is None and run_dir is not None:
+                first_run_dir_name = run_dir.name
 
     if all_matrix_rows:
-        csv_path = _write_csv(all_matrix_rows, _RESULTS_DIR)
+        versioned_csv = (
+            f"cross_model_matrix_{first_run_dir_name}.csv"
+            if first_run_dir_name
+            else "cross_model_matrix.csv"
+        )
+        csv_path = _write_csv(all_matrix_rows, _RESULTS_DIR, versioned_csv)
         _print_summary(all_matrix_rows)
         print(f"Results matrix written to: {csv_path}")
 

--- a/bili/aegis/suites/cross_model/run_cross_model_suite.py
+++ b/bili/aegis/suites/cross_model/run_cross_model_suite.py
@@ -147,7 +147,7 @@ _ALL_PHASES: list[str] = [
 
 # Each entry: (model_id, human-readable display name).
 # model_id values must match entries in bili/iris/config/llm_config.py.
-_MODEL_MATRIX: list[tuple[str, str]] = [
+MODEL_MATRIX: list[tuple[str, str]] = [
     (
         "us.anthropic.claude-3-5-haiku-20241022-v1:0",
         "Claude 3.5 Haiku (Bedrock)",
@@ -706,17 +706,17 @@ def main() -> None:
         if args.models:
             model_ids = set(args.models)
             model_matrix = [
-                (mid, name) for mid, name in _MODEL_MATRIX if mid in model_ids
+                (mid, name) for mid, name in MODEL_MATRIX if mid in model_ids
             ]
             if not model_matrix:
                 print(
                     f"No models matched: {args.models}.  "
-                    f"Valid IDs: {[m[0] for m in _MODEL_MATRIX]}",
+                    f"Valid IDs: {[m[0] for m in MODEL_MATRIX]}",
                     file=sys.stderr,
                 )
                 sys.exit(1)
         else:
-            model_matrix = list(_MODEL_MATRIX)
+            model_matrix = list(MODEL_MATRIX)
 
     # Resolve baseline results dir
     baseline_results_dir: Path | None = None

--- a/bili/aegis/suites/cross_model/run_cross_model_suite.py
+++ b/bili/aegis/suites/cross_model/run_cross_model_suite.py
@@ -116,7 +116,7 @@ from bili.aegis.security.detector import (  # noqa: E402  pylint: disable=wrong-
 from bili.aegis.security.logger import (  # noqa: E402  pylint: disable=wrong-import-position
     SecurityEventLogger,
 )
-from bili.aegis.suites._helpers import CONFIG_PATHS
+from bili.aegis.suites._helpers import CONFIG_PATHS, DEFAULT_BASELINE_RESULTS_DIR
 from bili.aegis.suites._helpers import (  # noqa: E402  pylint: disable=wrong-import-position
     config_fingerprint as _config_fingerprint_helper,
 )
@@ -451,12 +451,13 @@ def _run_config_for_model(  # pylint: disable=too-many-locals,too-many-arguments
                         except (
                             Exception
                         ) as t3_exc:  # pylint: disable=broad-exception-caught
-                            LOGGER.warning(
+                            LOGGER.error(
                                 "SemanticEvaluator failed for %s/%s/%s: %s",
                                 model_id,
                                 ip.payload_id,
                                 phase,
                                 t3_exc,
+                                exc_info=True,
                             )
 
                 resistant_list = sorted(attack_result.resistant_agents)
@@ -494,7 +495,9 @@ def _run_config_for_model(  # pylint: disable=too-many-locals,too-many-arguments
                             datetime.timezone.utc
                         ).isoformat(),
                         "stub_mode": stub_mode,
-                        "semantic_tier": "skipped" if stub_mode else "evaluated",
+                        "semantic_tier": (
+                            "skipped" if (stub_mode or not tier3_score) else "evaluated"
+                        ),
                         "tier3_score": tier3_score,
                         "tier3_confidence": tier3_confidence,
                         "tier3_reasoning": tier3_reasoning,
@@ -531,6 +534,79 @@ def _run_config_for_model(  # pylint: disable=too-many-locals,too-many-arguments
                 )
 
     return matrix_rows, run_dir
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def run_cross_model_suite(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    *,
+    payloads: list,
+    config_paths: list[str],
+    phases: list[str],
+    model_matrix: list[tuple[str | None, str]],
+    stub_mode: bool,
+    semantic_evaluator: Any,
+    baseline_results_dir: Path | None,
+    results_dir: Path,
+    repo_root: Path,
+) -> tuple[list[dict], str | None]:
+    """Run the cross-model suite against *config_paths* and return results.
+
+    Unlike :func:`main`, this does **not** call ``sys.exit()`` — it is
+    designed to be called programmatically (e.g. from the AEGIS GUI batch
+    runner).
+
+    Args:
+        payloads:             Payload objects to test (typically injection payloads).
+        config_paths:         YAML config paths relative to *repo_root*.
+        phases:               Injection phases to run.
+        model_matrix:         List of ``(model_id, display_name)`` tuples.
+                              Pass ``[(None, "stub")]`` for stub mode.
+        stub_mode:            If ``True``, skip LLM calls.
+        semantic_evaluator:   Pre-constructed ``SemanticEvaluator`` instance,
+                              or ``None`` to skip Tier 3.
+        baseline_results_dir: Path to baseline results for Tier 3 comparison.
+        results_dir:          Directory where results are written.
+        repo_root:            Absolute path to the repository root.
+
+    Returns:
+        ``(all_matrix_rows, first_run_dir_name)`` tuple.
+    """
+    all_matrix_rows: list[dict] = []
+    first_run_dir_name: str | None = None
+
+    for model_id, model_display_name in model_matrix:
+        for yaml_path in config_paths:
+            rows, run_dir = _run_config_for_model(
+                yaml_path=yaml_path,
+                model_id=model_id,
+                model_display_name=model_display_name,
+                payloads=payloads,
+                phases=phases,
+                stub_mode=stub_mode,
+                semantic_evaluator=semantic_evaluator,
+                baseline_results_dir=baseline_results_dir,
+                results_dir=results_dir,
+                repo_root=repo_root,
+            )
+            all_matrix_rows.extend(rows)
+            if first_run_dir_name is None and run_dir is not None:
+                first_run_dir_name = run_dir.name
+
+    if all_matrix_rows:
+        versioned_csv = (
+            f"cross_model_matrix_{first_run_dir_name}.csv"
+            if first_run_dir_name
+            else "cross_model_matrix.csv"
+        )
+        csv_path = _write_csv(all_matrix_rows, results_dir, versioned_csv)
+        _print_summary(all_matrix_rows)
+        print(f"Results matrix written to: {csv_path}")
+
+    return all_matrix_rows, first_run_dir_name
 
 
 # ---------------------------------------------------------------------------
@@ -597,12 +673,12 @@ def main() -> None:
     )
     parser.add_argument(
         "--baseline-results",
-        default=None,
+        default=DEFAULT_BASELINE_RESULTS_DIR,
         metavar="DIR",
         help=(
-            "Path to baseline results directory for Tier 3 comparison "
-            "(e.g. bili/aegis/suites/baseline/results).  "
-            "Required for real-mode Tier 3 evaluation."
+            "Path to baseline results directory for Tier 3 comparison. "
+            f"Defaults to '{DEFAULT_BASELINE_RESULTS_DIR}'. "
+            "Pass an explicit path to override."
         ),
     )
     parser.add_argument(

--- a/bili/aegis/suites/injection/run_injection_suite.py
+++ b/bili/aegis/suites/injection/run_injection_suite.py
@@ -76,6 +76,7 @@ from bili.aegis.attacks.models import (  # noqa: E402  pylint: disable=wrong-imp
 )
 from bili.aegis.suites._helpers import (  # noqa: E402  pylint: disable=wrong-import-position
     CONFIG_PATHS,
+    DEFAULT_BASELINE_RESULTS_DIR,
 )
 from bili.aegis.suites._suite_runner import (  # noqa: E402  pylint: disable=wrong-import-position
     run_suite,
@@ -135,12 +136,12 @@ def main() -> None:
     )
     parser.add_argument(
         "--baseline-results",
-        default=None,
+        default=DEFAULT_BASELINE_RESULTS_DIR,
         metavar="DIR",
         help=(
-            "Path to baseline results directory for Tier 3 comparison "
-            "(e.g. bili/aegis/suites/baseline/results). "
-            "Required for real-mode Tier 3 evaluation."
+            "Path to baseline results directory for Tier 3 comparison. "
+            f"Defaults to '{DEFAULT_BASELINE_RESULTS_DIR}'. "
+            "Pass an explicit path to override."
         ),
     )
     parser.add_argument(

--- a/bili/aegis/suites/jailbreak/run_jailbreak_suite.py
+++ b/bili/aegis/suites/jailbreak/run_jailbreak_suite.py
@@ -74,6 +74,7 @@ from bili.aegis.attacks.models import (  # noqa: E402  pylint: disable=wrong-imp
 )
 from bili.aegis.suites._helpers import (  # noqa: E402  pylint: disable=wrong-import-position
     CONFIG_PATHS,
+    DEFAULT_BASELINE_RESULTS_DIR,
 )
 from bili.aegis.suites._suite_runner import (  # noqa: E402  pylint: disable=wrong-import-position
     run_suite,
@@ -133,12 +134,12 @@ def main() -> None:
     )
     parser.add_argument(
         "--baseline-results",
-        default=None,
+        default=DEFAULT_BASELINE_RESULTS_DIR,
         metavar="DIR",
         help=(
-            "Path to baseline results directory for Tier 3 comparison "
-            "(e.g. bili/aegis/suites/baseline/results). "
-            "Required for real-mode Tier 3 evaluation."
+            "Path to baseline results directory for Tier 3 comparison. "
+            f"Defaults to '{DEFAULT_BASELINE_RESULTS_DIR}'. "
+            "Pass an explicit path to override."
         ),
     )
     parser.add_argument(

--- a/bili/aegis/suites/memory_poisoning/run_memory_poisoning_suite.py
+++ b/bili/aegis/suites/memory_poisoning/run_memory_poisoning_suite.py
@@ -74,6 +74,7 @@ from bili.aegis.attacks.models import (  # noqa: E402  pylint: disable=wrong-imp
 )
 from bili.aegis.suites._helpers import (  # noqa: E402  pylint: disable=wrong-import-position
     CONFIG_PATHS,
+    DEFAULT_BASELINE_RESULTS_DIR,
 )
 from bili.aegis.suites._suite_runner import (  # noqa: E402  pylint: disable=wrong-import-position
     run_suite,
@@ -136,12 +137,12 @@ def main() -> None:
     )
     parser.add_argument(
         "--baseline-results",
-        default=None,
+        default=DEFAULT_BASELINE_RESULTS_DIR,
         metavar="DIR",
         help=(
-            "Path to baseline results directory for Tier 3 comparison "
-            "(e.g. bili/aegis/suites/baseline/results). "
-            "Required for real-mode Tier 3 evaluation."
+            "Path to baseline results directory for Tier 3 comparison. "
+            f"Defaults to '{DEFAULT_BASELINE_RESULTS_DIR}'. "
+            "Pass an explicit path to override."
         ),
     )
     parser.add_argument(

--- a/bili/aegis/suites/persistence/payloads/persistence_payloads.py
+++ b/bili/aegis/suites/persistence/payloads/persistence_payloads.py
@@ -271,3 +271,12 @@ PERSISTENCE_PAYLOADS: list[PersistencePayload] = [
         notes="Fabricates rapport and value-alignment framing to condition permissive tone",
     ),
 ]
+
+# ---------------------------------------------------------------------------
+# Lookup index
+# ---------------------------------------------------------------------------
+
+#: Lookup by ``payload_id`` — e.g. ``PAYLOADS_BY_ID["pe_session_001"]``.
+PAYLOADS_BY_ID: dict[str, PersistencePayload] = {
+    pp.payload_id: pp for pp in PERSISTENCE_PAYLOADS
+}

--- a/bili/aegis/suites/persistence/run_persistence_suite.py
+++ b/bili/aegis/suites/persistence/run_persistence_suite.py
@@ -106,6 +106,7 @@ from bili.aegis.suites._helpers import CONFIG_PATHS
 from bili.aegis.suites._helpers import (  # noqa: E402  pylint: disable=wrong-import-position
     config_fingerprint as _config_fingerprint_helper,
 )
+from bili.aegis.suites._helpers import latest_run_dir, next_run_dir
 from bili.aegis.suites.persistence.payloads.persistence_payloads import (  # noqa: E402  pylint: disable=wrong-import-position
     PERSISTENCE_PAYLOADS,
 )
@@ -199,9 +200,14 @@ def _checkpointer_is_persistent(config: Any) -> tuple[bool, str]:
 # ---------------------------------------------------------------------------
 
 
-def _write_result(result_dict: dict, results_dir: Path) -> Path:
-    """Write one result JSON to results_dir/{mas_id}/{payload_id}_{phase}.json."""
-    out_dir = results_dir / result_dict["mas_id"]
+def _write_result(
+    result_dict: dict, results_dir: Path, run_dir: Path | None = None
+) -> Path:
+    """Write one result JSON to run_dir/{payload_id}_{phase}.json.
+
+    Falls back to ``results_dir/{mas_id}/`` when *run_dir* is ``None``.
+    """
+    out_dir = run_dir if run_dir is not None else (results_dir / result_dict["mas_id"])
     out_dir.mkdir(parents=True, exist_ok=True)
     filename = f"{result_dict['payload_id']}_{result_dict['injection_phase']}.json"
     out_path = out_dir / filename
@@ -209,10 +215,10 @@ def _write_result(result_dict: dict, results_dir: Path) -> Path:
     return out_path
 
 
-def _write_csv(rows: list[dict], results_dir: Path) -> Path:
-    """Write the results matrix CSV."""
+def _write_csv(rows: list[dict], results_dir: Path, csv_filename: str) -> Path:
+    """Write the results matrix CSV to *results_dir*/*csv_filename*."""
     results_dir.mkdir(parents=True, exist_ok=True)
-    csv_path = results_dir / "persistence_results_matrix.csv"
+    csv_path = results_dir / csv_filename
     with csv_path.open("w", newline="", encoding="utf-8") as fh:
         writer = csv.DictWriter(fh, fieldnames=_CSV_COLUMNS)
         writer.writeheader()
@@ -253,14 +259,18 @@ def _run_persistence_config(
     baseline_results_dir: Path | None,
     results_dir: Path,
     repo_root: Path,
-) -> list[
-    dict
+) -> tuple[
+    list[dict], Path | None
 ]:  # pylint: disable=too-many-locals,too-many-arguments,too-many-positional-arguments
-    """Run all payloads for one MAS config, skipping if no persistent backend."""
+    """Run all payloads for one MAS config, skipping if no persistent backend.
+
+    Returns ``(matrix_rows, run_dir)``.  *run_dir* is ``None`` when the config
+    was skipped (no persistent backend available).
+    """
     full_path = repo_root / yaml_path
     if not full_path.exists():
         print(f"  Config not found, skipping: {yaml_path}", file=sys.stderr)
-        return []
+        return [], None
 
     config = load_mas_from_yaml(str(full_path))
     if stub_mode:
@@ -298,12 +308,13 @@ def _run_persistence_config(
                     "skip_reason": skip_reason,
                 }
             )
-        return skip_rows
+        return skip_rows, None
 
     config_results_dir = results_dir / mas_id
-    config_results_dir.mkdir(parents=True, exist_ok=True)
-    attack_log_path = config_results_dir / "attack_log.ndjson"
-    sec_log_path = config_results_dir / "security_events.ndjson"
+    run_dir = next_run_dir(config_results_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    attack_log_path = run_dir / "attack_log.ndjson"
+    sec_log_path = run_dir / "security_events.ndjson"
 
     sec_logger = SecurityEventLogger(log_path=sec_log_path)
     detector = SecurityEventDetector(
@@ -431,7 +442,7 @@ def _run_persistence_config(
                     "tier3_reasoning": tier3_reasoning,
                 },
             }
-            out_path = _write_result(result_dict, results_dir)
+            out_path = _write_result(result_dict, results_dir, run_dir=run_dir)
             status = "ok" if attack_result.success else "FAIL"
             influenced_count = len(attack_result.influenced_agents)
             print(f"{status}  (influenced={influenced_count}) → {out_path.name}")
@@ -458,17 +469,23 @@ def _run_persistence_config(
                 }
             )
 
-    return matrix_rows
+    return matrix_rows, run_dir
 
 
 def _load_baseline(baseline_results_dir: Path | None, mas_id: str) -> dict | None:
-    """Try to load a baseline result for Tier 3 comparison."""
+    """Try to load a baseline result for Tier 3 comparison.
+
+    Prefers the most recent ``run_NNN`` subdirectory; falls back to the flat
+    legacy layout when no versioned run directories exist.
+    """
     if baseline_results_dir is None:
         return None
     config_baseline_dir = baseline_results_dir / mas_id
-    if not config_baseline_dir.exists():
+    run_dir = latest_run_dir(config_baseline_dir)
+    search_dir = run_dir if run_dir is not None else config_baseline_dir
+    if not search_dir.exists():
         return None
-    result_files = sorted(config_baseline_dir.glob("*.json"))
+    result_files = sorted(search_dir.glob("*.json"))
     if not result_files:
         return None
     try:
@@ -577,8 +594,9 @@ def main() -> None:
             LOGGER.warning("Could not initialise SemanticEvaluator: %s", exc)
 
     all_matrix_rows: list[dict] = []
+    first_run_dir_name: str | None = None
     for yaml_path in args.configs:
-        rows = _run_persistence_config(
+        rows, run_dir = _run_persistence_config(
             yaml_path=yaml_path,
             payloads=payloads,
             stub_mode=args.stub,
@@ -588,9 +606,16 @@ def main() -> None:
             repo_root=_REPO_ROOT,
         )
         all_matrix_rows.extend(rows)
+        if first_run_dir_name is None and run_dir is not None:
+            first_run_dir_name = run_dir.name
 
     if all_matrix_rows:
-        csv_path = _write_csv(all_matrix_rows, _RESULTS_DIR)
+        csv_filename = (
+            f"persistence_results_matrix_{first_run_dir_name}.csv"
+            if first_run_dir_name
+            else "persistence_results_matrix.csv"
+        )
+        csv_path = _write_csv(all_matrix_rows, _RESULTS_DIR, csv_filename)
         _print_summary(all_matrix_rows)
         print(f"Results matrix written to: {csv_path}")
 

--- a/bili/aegis/suites/persistence/run_persistence_suite.py
+++ b/bili/aegis/suites/persistence/run_persistence_suite.py
@@ -397,11 +397,12 @@ def _run_persistence_config(
                     except (
                         Exception
                     ) as t3_exc:  # pylint: disable=broad-exception-caught
-                        LOGGER.warning(
+                        LOGGER.error(
                             "SemanticEvaluator failed for %s/%s: %s",
                             ip.payload_id,
                             _PHASE,
                             t3_exc,
+                            exc_info=True,
                         )
 
             resistant_list = sorted(attack_result.resistant_agents)
@@ -436,7 +437,9 @@ def _run_persistence_config(
                         datetime.timezone.utc
                     ).isoformat(),
                     "stub_mode": stub_mode,
-                    "semantic_tier": "skipped" if stub_mode else "evaluated",
+                    "semantic_tier": (
+                        "skipped" if (stub_mode or not tier3_score) else "evaluated"
+                    ),
                     "tier3_score": tier3_score,
                     "tier3_confidence": tier3_confidence,
                     "tier3_reasoning": tier3_reasoning,
@@ -493,6 +496,70 @@ def _load_baseline(baseline_results_dir: Path | None, mas_id: str) -> dict | Non
     except (OSError, json.JSONDecodeError) as exc:
         LOGGER.warning("Could not load baseline for %s: %s", mas_id, exc)
         return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def run_persistence_suite(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    *,
+    payloads: list,
+    config_paths: list[str],
+    stub_mode: bool,
+    semantic_evaluator: Any,
+    baseline_results_dir: Path | None,
+    results_dir: Path,
+    repo_root: Path,
+) -> tuple[list[dict], str | None]:
+    """Run the persistence suite against *config_paths* and return results.
+
+    Unlike :func:`main`, this does **not** call ``sys.exit()`` — it is
+    designed to be called programmatically (e.g. from the AEGIS GUI batch
+    runner).
+
+    Args:
+        payloads:             Persistence payload objects to test.
+        config_paths:         YAML config paths relative to *repo_root*.
+        stub_mode:            If ``True``, skip LLM calls.
+        semantic_evaluator:   Pre-constructed ``SemanticEvaluator`` instance,
+                              or ``None`` to skip Tier 3.
+        baseline_results_dir: Path to baseline results for Tier 3 comparison.
+        results_dir:          Directory where results are written.
+        repo_root:            Absolute path to the repository root.
+
+    Returns:
+        ``(all_matrix_rows, first_run_dir_name)`` tuple.
+    """
+    all_matrix_rows: list[dict] = []
+    first_run_dir_name: str | None = None
+
+    for yaml_path in config_paths:
+        rows, run_dir = _run_persistence_config(
+            yaml_path=yaml_path,
+            payloads=payloads,
+            stub_mode=stub_mode,
+            semantic_evaluator=semantic_evaluator,
+            baseline_results_dir=baseline_results_dir,
+            results_dir=results_dir,
+            repo_root=repo_root,
+        )
+        all_matrix_rows.extend(rows)
+        if first_run_dir_name is None and run_dir is not None:
+            first_run_dir_name = run_dir.name
+
+    if all_matrix_rows:
+        csv_filename = (
+            f"persistence_results_matrix_{first_run_dir_name}.csv"
+            if first_run_dir_name
+            else "persistence_results_matrix.csv"
+        )
+        csv_path = _write_csv(all_matrix_rows, results_dir, csv_filename)
+        _print_summary(all_matrix_rows)
+        print(f"Results matrix written to: {csv_path}")
+
+    return all_matrix_rows, first_run_dir_name
 
 
 # ---------------------------------------------------------------------------

--- a/bili/aegis/suites/persistence/run_persistence_suite.py
+++ b/bili/aegis/suites/persistence/run_persistence_suite.py
@@ -102,7 +102,7 @@ from bili.aegis.security.detector import (  # noqa: E402  pylint: disable=wrong-
 from bili.aegis.security.logger import (  # noqa: E402  pylint: disable=wrong-import-position
     SecurityEventLogger,
 )
-from bili.aegis.suites._helpers import CONFIG_PATHS
+from bili.aegis.suites._helpers import CONFIG_PATHS, DEFAULT_BASELINE_RESULTS_DIR
 from bili.aegis.suites._helpers import (  # noqa: E402  pylint: disable=wrong-import-position
     config_fingerprint as _config_fingerprint_helper,
 )
@@ -538,12 +538,12 @@ def main() -> None:
     )
     parser.add_argument(
         "--baseline-results",
-        default=None,
+        default=DEFAULT_BASELINE_RESULTS_DIR,
         metavar="DIR",
         help=(
-            "Path to baseline results directory for Tier 3 comparison "
-            "(e.g. bili/aegis/suites/baseline/results). "
-            "Required for real-mode Tier 3 evaluation."
+            "Path to baseline results directory for Tier 3 comparison. "
+            f"Defaults to '{DEFAULT_BASELINE_RESULTS_DIR}'. "
+            "Pass an explicit path to override."
         ),
     )
     parser.add_argument(

--- a/bili/aether/compiler/agent_generator.py
+++ b/bili/aether/compiler/agent_generator.py
@@ -156,6 +156,22 @@ def _generate_tool_agent_node(
         if not any(isinstance(m, HumanMessage) for m in messages):
             messages.append(HumanMessage(content="Begin your task."))
 
+        # Bedrock Converse API requires the first non-system message to be a
+        # HumanMessage.  In a sequential chain the first message in accumulated
+        # context is often an AIMessage from a prior agent — insert a synthetic
+        # task cue before it so the turn order constraint is satisfied.
+        first_non_sys = next(
+            (i for i, m in enumerate(messages) if not isinstance(m, SystemMessage)),
+            None,
+        )
+        if first_non_sys is not None and isinstance(messages[first_non_sys], AIMessage):
+            messages.insert(
+                first_non_sys,
+                HumanMessage(
+                    content="Please review the following context and complete your task."
+                ),
+            )
+
         # Some providers (e.g. Mistral on Bedrock) require the final turn to be
         # a HumanMessage.  Same guard as _generate_direct_llm_node.
         if messages and isinstance(messages[-1], AIMessage):
@@ -246,6 +262,22 @@ def _generate_direct_llm_node(agent: AgentSpec, llm: object) -> Callable[[dict],
             messages.extend(compatible)
         else:
             messages.append(HumanMessage(content="Begin your task."))
+
+        # Bedrock Converse API requires the first non-system message to be a
+        # HumanMessage.  In a sequential chain the first message in accumulated
+        # context is often an AIMessage from a prior agent — insert a synthetic
+        # task cue before it so the turn order constraint is satisfied.
+        first_non_sys = next(
+            (i for i, m in enumerate(messages) if not isinstance(m, SystemMessage)),
+            None,
+        )
+        if first_non_sys is not None and isinstance(messages[first_non_sys], AIMessage):
+            messages.insert(
+                first_non_sys,
+                HumanMessage(
+                    content="Please review the following context and complete your task."
+                ),
+            )
 
         # Some providers (e.g. Mistral on Bedrock) require the final turn to be
         # a HumanMessage.  If the accumulated context ends with an AIMessage from

--- a/bili/aether/ui/attack_page.py
+++ b/bili/aether/ui/attack_page.py
@@ -204,6 +204,8 @@ def _resolve_attack_config():
 def _init_attack_selections() -> None:
     """Initialize per-payload session state keys to True if not already set."""
     for suite in _SUITE_NAMES:
+        if f"attack_phase_{suite}" not in st.session_state:
+            st.session_state[f"attack_phase_{suite}"] = "pre_execution"
         library = _load_payload_library(suite)
         for pid in library:
             key = f"attack_selected_{suite}_{pid}"
@@ -264,6 +266,18 @@ def _render_payload_selector() -> None:
             use_container_width=True,
         )
 
+        st.caption("Injection phase:")
+        st.radio(
+            "Injection phase",
+            options=["pre_execution", "mid_execution"],
+            format_func=lambda x: (
+                "Pre-execution" if x == "pre_execution" else "Mid-execution"
+            ),
+            key=f"attack_phase_{suite}",
+            horizontal=True,
+            label_visibility="collapsed",
+        )
+
         for pid, payload_obj in library.items():
             sev = getattr(payload_obj, "severity", "").lower()
             text_preview = getattr(payload_obj, "payload", "")
@@ -284,9 +298,18 @@ def _render_payload_selector() -> None:
 
 def _execute_batch_attack(config, yaml_path: str, stub_mode: bool) -> None:
     """Run all selected payloads via run_suite() and display live progress."""
+    from bili.aegis.evaluator.semantic_evaluator import (  # pylint: disable=import-outside-toplevel
+        SemanticEvaluator,
+    )
     from bili.aegis.suites._suite_runner import (  # pylint: disable=import-outside-toplevel
         run_suite,
     )
+
+    skip_t3 = stub_mode or st.session_state.get("attack_skip_t3", False)
+    semantic_evaluator = (
+        SemanticEvaluator(model_name=_get_evaluator_model()) if not skip_t3 else None
+    )
+    baseline_results_dir = BASELINE_RESULTS_DIR if not skip_t3 else None
 
     # Collect selected payloads per suite
     suite_selections: dict[str, list] = {}
@@ -305,7 +328,6 @@ def _execute_batch_attack(config, yaml_path: str, stub_mode: bool) -> None:
         return
 
     total_suites = len(suite_selections)
-    phase = st.session_state.get("attack_phase", "pre_execution")
     progress_bar = st.progress(0, text="Starting batch attack run\u2026")
     status_area = st.container()
     passed_suites = 0
@@ -315,6 +337,7 @@ def _execute_batch_attack(config, yaml_path: str, stub_mode: bool) -> None:
             i / total_suites,
             text=f"Running {_SUITE_DISPLAY[suite]} ({i + 1}/{total_suites})\u2026",
         )
+        phase = st.session_state.get(f"attack_phase_{suite}", "pre_execution")
         results_dir = _SUITES_DIR / suite / "results"
         try:
             run_suite(
@@ -328,8 +351,8 @@ def _execute_batch_attack(config, yaml_path: str, stub_mode: bool) -> None:
                 config_paths=[yaml_path] if yaml_path else [],
                 phases=[phase],
                 stub=stub_mode,
-                semantic_evaluator=None,
-                baseline_results_dir=None,
+                semantic_evaluator=semantic_evaluator,
+                baseline_results_dir=baseline_results_dir,
             )
             # run_suite() normally exits via sys.exit(); reaching here means it
             # returned normally (shouldn't happen, but treat as success).
@@ -544,18 +567,8 @@ def _render_main() -> None:
 
     st.markdown("---")
 
-    # Injection phase and stub mode
-    col_phase, col_stub, _ = st.columns([2, 1, 2])
-    with col_phase:
-        st.radio(
-            "Injection phase",
-            ["pre_execution", "mid_execution"],
-            key="attack_phase",
-            format_func=lambda p: (
-                "Pre-execution" if p == "pre_execution" else "Mid-execution"
-            ),
-            horizontal=True,
-        )
+    # Stub mode and T3 options
+    col_stub, col_t3, _ = st.columns([1, 1, 2])
     with col_stub:
         stub_mode = st.toggle(
             "Stub mode",
@@ -565,6 +578,16 @@ def _render_main() -> None:
         )
         if stub_mode:
             st.caption("No LLM calls")
+    with col_t3:
+        skip_t3 = st.toggle(
+            "Skip T3 evaluation",
+            value=False,
+            key="attack_skip_t3",
+            help="Skip Tier 3 semantic evaluation. Useful when baseline results are unavailable or to reduce API spend.",
+            disabled=stub_mode,
+        )
+        if stub_mode or skip_t3:
+            st.caption("T3 skipped")
 
     # Dynamic batch run button
     total_selected = sum(
@@ -938,13 +961,23 @@ def _run_tier3_evaluation(result_dict: dict, baseline_result: dict) -> Optional[
 
 
 def _load_baseline_result(mas_id: str) -> Optional[dict]:
-    """Load the first available baseline result for *mas_id*, or None."""
+    """Load the first available baseline result for *mas_id*, or None.
+
+    Prefers the most recent ``run_NNN`` subdirectory; falls back to the flat
+    legacy layout when no versioned run directories exist.
+    """
+    from bili.aegis.suites._helpers import (  # pylint: disable=import-outside-toplevel
+        latest_run_dir,
+    )
+
     # Sanitize mas_id to prevent path traversal (e.g. "../../etc")
     safe_id = mas_id.replace("..", "").replace("/", "_").replace("\\", "_")
     mas_dir = BASELINE_RESULTS_DIR / safe_id
-    if not mas_dir.exists():
+    run_dir = latest_run_dir(mas_dir)
+    search_dir = run_dir if run_dir is not None else mas_dir
+    if not search_dir.exists():
         return None
-    for path in sorted(mas_dir.glob("**/*.json")):
+    for path in sorted(search_dir.glob("*.json")):
         try:
             return json.loads(path.read_text(encoding="utf-8"))
         except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/bili/aether/ui/attack_page.py
+++ b/bili/aether/ui/attack_page.py
@@ -82,6 +82,8 @@ _SUITE_NAMES = [
     "memory_poisoning",
     "bias_inheritance",
     "agent_impersonation",
+    "persistence",
+    "cross_model",
 ]
 
 _SUITE_DISPLAY = {
@@ -90,6 +92,8 @@ _SUITE_DISPLAY = {
     "memory_poisoning": "Memory Poisoning",
     "bias_inheritance": "Bias Inheritance",
     "agent_impersonation": "Agent Impersonation",
+    "persistence": "Persistence",
+    "cross_model": "Cross-Model Transferability",
 }
 
 _SUITE_PAYLOAD_MODULES = {
@@ -104,6 +108,9 @@ _SUITE_PAYLOAD_MODULES = {
     "agent_impersonation": (
         "bili.aegis.suites.agent_impersonation.payloads.agent_impersonation_payloads"
     ),
+    # Persistence has its own payloads; cross_model reuses the injection payload set.
+    "persistence": ("bili.aegis.suites.persistence.payloads.persistence_payloads"),
+    "cross_model": ("bili.aegis.suites.injection.payloads.prompt_injection_payloads"),
 }
 
 _SUITE_ATTACK_TYPE = {
@@ -112,7 +119,22 @@ _SUITE_ATTACK_TYPE = {
     "memory_poisoning": "memory_poisoning",
     "bias_inheritance": "bias_inheritance",
     "agent_impersonation": "agent_impersonation",
+    # persistence and cross_model use their own runners — attack_type not used
+    # by _execute_batch_attack for these suites.
+    "persistence": "persistence",
+    "cross_model": "prompt_injection",
 }
+
+# Suites that use the shared _suite_runner.run_suite() path.
+_STANDARD_SUITES = frozenset(
+    [
+        "injection",
+        "jailbreak",
+        "memory_poisoning",
+        "bias_inheritance",
+        "agent_impersonation",
+    ]
+)
 
 _SEV_PREFIX = {"high": "[HIGH]", "medium": "[MED]", "low": "[LOW]"}
 
@@ -205,7 +227,11 @@ def _init_attack_selections() -> None:
     """Initialize per-payload session state keys to True if not already set."""
     for suite in _SUITE_NAMES:
         if f"attack_phase_{suite}" not in st.session_state:
-            st.session_state[f"attack_phase_{suite}"] = "pre_execution"
+            # Persistence uses a fixed checkpoint phase; all others default to pre_execution.
+            default_phase = (
+                "checkpoint_injection" if suite == "persistence" else "pre_execution"
+            )
+            st.session_state[f"attack_phase_{suite}"] = default_phase
         library = _load_payload_library(suite)
         for pid in library:
             key = f"attack_selected_{suite}_{pid}"
@@ -266,17 +292,30 @@ def _render_payload_selector() -> None:
             use_container_width=True,
         )
 
-        st.caption("Injection phase:")
-        st.radio(
-            "Injection phase",
-            options=["pre_execution", "mid_execution"],
-            format_func=lambda x: (
-                "Pre-execution" if x == "pre_execution" else "Mid-execution"
-            ),
-            key=f"attack_phase_{suite}",
-            horizontal=True,
-            label_visibility="collapsed",
-        )
+        if suite == "persistence":
+            st.caption("Injection phase: Checkpoint injection (only phase)")
+        else:
+            st.caption("Injection phase:")
+            st.radio(
+                "Injection phase",
+                options=["pre_execution", "mid_execution"],
+                format_func=lambda x: (
+                    "Pre-execution" if x == "pre_execution" else "Mid-execution"
+                ),
+                key=f"attack_phase_{suite}",
+                horizontal=True,
+                label_visibility="collapsed",
+            )
+        if suite == "cross_model":
+            st.caption(
+                "Runs across 4 models: Claude 3.5 Haiku, Claude Sonnet 4, "
+                "Amazon Nova Pro, Gemini 2.0 Flash. Stub mode uses a single null model."
+            )
+        if suite == "persistence":
+            st.caption(
+                "Requires a postgres or mongo checkpointer. "
+                "Configs without a persistent backend are skipped automatically."
+            )
 
         for pid, payload_obj in library.items():
             sev = getattr(payload_obj, "severity", "").lower()
@@ -313,8 +352,9 @@ def _execute_batch_attack(config, yaml_path: str, stub_mode: bool) -> None:
     )
 
     skip_t3 = stub_mode or st.session_state.get("attack_skip_t3", False)
+    evaluator_model = _get_evaluator_model()
     semantic_evaluator = (
-        SemanticEvaluator(model_name=_get_evaluator_model()) if not skip_t3 else None
+        SemanticEvaluator(model_name=evaluator_model) if not skip_t3 else None
     )
     baseline_results_dir = BASELINE_RESULTS_DIR if not skip_t3 else None
 
@@ -347,31 +387,109 @@ def _execute_batch_attack(config, yaml_path: str, stub_mode: bool) -> None:
         phase = st.session_state.get(f"attack_phase_{suite}", "pre_execution")
         results_dir = _SUITES_DIR / suite / "results"
         try:
-            run_suite(
-                payloads=payloads,
-                attack_suite=suite,
-                attack_type=_SUITE_ATTACK_TYPE[suite],
-                csv_filename=f"{suite}_results_matrix.csv",
-                suite_name=_SUITE_DISPLAY[suite],
-                results_dir=results_dir,
-                repo_root=_REPO_ROOT,
-                config_paths=[yaml_path] if yaml_path else [],
-                phases=[phase],
-                stub=stub_mode,
-                semantic_evaluator=semantic_evaluator,
-                baseline_results_dir=baseline_results_dir,
-            )
-            # run_suite() normally exits via sys.exit(); reaching here means it
-            # returned normally (shouldn't happen, but treat as success).
-            passed_suites += 1
-            with status_area:
-                st.markdown(
-                    f"\u2705 **{_SUITE_DISPLAY[suite]}** — {len(payloads)} payload(s)"
+            if suite in _STANDARD_SUITES:
+                # Standard suites go through the shared _suite_runner.run_suite()
+                # which calls sys.exit() on completion — caught below.
+                run_suite(
+                    payloads=payloads,
+                    attack_suite=suite,
+                    attack_type=_SUITE_ATTACK_TYPE[suite],
+                    csv_filename=f"{suite}_results_matrix.csv",
+                    suite_name=_SUITE_DISPLAY[suite],
+                    results_dir=results_dir,
+                    repo_root=_REPO_ROOT,
+                    config_paths=[yaml_path] if yaml_path else [],
+                    phases=[phase],
+                    stub=stub_mode,
+                    semantic_evaluator=semantic_evaluator,
+                    baseline_results_dir=baseline_results_dir,
                 )
+                # run_suite() normally exits via sys.exit(); reaching here means
+                # it returned normally (treat as success).
+                passed_suites += 1
+                with status_area:
+                    st.markdown(
+                        f"\u2705 **{_SUITE_DISPLAY[suite]}** — {len(payloads)} payload(s)"
+                    )
+
+            elif suite == "persistence":
+                from bili.aegis.evaluator.evaluator_config import (  # pylint: disable=import-outside-toplevel
+                    PERSISTENCE_JUDGE_PROMPT,
+                    PERSISTENCE_SCORE_DESCRIPTIONS,
+                )
+                from bili.aegis.suites.persistence.run_persistence_suite import (  # pylint: disable=import-outside-toplevel
+                    run_persistence_suite,
+                )
+
+                persistence_evaluator = (
+                    SemanticEvaluator(
+                        score_descriptions=PERSISTENCE_SCORE_DESCRIPTIONS,
+                        judge_prompt_template=PERSISTENCE_JUDGE_PROMPT,
+                        model_name=evaluator_model,
+                    )
+                    if not skip_t3
+                    else None
+                )
+                matrix_rows, _ = run_persistence_suite(
+                    payloads=payloads,
+                    config_paths=[yaml_path] if yaml_path else [],
+                    stub_mode=stub_mode,
+                    semantic_evaluator=persistence_evaluator,
+                    baseline_results_dir=baseline_results_dir,
+                    results_dir=results_dir,
+                    repo_root=_REPO_ROOT,
+                )
+                ran = [r for r in matrix_rows if r.get("skipped") != "true"]
+                all_passed = all(r.get("tier1_pass") == "true" for r in ran)
+                if all_passed or not ran:
+                    passed_suites += 1
+                    with status_area:
+                        st.markdown(
+                            f"\u2705 **{_SUITE_DISPLAY[suite]}** — {len(payloads)} payload(s)"
+                        )
+                else:
+                    with status_area:
+                        st.markdown(
+                            f"\u26a0\ufe0f **{_SUITE_DISPLAY[suite]}** — "
+                            f"{len(payloads)} payload(s) (some cases failed)"
+                        )
+
+            elif suite == "cross_model":
+                from bili.aegis.suites.cross_model.run_cross_model_suite import (  # pylint: disable=import-outside-toplevel
+                    _MODEL_MATRIX,
+                    run_cross_model_suite,
+                )
+
+                model_matrix = [(None, "stub")] if stub_mode else list(_MODEL_MATRIX)
+                matrix_rows, _ = run_cross_model_suite(
+                    payloads=payloads,
+                    config_paths=[yaml_path] if yaml_path else [],
+                    phases=[phase],
+                    model_matrix=model_matrix,
+                    stub_mode=stub_mode,
+                    semantic_evaluator=semantic_evaluator,
+                    baseline_results_dir=baseline_results_dir,
+                    results_dir=results_dir,
+                    repo_root=_REPO_ROOT,
+                )
+                ran = [r for r in matrix_rows if r.get("skipped") != "true"]
+                all_passed = all(r.get("tier1_pass") == "true" for r in ran)
+                if all_passed or not ran:
+                    passed_suites += 1
+                    with status_area:
+                        st.markdown(
+                            f"\u2705 **{_SUITE_DISPLAY[suite]}** — {len(payloads)} payload(s)"
+                        )
+                else:
+                    with status_area:
+                        st.markdown(
+                            f"\u26a0\ufe0f **{_SUITE_DISPLAY[suite]}** — "
+                            f"{len(payloads)} payload(s) (some cases failed)"
+                        )
+
         except SystemExit as exc:
-            # run_suite() is a CLI tool that always calls sys.exit() after writing
-            # results to disk.  Exit code 0 = all cases passed; non-zero = failures.
-            # Results are already on disk in either case.
+            # run_suite() calls sys.exit() after writing results to disk.
+            # Exit code 0 = all cases passed; non-zero = failures.
             if exc.code == 0:
                 passed_suites += 1
                 with status_area:

--- a/bili/aether/ui/attack_page.py
+++ b/bili/aether/ui/attack_page.py
@@ -114,7 +114,7 @@ _SUITE_ATTACK_TYPE = {
     "agent_impersonation": "agent_impersonation",
 }
 
-_SEV_PREFIX = {"high": "[HIGH]", "medium": "[MED] ", "low": "[LOW] "}
+_SEV_PREFIX = {"high": "[HIGH]", "medium": "[MED]", "low": "[LOW]"}
 
 # Strategy function name for each attack_type string
 _PRE_EXEC_STRATEGY_FN = {
@@ -181,14 +181,19 @@ def _resolve_attack_config():
 
     if selected_idx and selected_idx > 0:
         yaml_path_obj = yaml_files[selected_idx - 1]
-        try:
-            config = load_mas_from_yaml(str(yaml_path_obj))
-            st.session_state.attack_config = config
-            st.session_state.attack_yaml_path = str(yaml_path_obj)
-            if config.agents and not st.session_state.get("attack_target_agent_id"):
-                st.session_state.attack_target_agent_id = config.agents[0].agent_id
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            st.error(f"Failed to load `{yaml_path_obj.name}`: {exc}")
+        # Only reload if the selected file differs from what is currently loaded,
+        # to avoid a full disk read and target-agent reset on every render.
+        if st.session_state.get("attack_yaml_path") != str(yaml_path_obj):
+            try:
+                config = load_mas_from_yaml(str(yaml_path_obj))
+                st.session_state.attack_config = config
+                st.session_state.attack_yaml_path = str(yaml_path_obj)
+                # Always reset target to first agent of the new config so
+                # a stale agent_id from a previous config is never forwarded.
+                if config.agents:
+                    st.session_state.attack_target_agent_id = config.agents[0].agent_id
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                st.error(f"Failed to load `{yaml_path_obj.name}`: {exc}")
 
 
 # ---------------------------------------------------------------------------
@@ -326,11 +331,29 @@ def _execute_batch_attack(config, yaml_path: str, stub_mode: bool) -> None:
                 semantic_evaluator=None,
                 baseline_results_dir=None,
             )
+            # run_suite() normally exits via sys.exit(); reaching here means it
+            # returned normally (shouldn't happen, but treat as success).
             passed_suites += 1
             with status_area:
                 st.markdown(
                     f"\u2705 **{_SUITE_DISPLAY[suite]}** — {len(payloads)} payload(s)"
                 )
+        except SystemExit as exc:
+            # run_suite() is a CLI tool that always calls sys.exit() after writing
+            # results to disk.  Exit code 0 = all cases passed; non-zero = failures.
+            # Results are already on disk in either case.
+            if exc.code == 0:
+                passed_suites += 1
+                with status_area:
+                    st.markdown(
+                        f"\u2705 **{_SUITE_DISPLAY[suite]}** — {len(payloads)} payload(s)"
+                    )
+            else:
+                with status_area:
+                    st.markdown(
+                        f"\u26a0\ufe0f **{_SUITE_DISPLAY[suite]}** — "
+                        f"{len(payloads)} payload(s) (some cases failed)"
+                    )
         except Exception as exc:  # pylint: disable=broad-exception-caught
             LOGGER.error("Batch attack failed for suite %s: %s", suite, exc)
             with status_area:

--- a/bili/aether/ui/attack_page.py
+++ b/bili/aether/ui/attack_page.py
@@ -298,6 +298,13 @@ def _render_payload_selector() -> None:
 
 def _execute_batch_attack(config, yaml_path: str, stub_mode: bool) -> None:
     """Run all selected payloads via run_suite() and display live progress."""
+    if not yaml_path:
+        st.error(
+            "No YAML config path available. Select a YAML file in the sidebar "
+            "or use **Send to Attack Suite** from the AETHER visualizer."
+        )
+        return
+
     from bili.aegis.evaluator.semantic_evaluator import (  # pylint: disable=import-outside-toplevel
         SemanticEvaluator,
     )

--- a/bili/aether/ui/attack_page.py
+++ b/bili/aether/ui/attack_page.py
@@ -437,17 +437,6 @@ def _render_sidebar() -> None:
             key="attack_payload_custom",
         )
 
-    # Phase
-    st.radio(
-        "Injection phase",
-        ["pre_execution", "mid_execution"],
-        key="attack_phase",
-        format_func=lambda p: (
-            "Pre-execution" if p == "pre_execution" else "Mid-execution"
-        ),
-        horizontal=True,
-    )
-
     target = st.session_state.get("attack_target_agent_id")
     run_disabled = target is None
 

--- a/bili/aether/ui/attack_page.py
+++ b/bili/aether/ui/attack_page.py
@@ -213,10 +213,10 @@ def _init_attack_selections() -> None:
                 st.session_state[key] = True
 
 
-def _on_suite_header_change(hdr_key: str, payload_ids: list) -> None:
+def _on_suite_header_change(hdr_key: str, payload_keys: list) -> None:
     """Propagate suite header checkbox state to all child payload checkboxes."""
     new_val = st.session_state[hdr_key]
-    for pid in payload_ids:
+    for pid in payload_keys:
         st.session_state[pid] = new_val
 
 
@@ -237,7 +237,7 @@ def _render_payload_selector() -> None:
         payload_keys = [f"attack_selected_{suite}_{pid}" for pid in library]
         n_selected = sum(1 for k in payload_keys if st.session_state.get(k, True))
         n_total = len(payload_keys)
-        all_checked = n_selected == n_total
+        all_checked = n_selected == n_total and n_total > 0
 
         hdr_key = f"attack_suite_hdr_{suite}"
         st.session_state[hdr_key] = all_checked

--- a/bili/aether/ui/attack_page.py
+++ b/bili/aether/ui/attack_page.py
@@ -335,6 +335,44 @@ def _render_payload_selector() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _report_suite_result(
+    matrix_rows: list[dict],
+    suite: str,
+    payloads: list,
+    status_area: Any,
+    passed_suites: int,
+) -> int:
+    """Update *status_area* with the suite outcome and return updated *passed_suites*.
+
+    Three distinct outcomes:
+    - All rows skipped (no eligible configs): shows a skip indicator — counts
+      as "not failed" so the overall run still succeeds.
+    - All ran rows passed: green checkmark.
+    - At least one ran row failed: warning indicator.
+    """
+    ran = [r for r in matrix_rows if r.get("skipped") != "true"]
+    if not ran:
+        with status_area:
+            st.markdown(
+                f"\u23ed\ufe0f **{_SUITE_DISPLAY[suite]}** — "
+                f"skipped (no eligible configs)"
+            )
+        passed_suites += 1
+    elif all(r.get("tier1_pass") == "true" for r in ran):
+        passed_suites += 1
+        with status_area:
+            st.markdown(
+                f"\u2705 **{_SUITE_DISPLAY[suite]}** — {len(payloads)} payload(s)"
+            )
+    else:
+        with status_area:
+            st.markdown(
+                f"\u26a0\ufe0f **{_SUITE_DISPLAY[suite]}** — "
+                f"{len(payloads)} payload(s) (some cases failed)"
+            )
+    return passed_suites
+
+
 def _execute_batch_attack(config, yaml_path: str, stub_mode: bool) -> None:
     """Run all selected payloads via run_suite() and display live progress."""
     if not yaml_path:
@@ -384,12 +422,12 @@ def _execute_batch_attack(config, yaml_path: str, stub_mode: bool) -> None:
             i / total_suites,
             text=f"Running {_SUITE_DISPLAY[suite]} ({i + 1}/{total_suites})\u2026",
         )
-        phase = st.session_state.get(f"attack_phase_{suite}", "pre_execution")
         results_dir = _SUITES_DIR / suite / "results"
         try:
             if suite in _STANDARD_SUITES:
                 # Standard suites go through the shared _suite_runner.run_suite()
                 # which calls sys.exit() on completion — caught below.
+                phase = st.session_state.get(f"attack_phase_{suite}", "pre_execution")
                 run_suite(
                     payloads=payloads,
                     attack_suite=suite,
@@ -430,6 +468,8 @@ def _execute_batch_attack(config, yaml_path: str, stub_mode: bool) -> None:
                     if not skip_t3
                     else None
                 )
+                # Persistence always uses the CHECKPOINT phase internally;
+                # no phase parameter is passed to run_persistence_suite().
                 matrix_rows, _ = run_persistence_suite(
                     payloads=payloads,
                     config_paths=[yaml_path] if yaml_path else [],
@@ -439,28 +479,18 @@ def _execute_batch_attack(config, yaml_path: str, stub_mode: bool) -> None:
                     results_dir=results_dir,
                     repo_root=_REPO_ROOT,
                 )
-                ran = [r for r in matrix_rows if r.get("skipped") != "true"]
-                all_passed = all(r.get("tier1_pass") == "true" for r in ran)
-                if all_passed or not ran:
-                    passed_suites += 1
-                    with status_area:
-                        st.markdown(
-                            f"\u2705 **{_SUITE_DISPLAY[suite]}** — {len(payloads)} payload(s)"
-                        )
-                else:
-                    with status_area:
-                        st.markdown(
-                            f"\u26a0\ufe0f **{_SUITE_DISPLAY[suite]}** — "
-                            f"{len(payloads)} payload(s) (some cases failed)"
-                        )
+                passed_suites = _report_suite_result(
+                    matrix_rows, suite, payloads, status_area, passed_suites
+                )
 
             elif suite == "cross_model":
                 from bili.aegis.suites.cross_model.run_cross_model_suite import (  # pylint: disable=import-outside-toplevel
-                    _MODEL_MATRIX,
+                    MODEL_MATRIX,
                     run_cross_model_suite,
                 )
 
-                model_matrix = [(None, "stub")] if stub_mode else list(_MODEL_MATRIX)
+                phase = st.session_state.get(f"attack_phase_{suite}", "pre_execution")
+                model_matrix = [(None, "stub")] if stub_mode else list(MODEL_MATRIX)
                 matrix_rows, _ = run_cross_model_suite(
                     payloads=payloads,
                     config_paths=[yaml_path] if yaml_path else [],
@@ -472,20 +502,9 @@ def _execute_batch_attack(config, yaml_path: str, stub_mode: bool) -> None:
                     results_dir=results_dir,
                     repo_root=_REPO_ROOT,
                 )
-                ran = [r for r in matrix_rows if r.get("skipped") != "true"]
-                all_passed = all(r.get("tier1_pass") == "true" for r in ran)
-                if all_passed or not ran:
-                    passed_suites += 1
-                    with status_area:
-                        st.markdown(
-                            f"\u2705 **{_SUITE_DISPLAY[suite]}** — {len(payloads)} payload(s)"
-                        )
-                else:
-                    with status_area:
-                        st.markdown(
-                            f"\u26a0\ufe0f **{_SUITE_DISPLAY[suite]}** — "
-                            f"{len(payloads)} payload(s) (some cases failed)"
-                        )
+                passed_suites = _report_suite_result(
+                    matrix_rows, suite, payloads, status_area, passed_suites
+                )
 
         except SystemExit as exc:
             # run_suite() calls sys.exit() after writing results to disk.

--- a/bili/aether/ui/attack_page.py
+++ b/bili/aether/ui/attack_page.py
@@ -54,6 +54,11 @@ BASELINE_RESULTS_DIR = (
     / "baseline"
     / "results"
 )
+EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "config" / "examples"
+
+# Batch runner paths
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_SUITES_DIR = Path(__file__).resolve().parent.parent.parent / "aegis" / "suites"
 
 LOGGER = logging.getLogger(__name__)
 
@@ -109,6 +114,8 @@ _SUITE_ATTACK_TYPE = {
     "agent_impersonation": "agent_impersonation",
 }
 
+_SEV_PREFIX = {"high": "[HIGH]", "medium": "[MED] ", "low": "[LOW] "}
+
 # Strategy function name for each attack_type string
 _PRE_EXEC_STRATEGY_FN = {
     "prompt_injection": "inject_prompt_injection",
@@ -124,18 +131,222 @@ _PRE_EXEC_STRATEGY_FN = {
 # ---------------------------------------------------------------------------
 
 
-def push_config_to_attack_state(config: MASConfig) -> None:
+def push_config_to_attack_state(config: MASConfig, yaml_path: str = "") -> None:
     """Write *config* into session state so the Attack page loads it fresh.
 
     Call this from any page that has a "Send to Attack Suite" button.  Clears
     previous attack results so the new config starts from a clean slate.
+
+    Args:
+        config:    The MASConfig to run attacks against.
+        yaml_path: Absolute or repo-relative path to the YAML file — required
+                   by ``run_suite`` for config fingerprinting.
     """
     st.session_state.attack_config = config
+    st.session_state.attack_yaml_path = yaml_path
     if config.agents:
         st.session_state.attack_target_agent_id = config.agents[0].agent_id
     for key in ("attack_result", "attack_verdict", "attack_node_states"):
         st.session_state.pop(key, None)
     st.toast("Config loaded in Attack Suite \u2713")
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_attack_config():
+    """Render YAML selector and sync resolved config into session state.
+
+    When a file is explicitly selected, loads it and writes the result into
+    ``attack_config`` / ``attack_yaml_path`` so that ``_render_main()`` can
+    read the correct values from session state on the same render pass.
+    """
+    from bili.aether.config.loader import (  # pylint: disable=import-outside-toplevel
+        load_mas_from_yaml,
+    )
+
+    yaml_files = sorted(EXAMPLES_DIR.glob("*.yaml")) if EXAMPLES_DIR.exists() else []
+    yaml_display = ["(use config from AETHER visualizer)"] + [
+        f.stem.replace("_", " ").title() for f in yaml_files
+    ]
+
+    selected_idx = st.selectbox(
+        "YAML Configuration",
+        range(len(yaml_display)),
+        format_func=lambda i: yaml_display[i],
+        key="attack_yaml_selector",
+    )
+
+    if selected_idx and selected_idx > 0:
+        yaml_path_obj = yaml_files[selected_idx - 1]
+        try:
+            config = load_mas_from_yaml(str(yaml_path_obj))
+            st.session_state.attack_config = config
+            st.session_state.attack_yaml_path = str(yaml_path_obj)
+            if config.agents and not st.session_state.get("attack_target_agent_id"):
+                st.session_state.attack_target_agent_id = config.agents[0].agent_id
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            st.error(f"Failed to load `{yaml_path_obj.name}`: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Payload selection helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_attack_selections() -> None:
+    """Initialize per-payload session state keys to True if not already set."""
+    for suite in _SUITE_NAMES:
+        library = _load_payload_library(suite)
+        for pid in library:
+            key = f"attack_selected_{suite}_{pid}"
+            if key not in st.session_state:
+                st.session_state[key] = True
+
+
+def _on_suite_header_change(hdr_key: str, payload_ids: list) -> None:
+    """Propagate suite header checkbox state to all child payload checkboxes."""
+    new_val = st.session_state[hdr_key]
+    for pid in payload_ids:
+        st.session_state[pid] = new_val
+
+
+def _set_suite_payloads(payload_keys: list, value: bool) -> None:
+    """Set all payloads in a suite to *value* (used by Select/Deselect All)."""
+    for key in payload_keys:
+        st.session_state[key] = value
+
+
+def _render_payload_selector() -> None:
+    """Render the two-level suite/payload selection hierarchy."""
+    _init_attack_selections()
+
+    st.markdown("**Select payloads to run:**")
+
+    for suite in _SUITE_NAMES:
+        library = _load_payload_library(suite)
+        payload_keys = [f"attack_selected_{suite}_{pid}" for pid in library]
+        n_selected = sum(1 for k in payload_keys if st.session_state.get(k, True))
+        n_total = len(payload_keys)
+        all_checked = n_selected == n_total
+
+        hdr_key = f"attack_suite_hdr_{suite}"
+        st.session_state[hdr_key] = all_checked
+
+        display = _SUITE_DISPLAY[suite]
+        st.checkbox(
+            f"**{display}** ({n_selected}/{n_total})",
+            key=hdr_key,
+            on_change=_on_suite_header_change,
+            args=(hdr_key, payload_keys),
+        )
+
+        col_a, col_b, _ = st.columns([1, 1, 2])
+        col_a.button(
+            "Select All",
+            key=f"atk_sel_{suite}",
+            on_click=_set_suite_payloads,
+            args=(payload_keys, True),
+            use_container_width=True,
+        )
+        col_b.button(
+            "Deselect All",
+            key=f"atk_desel_{suite}",
+            on_click=_set_suite_payloads,
+            args=(payload_keys, False),
+            use_container_width=True,
+        )
+
+        for pid, payload_obj in library.items():
+            sev = getattr(payload_obj, "severity", "").lower()
+            text_preview = getattr(payload_obj, "payload", "")
+            preview = text_preview[:60] + ("\u2026" if len(text_preview) > 60 else "")
+            sev_badge = _SEV_PREFIX.get(sev, "[---]")
+            _, col_p = st.columns([0.05, 0.95])
+            with col_p:
+                st.checkbox(
+                    f"{sev_badge} `{pid}` \u2014 {preview}",
+                    key=f"attack_selected_{suite}_{pid}",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Batch execution
+# ---------------------------------------------------------------------------
+
+
+def _execute_batch_attack(config, yaml_path: str, stub_mode: bool) -> None:
+    """Run all selected payloads via run_suite() and display live progress."""
+    from bili.aegis.suites._suite_runner import (  # pylint: disable=import-outside-toplevel
+        run_suite,
+    )
+
+    # Collect selected payloads per suite
+    suite_selections: dict[str, list] = {}
+    for suite in _SUITE_NAMES:
+        library = _load_payload_library(suite)
+        selected = [
+            obj
+            for pid, obj in library.items()
+            if st.session_state.get(f"attack_selected_{suite}_{pid}", True)
+        ]
+        if selected:
+            suite_selections[suite] = selected
+
+    if not suite_selections:
+        st.warning("No payloads selected. Enable at least one payload.")
+        return
+
+    total_suites = len(suite_selections)
+    phase = st.session_state.get("attack_phase", "pre_execution")
+    progress_bar = st.progress(0, text="Starting batch attack run\u2026")
+    status_area = st.container()
+    passed_suites = 0
+
+    for i, (suite, payloads) in enumerate(suite_selections.items()):
+        progress_bar.progress(
+            i / total_suites,
+            text=f"Running {_SUITE_DISPLAY[suite]} ({i + 1}/{total_suites})\u2026",
+        )
+        results_dir = _SUITES_DIR / suite / "results"
+        try:
+            run_suite(
+                payloads=payloads,
+                attack_suite=suite,
+                attack_type=_SUITE_ATTACK_TYPE[suite],
+                csv_filename=f"{suite}_results_matrix.csv",
+                suite_name=_SUITE_DISPLAY[suite],
+                results_dir=results_dir,
+                repo_root=_REPO_ROOT,
+                config_paths=[yaml_path] if yaml_path else [],
+                phases=[phase],
+                stub=stub_mode,
+                semantic_evaluator=None,
+                baseline_results_dir=None,
+            )
+            passed_suites += 1
+            with status_area:
+                st.markdown(
+                    f"\u2705 **{_SUITE_DISPLAY[suite]}** — {len(payloads)} payload(s)"
+                )
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            LOGGER.error("Batch attack failed for suite %s: %s", suite, exc)
+            with status_area:
+                st.markdown(f"\u274c **{_SUITE_DISPLAY[suite]}** — failed: {exc}")
+
+    progress_bar.progress(
+        1.0, text=f"Complete \u2014 {passed_suites}/{total_suites} suite(s) passed"
+    )
+    if passed_suites == total_suites:
+        st.success(f"All {total_suites} suite(s) completed.")
+    else:
+        st.warning(
+            f"{passed_suites}/{total_suites} suite(s) completed "
+            f"\u2014 {total_suites - passed_suites} failed."
+        )
+    st.info("Navigate to **Attack Results** in the sidebar to view your results.")
 
 
 def render_attack_page() -> None:
@@ -162,13 +373,19 @@ def _render_sidebar() -> None:
     st.caption("Adversarial Evaluation and Guarding of Intelligent Systems")
     st.markdown("---")
     st.markdown("#### Attack Suite")
+    st.markdown(
+        "Run batch attacks from the main area, or use the controls below for a "
+        "single-payload exploratory attack against a specific graph node."
+    )
+
+    _resolve_attack_config()
 
     config: Optional[MASConfig] = st.session_state.get("attack_config")
     if config is None:
-        st.caption("No MAS loaded.")
         return
 
-    st.caption(f"Config: `{config.mas_id}`")
+    st.markdown("---")
+    st.markdown("##### Single-payload exploratory attack")
 
     # Suite selector
     suite_display_names = [_SUITE_DISPLAY[s] for s in _SUITE_NAMES]
@@ -195,27 +412,26 @@ def _render_sidebar() -> None:
         payload_ids = list(library.keys())
         if not payload_ids:
             st.warning("No payloads found for this suite.")
-            return
-
-        selected_pid = st.selectbox(
-            "Payload",
-            payload_ids,
-            format_func=lambda pid: f"{pid} — {_get_notes(library[pid])[:55]}",
-            key="attack_payload_id",
-        )
-        if selected_pid:
-            payload_obj = library[selected_pid]
-            st.text_area(
-                "Payload preview",
-                value=getattr(payload_obj, "payload", ""),
-                height=100,
-                disabled=True,
-                key="attack_payload_preview",
+        else:
+            selected_pid = st.selectbox(
+                "Payload",
+                payload_ids,
+                format_func=lambda pid: f"{pid} — {_get_notes(library[pid])[:55]}",
+                key="attack_payload_id",
             )
+            if selected_pid:
+                payload_obj = library[selected_pid]
+                st.text_area(
+                    "Payload preview",
+                    value=getattr(payload_obj, "payload", ""),
+                    height=100,
+                    disabled=True,
+                    key="attack_payload_preview",
+                )
     else:
         st.text_area(
             "Custom payload",
-            placeholder="Enter adversarial payload text…",
+            placeholder="Enter adversarial payload text\u2026",
             height=120,
             max_chars=10000,
             key="attack_payload_custom",
@@ -231,8 +447,6 @@ def _render_sidebar() -> None:
         ),
         horizontal=True,
     )
-
-    st.markdown("---")
 
     target = st.session_state.get("attack_target_agent_id")
     run_disabled = target is None
@@ -271,6 +485,7 @@ def _render_sidebar() -> None:
 def _render_main() -> None:
     """Render the Attack page main area."""
     config: Optional[MASConfig] = st.session_state.get("attack_config")
+    yaml_path: str = st.session_state.get("attack_yaml_path", "")
 
     st.markdown("# AEGIS Attack Suite")
     st.markdown(
@@ -287,25 +502,95 @@ def _render_main() -> None:
         "communication channels. The Attack Suite lets you explore these "
         "risks interactively."
     )
-    st.markdown(
-        "Load a MAS configuration from AETHER, select a target agent on "
-        "the graph, and choose from 5 attack types (prompt injection, "
-        "jailbreak, memory poisoning, bias inheritance, agent impersonation). "
-        "AEGIS injects the adversarial payload, streams the execution, "
-        "tracks propagation across agents, and evaluates each agent's "
-        "response through structural validation (Tier 1), heuristic "
-        "propagation tracking (Tier 2), and LLM-based semantic scoring "
-        "(Tier 3)."
-    )
     st.markdown("---")
 
     if config is None:
         st.info(
             "No MAS loaded.\n\n"
-            "Use **Send to Attack Suite** from the AETHER Chat or Visualizer page to "
-            "load a configuration."
+            "Select a YAML file in the sidebar, or use **Send to Attack Suite** from "
+            "the AETHER Chat or Visualizer page to load a configuration."
         )
         return
+
+    st.markdown(f"**Config:** `{config.mas_id}` — {config.name}")
+    st.markdown(
+        f"**Workflow:** {config.workflow_type.value} &nbsp;|&nbsp; "
+        f"**Agents:** {len(config.agents)}"
+    )
+    st.markdown("---")
+
+    # -----------------------------------------------------------------------
+    # Batch attack — two-level payload selection
+    # -----------------------------------------------------------------------
+    st.markdown("## Batch Attack Run")
+    st.markdown(
+        "Select payloads across one or more suites and run them all at once. "
+        "Results are written to disk and visible in the **Attack Results** viewer."
+    )
+
+    _render_payload_selector()
+
+    st.markdown("---")
+
+    # Injection phase and stub mode
+    col_phase, col_stub, _ = st.columns([2, 1, 2])
+    with col_phase:
+        st.radio(
+            "Injection phase",
+            ["pre_execution", "mid_execution"],
+            key="attack_phase",
+            format_func=lambda p: (
+                "Pre-execution" if p == "pre_execution" else "Mid-execution"
+            ),
+            horizontal=True,
+        )
+    with col_stub:
+        stub_mode = st.toggle(
+            "Stub mode",
+            value=False,
+            key="attack_stub_mode",
+            help="Skip LLM calls — useful for structural verification without API spend.",
+        )
+        if stub_mode:
+            st.caption("No LLM calls")
+
+    # Dynamic batch run button
+    total_selected = sum(
+        1
+        for suite in _SUITE_NAMES
+        for pid in _load_payload_library(suite)
+        if st.session_state.get(f"attack_selected_{suite}_{pid}", True)
+    )
+    suites_with_selection = sum(
+        1
+        for suite in _SUITE_NAMES
+        if any(
+            st.session_state.get(f"attack_selected_{suite}_{pid}", True)
+            for pid in _load_payload_library(suite)
+        )
+    )
+    btn_label = (
+        f"\u25b6 Run {total_selected} attack(s) across {suites_with_selection} suite(s)"
+    )
+    if st.button(
+        btn_label,
+        type="primary",
+        use_container_width=True,
+        key="attack_batch_run_button",
+        disabled=(total_selected == 0),
+    ):
+        _execute_batch_attack(config, yaml_path, stub_mode)
+
+    st.markdown("---")
+
+    # -----------------------------------------------------------------------
+    # Single-attack graph (used by sidebar Run Attack button)
+    # -----------------------------------------------------------------------
+    st.markdown("## Single-Agent Attack")
+    st.markdown(
+        "Click a node in the graph below to target a specific agent, then use "
+        "**Run Attack** in the sidebar."
+    )
 
     # Initialize target to first agent if not yet set
     if not st.session_state.get("attack_target_agent_id") and config.agents:
@@ -314,12 +599,7 @@ def _render_main() -> None:
     target_id: Optional[str] = st.session_state.get("attack_target_agent_id")
     phase: str = st.session_state.get("attack_phase", "pre_execution")
 
-    st.caption(
-        f"Config: `{config.mas_id}` | "
-        f"Target: `{target_id or 'None'}` | "
-        f"Phase: `{phase}`"
-    )
-    st.markdown("---")
+    st.caption(f"Target: `{target_id or 'None'}` | Phase: `{phase}`")
 
     # Graph — node clicks update attack_target_agent_id
     node_states: Optional[dict] = st.session_state.get("attack_node_states")

--- a/bili/aether/ui/attack_results_page.py
+++ b/bili/aether/ui/attack_results_page.py
@@ -896,11 +896,12 @@ def _render_expander_content(
             r.get("mas_id", ""),
             r.get("payload_id", ""),
             r.get("phase", ""),
+            r.get("run_id", "run_000"),
         )
 
 
 def _render_view_graph_button(
-    config_path: str, mas_id: str, payload_id: str, phase: str
+    config_path: str, mas_id: str, payload_id: str, phase: str, run_id: str = "run_000"
 ) -> None:
     """Render a 'View MAS graph →' button that loads the config into the visualizer."""
     st.markdown("---")
@@ -910,9 +911,7 @@ def _render_view_graph_button(
         st.caption(f"Config not found at `{config_path}` — graph view unavailable.")
         return
 
-    button_key = (
-        f"view_graph_{mas_id}_{payload_id}_{phase}_{config_path.replace('/', '_')}"
-    )
+    button_key = f"view_graph_{run_id}_{mas_id}_{payload_id}_{phase}_{config_path.replace('/', '_')}"
     if st.button("View MAS graph →", key=button_key, use_container_width=False):
         try:
             from bili.aether.config.loader import (  # pylint: disable=import-outside-toplevel

--- a/bili/aether/ui/attack_results_page.py
+++ b/bili/aether/ui/attack_results_page.py
@@ -82,9 +82,11 @@ def _load_suite_results(suite_dir: str) -> list[dict]:
     Cached per ``suite_dir`` with a 30-second TTL.  NDJSON logs and CSV files
     are excluded automatically (glob only matches ``*.json``).
 
-    Cross-model results live one level deeper
-    (``{mas_id}/{model_id_safe}/*.json``); the flat ``**/*.json`` glob covers
-    both layouts transparently.
+    Injects a ``run_id`` key derived from the file path into every raw dict:
+    - Versioned:  ``{mas_id}/run_NNN/{payload_file}.json``           → ``run_NNN``
+    - Cross-model versioned: ``{mas_id}/run_NNN/{model_safe}/{f}``   → ``run_NNN``
+    - Legacy flat: ``{mas_id}/{payload_file}.json``                  → ``run_000 (legacy)``
+    - Legacy cross-model: ``{mas_id}/{model_safe}/{payload_file}``   → ``run_000 (legacy)``
 
     Fields not present in the raw JSON are normalised to ``None`` so
     downstream code can use a single unified DataFrame regardless of suite.
@@ -98,6 +100,16 @@ def _load_suite_results(suite_dir: str) -> list[dict]:
     for path in sorted(results_dir.glob("**/*.json")):
         try:
             raw = json.loads(path.read_text(encoding="utf-8"))
+            # Derive run_id from path: parts[0]=mas_id, parts[1]=run_NNN or other
+            parts = path.relative_to(results_dir).parts
+            if (
+                len(parts) >= 2
+                and parts[1].startswith("run_")
+                and parts[1][4:].isdigit()
+            ):
+                raw["run_id"] = parts[1]
+            else:
+                raw["run_id"] = "run_000 (legacy)"
             results.append(_normalise(raw))
         except Exception as exc:  # pylint: disable=broad-exception-caught
             LOGGER.warning("Could not parse %s: %s", path, exc)
@@ -123,6 +135,7 @@ def _normalise(r: dict) -> dict:
 
     return {
         # Core identity
+        "run_id": r.get("run_id", "run_000 (legacy)"),
         "payload_id": r.get("payload_id", "?"),
         "injection_type": r.get("injection_type", "?"),
         "severity": r.get("severity", "?"),
@@ -165,6 +178,7 @@ def _build_dataframe(results: list[dict]) -> pd.DataFrame:
         try:
             rows.append(
                 {
+                    "run_id": r["run_id"],
                     "payload_id": r["payload_id"],
                     "injection_type": r["injection_type"],
                     "severity": r["severity"],
@@ -361,6 +375,7 @@ def _render_main(selected_suite: str, extra_paths: list[Path]) -> None:
 def _result_export_key(r: dict, is_cross_model: bool) -> tuple:
     """Return the lookup key used to match normalised results to df_filtered rows."""
     return (
+        r.get("run_id", "run_000 (legacy)"),
         r.get("mas_id"),
         r.get("payload_id"),
         r.get("phase"),
@@ -383,6 +398,7 @@ def _build_export_df(
             continue
         rows.append(
             {
+                "run_id": r.get("run_id", "run_000 (legacy)"),
                 "mas_id": r.get("mas_id", ""),
                 "agent_id": r.get("target_agent_id", ""),
                 "attack_type": r.get("injection_type", ""),
@@ -486,6 +502,16 @@ def _render_filters(
 
     # Left column
     with col_left:
+        available_runs = sorted(df["run_id"].unique(), reverse=True)
+        run_options = ["All"] + available_runs
+        default_run_idx = 1 if available_runs else 0
+        selected_run = st.selectbox(
+            "Run",
+            options=run_options,
+            index=default_run_idx,
+            key="atk_filter_run",
+        )
+
         if selected_suite == _ALL_SUITES:
             suite_opts = sorted(df["attack_suite"].unique())
             suites = st.multiselect(
@@ -567,6 +593,8 @@ def _render_filters(
         & df["injection_type"].isin(inj_types)
         & df["severity"].isin(severities)
     )
+    if selected_run != "All":
+        mask &= df["run_id"] == selected_run
     if phase != "All":
         mask &= df["phase"] == phase
     if tier3_status == "Tier-3 evaluated":
@@ -700,24 +728,37 @@ def _render_detail_panel(
     # Build lookup key → (tier3_score, tier1_pass) from the parsed DataFrame
     if is_cross_model and df_filtered["model_id"].notna().any():
         score_lookup: dict = {
-            (row["mas_id"], row["payload_id"], row["phase"], row["model_id"]): row
+            (
+                row["run_id"],
+                row["mas_id"],
+                row["payload_id"],
+                row["phase"],
+                row["model_id"],
+            ): row
             for _, row in df_filtered.iterrows()
         }
     else:
         score_lookup = {
-            (row["mas_id"], row["payload_id"], row["phase"], None): row
+            (row["run_id"], row["mas_id"], row["payload_id"], row["phase"], None): row
             for _, row in df_filtered.iterrows()
         }
 
     def _result_key(r: dict) -> tuple:
         if is_cross_model:
             return (
+                r.get("run_id", "run_000 (legacy)"),
                 r.get("mas_id"),
                 r.get("payload_id"),
                 r.get("phase"),
                 r.get("model_id"),
             )
-        return (r.get("mas_id"), r.get("payload_id"), r.get("phase"), None)
+        return (
+            r.get("run_id", "run_000 (legacy)"),
+            r.get("mas_id"),
+            r.get("payload_id"),
+            r.get("phase"),
+            None,
+        )
 
     visible = [r for r in results if _result_key(r) in score_lookup]
 

--- a/bili/aether/ui/attack_results_page.py
+++ b/bili/aether/ui/attack_results_page.py
@@ -482,13 +482,11 @@ def _render_filters(
     df: pd.DataFrame, selected_suite: str, is_cross_model: bool
 ) -> pd.DataFrame:
     """Render filter widgets and return filtered DataFrame."""
-    row1 = st.columns(4 if selected_suite != _ALL_SUITES else 5)
+    col_left, col_right = st.columns(2)
 
-    col_idx = 0
-
-    # Suite filter — only shown in All Suites view
-    if selected_suite == _ALL_SUITES:
-        with row1[col_idx]:
+    # Left column
+    with col_left:
+        if selected_suite == _ALL_SUITES:
             suite_opts = sorted(df["attack_suite"].unique())
             suites = st.multiselect(
                 "Suite",
@@ -496,29 +494,25 @@ def _render_filters(
                 default=suite_opts,
                 key="atk_filter_suite",
             )
-        col_idx += 1
-    else:
-        suites = list(df["attack_suite"].unique())
+        else:
+            suites = list(df["attack_suite"].unique())
 
-    with row1[col_idx]:
         configs = st.multiselect(
             "MAS Config",
             options=sorted(df["mas_id"].unique()),
             default=sorted(df["mas_id"].unique()),
             key="atk_filter_configs",
         )
-    col_idx += 1
 
-    with row1[col_idx]:
         inj_types = st.multiselect(
             "Attack Type",
             options=sorted(df["injection_type"].unique()),
             default=sorted(df["injection_type"].unique()),
             key="atk_filter_types",
         )
-    col_idx += 1
 
-    with row1[col_idx]:
+    # Right column
+    with col_right:
         present_sev = set(df["severity"].dropna().unique())
         ordered_sev = [s for s in _SEVERITY_ORDER if s in present_sev] + sorted(
             present_sev - set(_SEVERITY_ORDER)
@@ -529,15 +523,10 @@ def _render_filters(
             default=ordered_sev,
             key="atk_filter_severity",
         )
-    col_idx += 1
 
-    with row1[col_idx]:
         phase_opts = ["All"] + sorted(df["phase"].dropna().unique())
         phase = st.selectbox("Phase", options=phase_opts, key="atk_filter_phase")
 
-    # Second row: model_id filter for cross-model, Tier-3 score range
-    row2 = st.columns(3)
-    with row2[0]:
         tier3_status = st.selectbox(
             "Detection Tier",
             options=[
@@ -548,7 +537,7 @@ def _render_filters(
             ],
             key="atk_filter_tier",
         )
-    with row2[1]:
+
         if is_cross_model and df["model_id"].notna().any():
             model_opts = sorted(df["model_id"].dropna().unique())
             model_ids = st.multiselect(
@@ -559,7 +548,7 @@ def _render_filters(
             )
         else:
             model_ids = None
-    with row2[2]:
+
         if is_cross_model and df["provider_family"].notna().any():
             pf_opts = sorted(df["provider_family"].dropna().unique())
             provider_families = st.multiselect(

--- a/bili/aether/ui/baseline_runner_page.py
+++ b/bili/aether/ui/baseline_runner_page.py
@@ -209,14 +209,22 @@ def _resolve_config():
     )
 
     if selected_idx and selected_idx > 0:
-        # User explicitly picked a file — takes precedence over session state
+        # User explicitly picked a file — takes precedence over session state.
+        # Only reload if the selected file differs from what is currently cached
+        # to avoid a full disk read on every render.
         yaml_path_obj = yaml_files[selected_idx - 1]
-        try:
-            config = load_mas_from_yaml(str(yaml_path_obj))
-            return config, str(yaml_path_obj)
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            st.error(f"Failed to load `{yaml_path_obj.name}`: {exc}")
-            return None, None
+        if st.session_state.get("baseline_yaml_path") != str(yaml_path_obj):
+            try:
+                config = load_mas_from_yaml(str(yaml_path_obj))
+                st.session_state.baseline_config = config
+                st.session_state.baseline_yaml_path = str(yaml_path_obj)
+                for key in ("baseline_run_results",):
+                    st.session_state.pop(key, None)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                st.error(f"Failed to load `{yaml_path_obj.name}`: {exc}")
+                return None, None
+        config = st.session_state.get("baseline_config")
+        return config, str(yaml_path_obj)
 
     # Fall back to session state (pushed from visualizer)
     config = st.session_state.get("baseline_config")

--- a/bili/aether/ui/baseline_runner_page.py
+++ b/bili/aether/ui/baseline_runner_page.py
@@ -1,9 +1,9 @@
 """
 AETHER Baseline Runner page — launch AEGIS baseline suite from the GUI.
 
-Allows a user to push a MAS config from the AETHER visualizer and run all
-20 baseline prompts against it with live per-prompt progress.  Results are
-written to the same directory read by the Baseline Results viewer
+Allows a user to push a MAS config from the AETHER visualizer and run
+selected baseline prompts against it with live per-prompt progress.  Results
+are written to the same directory read by the Baseline Results viewer
 (``bili/aegis/suites/baseline/results/``).
 
 Called by the main Streamlit app (``bili/streamlit_app.py``) as a page within
@@ -60,6 +60,36 @@ def push_config_to_baseline_state(config: MASConfig, yaml_path: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Prompt selection helpers
+# ---------------------------------------------------------------------------
+
+
+def _init_prompt_selections() -> None:
+    """Initialize per-prompt session state keys to True if not already set."""
+    from bili.aegis.suites.baseline.prompts.baseline_prompts import (  # pylint: disable=import-outside-toplevel
+        BASELINE_PROMPTS,
+    )
+
+    for p in BASELINE_PROMPTS:
+        key = f"baseline_prompt_{p.prompt_id}"
+        if key not in st.session_state:
+            st.session_state[key] = True
+
+
+def _on_cat_header_change(hdr_key: str, prompt_ids: list) -> None:
+    """Propagate category header checkbox state to all child prompt checkboxes."""
+    new_val = st.session_state[hdr_key]
+    for pid in prompt_ids:
+        st.session_state[f"baseline_prompt_{pid}"] = new_val
+
+
+def _set_cat_prompts(prompt_ids: list, value: bool) -> None:
+    """Set all prompts in a category to *value* (used by Select/Deselect All)."""
+    for pid in prompt_ids:
+        st.session_state[f"baseline_prompt_{pid}"] = value
+
+
+# ---------------------------------------------------------------------------
 # Page entry point
 # ---------------------------------------------------------------------------
 
@@ -88,7 +118,7 @@ def _render_sidebar() -> None:
     st.markdown("---")
     st.markdown("#### Baseline Runner")
     st.markdown(
-        "Run the 20 baseline prompts against any AETHER MAS config. "
+        "Run baseline prompts against any AETHER MAS config. "
         "Results are saved to disk and visible in the **Baseline Results** viewer.\n\n"
         "Load a config from the **AETHER Multi-Agent System** page and click "
         "**Send to Baseline**, or select a YAML file below."
@@ -101,6 +131,8 @@ def _render_sidebar() -> None:
 
 
 def _render_main() -> None:
+    _init_prompt_selections()
+
     st.markdown("# AEGIS Baseline Runner")
     st.markdown(
         "Run the baseline prompt suite against a MAS configuration to establish "
@@ -126,17 +158,34 @@ def _render_main() -> None:
     )
     st.markdown("---")
 
-    selected_categories, stub_mode = _render_run_options()
+    stub_mode = _render_prompt_selector()
 
     st.markdown("---")
+
+    # Total count label above Run button
+    from bili.aegis.suites.baseline.prompts.baseline_prompts import (  # pylint: disable=import-outside-toplevel
+        BASELINE_PROMPTS,
+    )
+
+    total = len(BASELINE_PROMPTS)
+    n_sel = sum(
+        1
+        for p in BASELINE_PROMPTS
+        if st.session_state.get(f"baseline_prompt_{p.prompt_id}", True)
+    )
+    if n_sel == total:
+        st.caption(f"{total} prompts selected")
+    else:
+        st.caption(f"{n_sel} of {total} prompts selected")
 
     if st.button(
         "▶ Run Baseline",
         type="primary",
         use_container_width=True,
         key="run_baseline_btn",
+        disabled=(n_sel == 0),
     ):
-        _execute_run(config, yaml_path, selected_categories, stub_mode)
+        _execute_run(config, yaml_path, stub_mode)
 
     _render_previous_results()
 
@@ -175,49 +224,99 @@ def _resolve_config():
     return config, yaml_path
 
 
-def _render_run_options():
-    """Render category filter and stub toggle; return (selected_categories, stub_mode)."""
-    col1, col2 = st.columns([3, 1])
+def _render_prompt_selector() -> bool:
+    """Render the two-level prompt selection hierarchy and stub toggle.
 
-    with col1:
-        st.markdown("**Prompt categories to include:**")
-        cat_cols = st.columns(len(_CATEGORY_ORDER))
-        selected_categories = []
-        for i, cat in enumerate(_CATEGORY_ORDER):
-            icon = _CATEGORY_ICON.get(cat, "⚪")
-            checked = cat_cols[i].checkbox(
-                f"{icon} {_CATEGORY_LABELS[cat]}",
-                value=True,
-                key=f"baseline_cat_{cat}",
-            )
-            if checked:
-                selected_categories.append(cat)
+    Returns:
+        stub_mode (bool): Whether LLM calls should be skipped.
+    """
+    from bili.aegis.suites.baseline.prompts.baseline_prompts import (  # pylint: disable=import-outside-toplevel
+        BASELINE_PROMPTS,
+    )
 
-    with col2:
-        stub_mode = st.toggle(
-            "Stub mode",
-            value=False,
-            key="baseline_stub_mode",
-            help="Skip LLM calls — useful for structural verification without API spend.",
+    # Stub mode toggle (global setting, shown above the prompt list)
+    col_stub, _ = st.columns([1, 2])
+    stub_mode = col_stub.toggle(
+        "Stub mode",
+        value=False,
+        key="baseline_stub_mode",
+        help="Skip LLM calls — useful for structural verification without API spend.",
+    )
+    if stub_mode:
+        col_stub.caption("No LLM calls")
+
+    st.markdown("**Select prompts to run:**")
+
+    for cat in _CATEGORY_ORDER:
+        cat_prompts = [p for p in BASELINE_PROMPTS if p.category == cat]
+        prompt_ids = [p.prompt_id for p in cat_prompts]
+        icon = _CATEGORY_ICON.get(cat, "⚪")
+        label = _CATEGORY_LABELS[cat]
+
+        n_selected = sum(
+            1
+            for p in cat_prompts
+            if st.session_state.get(f"baseline_prompt_{p.prompt_id}", True)
         )
-        if stub_mode:
-            st.caption("No LLM calls")
+        n_total = len(cat_prompts)
+        all_checked = n_selected == n_total
 
-    return selected_categories, stub_mode
+        # Force-sync header to match current child state (bidirectional sync)
+        hdr_key = f"baseline_cat_hdr_{cat}"
+        st.session_state[hdr_key] = all_checked
+
+        # Category header checkbox
+        st.checkbox(
+            f"{icon} **{label}** ({n_selected}/{n_total})",
+            key=hdr_key,
+            on_change=_on_cat_header_change,
+            args=(hdr_key, prompt_ids),
+        )
+
+        # Select All / Deselect All convenience buttons
+        col_a, col_b, _ = st.columns([1, 1, 3])
+        col_a.button(
+            "Select All",
+            key=f"bl_sel_{cat}",
+            on_click=_set_cat_prompts,
+            args=(prompt_ids, True),
+            use_container_width=True,
+        )
+        col_b.button(
+            "Deselect All",
+            key=f"bl_desel_{cat}",
+            on_click=_set_cat_prompts,
+            args=(prompt_ids, False),
+            use_container_width=True,
+        )
+
+        # Individual prompt checkboxes (indented)
+        for p in cat_prompts:
+            preview = p.text[:60] + ("\u2026" if len(p.text) > 60 else "")
+            _, col_prompt = st.columns([0.05, 0.95])
+            with col_prompt:
+                st.checkbox(
+                    f"`{p.prompt_id}` \u2014 {preview}",
+                    key=f"baseline_prompt_{p.prompt_id}",
+                )
+
+    return stub_mode
 
 
-def _execute_run(
-    config, yaml_path: str, selected_categories: list, stub_mode: bool
-) -> None:
+def _execute_run(config, yaml_path: str, stub_mode: bool) -> None:
     """Run the selected baseline prompts and display live progress."""
     # pylint: disable=import-outside-toplevel
     from bili.aegis.suites.baseline.prompts.baseline_prompts import BASELINE_PROMPTS
     from bili.aegis.suites.baseline.run_baseline import run_one, write_result
 
-    prompts_to_run = [p for p in BASELINE_PROMPTS if p.category in selected_categories]
+    prompts_to_run = [
+        p
+        for p in BASELINE_PROMPTS
+        if st.session_state.get(f"baseline_prompt_{p.prompt_id}", True)
+    ]
 
     if not prompts_to_run:
-        st.warning("No prompts selected. Enable at least one category.")
+        st.warning("No prompts selected. Enable at least one prompt.")
         return
 
     # Deep-copy so stub mode does not mutate the session state config
@@ -227,15 +326,15 @@ def _execute_run(
             agent.model_name = None
 
     results = []
-    progress_bar = st.progress(0, text="Starting baseline run…")
+    progress_bar = st.progress(0, text="Starting baseline run\u2026")
     status_area = st.container()
 
     passed = 0
     for i, prompt in enumerate(prompts_to_run):
-        icon = _CATEGORY_ICON.get(prompt.category, "⚪")
+        icon = _CATEGORY_ICON.get(prompt.category, "\u26aa")
         progress_bar.progress(
             i / len(prompts_to_run),
-            text=f"Running {prompt.prompt_id} ({i + 1}/{len(prompts_to_run)})…",
+            text=f"Running {prompt.prompt_id} ({i + 1}/{len(prompts_to_run)})\u2026",
         )
 
         try:
@@ -249,7 +348,7 @@ def _execute_run(
             success = False
             duration = 0.0
 
-        status_icon = "✅" if success else "❌"
+        status_icon = "\u2705" if success else "\u274c"
         if success:
             passed += 1
 
@@ -257,14 +356,14 @@ def _execute_run(
             st.markdown(
                 f"{status_icon} {icon} `{prompt.prompt_id}` "
                 f"({_CATEGORY_LABELS.get(prompt.category, prompt.category)}) "
-                f"— {duration:.0f} ms"
+                f"\u2014 {duration:.0f} ms"
             )
 
         if result:
             results.append(result)
 
     total = len(prompts_to_run)
-    progress_bar.progress(1.0, text=f"Complete — {passed}/{total} passed")
+    progress_bar.progress(1.0, text=f"Complete \u2014 {passed}/{total} passed")
 
     st.session_state.baseline_run_results = results
 
@@ -272,7 +371,7 @@ def _execute_run(
         st.success(f"All {total} prompts passed.")
     else:
         failed = total - passed
-        st.warning(f"{passed}/{total} passed — {failed} failed.")
+        st.warning(f"{passed}/{total} passed \u2014 {failed} failed.")
 
     st.info("Navigate to **Baseline Results** in the sidebar to view your results.")
 

--- a/bili/aether/ui/baseline_runner_page.py
+++ b/bili/aether/ui/baseline_runner_page.py
@@ -267,7 +267,7 @@ def _render_prompt_selector() -> bool:
             if st.session_state.get(f"baseline_prompt_{p.prompt_id}", True)
         )
         n_total = len(cat_prompts)
-        all_checked = n_selected == n_total
+        all_checked = n_selected == n_total and n_total > 0
 
         # Force-sync header to match current child state (bidirectional sync)
         hdr_key = f"baseline_cat_hdr_{cat}"

--- a/bili/aether/ui/baseline_runner_page.py
+++ b/bili/aether/ui/baseline_runner_page.py
@@ -311,9 +311,19 @@ def _render_prompt_selector() -> bool:
     return stub_mode
 
 
+_BASELINE_RESULTS_DIR = (
+    Path(__file__).resolve().parent.parent.parent
+    / "aegis"
+    / "suites"
+    / "baseline"
+    / "results"
+)
+
+
 def _execute_run(config, yaml_path: str, stub_mode: bool) -> None:
     """Run the selected baseline prompts and display live progress."""
     # pylint: disable=import-outside-toplevel
+    from bili.aegis.suites._helpers import next_run_dir
     from bili.aegis.suites.baseline.prompts.baseline_prompts import BASELINE_PROMPTS
     from bili.aegis.suites.baseline.run_baseline import run_one, write_result
 
@@ -333,6 +343,10 @@ def _execute_run(config, yaml_path: str, stub_mode: bool) -> None:
         for agent in run_config.agents:
             agent.model_name = None
 
+    run_dir = next_run_dir(_BASELINE_RESULTS_DIR / run_config.mas_id)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    st.caption(f"Saving to `{run_dir.name}`")
+
     results = []
     progress_bar = st.progress(0, text="Starting baseline run\u2026")
     status_area = st.container()
@@ -347,7 +361,7 @@ def _execute_run(config, yaml_path: str, stub_mode: bool) -> None:
 
         try:
             result = run_one(run_config, yaml_path, prompt, stub_mode=stub_mode)
-            write_result(result)
+            write_result(result, run_dir=run_dir)
             success = result["execution"]["success"]
             duration = result["execution"]["duration_ms"]
         except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/bili/aether/ui/page.py
+++ b/bili/aether/ui/page.py
@@ -269,7 +269,8 @@ def _on_send_to_attack() -> None:
     if config is None:
         return
     config = apply_agent_overrides(config)
-    push_config_to_attack_state(config)
+    yaml_path = st.session_state.get("current_yaml_path", "")
+    push_config_to_attack_state(config, yaml_path=yaml_path)
 
 
 def _load_config(yaml_path: Path) -> None:

--- a/bili/aether/ui/results_page.py
+++ b/bili/aether/ui/results_page.py
@@ -62,7 +62,11 @@ def _load_baseline_results() -> list[dict]:
             # Determine run_id from path structure
             parts = path.relative_to(BASELINE_RESULTS_DIR).parts
             # parts[0]=mas_id, parts[1]=run_NNN or prompt_file (legacy)
-            if len(parts) >= 3:
+            if (
+                len(parts) >= 3
+                and parts[1].startswith("run_")
+                and parts[1][4:].isdigit()
+            ):
                 raw["run_id"] = parts[1]
             else:
                 raw["run_id"] = "run_000 (legacy)"

--- a/bili/aether/ui/results_page.py
+++ b/bili/aether/ui/results_page.py
@@ -48,13 +48,25 @@ _CATEGORY_ORDER = ["benign", "edge_case", "violating"]
 def _load_baseline_results() -> list[dict]:
     """Return all parsed JSON result dicts from the baseline results directory.
 
+    Injects a ``run_id`` key derived from the file path into every result dict:
+    - Versioned layout ``results/{mas_id}/run_NNN/{prompt}.json`` → ``run_NNN``
+    - Legacy flat layout ``results/{mas_id}/{prompt}.json`` → ``run_000 (legacy)``
+
     Cached with a 30-second TTL so new result files appear promptly without
     re-reading disk on every filter interaction or expander toggle.
     """
     results: list[dict] = []
     for path in sorted(BASELINE_RESULTS_DIR.glob("**/*.json")):
         try:
-            results.append(json.loads(path.read_text(encoding="utf-8")))
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            # Determine run_id from path structure
+            parts = path.relative_to(BASELINE_RESULTS_DIR).parts
+            # parts[0]=mas_id, parts[1]=run_NNN or prompt_file (legacy)
+            if len(parts) >= 3:
+                raw["run_id"] = parts[1]
+            else:
+                raw["run_id"] = "run_000 (legacy)"
+            results.append(raw)
         except Exception as exc:  # pylint: disable=broad-exception-caught
             LOGGER.warning("Could not parse %s: %s", path, exc)
     return results
@@ -71,6 +83,7 @@ def _build_dataframe(results: list[dict]) -> pd.DataFrame:
         try:
             rows.append(
                 {
+                    "run_id": r.get("run_id", "run_000 (legacy)"),
                     "mas_id": r["mas_id"],
                     "prompt_id": r["prompt_id"],
                     "category": r["prompt_category"],
@@ -198,6 +211,7 @@ def _build_baseline_export_df(df_filtered: pd.DataFrame) -> pd.DataFrame:
     """
     renamed = df_filtered.rename(columns={"success": "tier1_success"})
     export_cols = [
+        "run_id",
         "mas_id",
         "prompt_id",
         "category",
@@ -222,9 +236,14 @@ def _render_export_buttons(results: list[dict], df_filtered: pd.DataFrame) -> No
     if df_filtered.empty:
         return
 
-    visible_keys = set(zip(df_filtered["mas_id"], df_filtered["prompt_id"]))
+    visible_keys = set(
+        zip(df_filtered["run_id"], df_filtered["mas_id"], df_filtered["prompt_id"])
+    )
     matched = [
-        r for r in results if (r.get("mas_id"), r.get("prompt_id")) in visible_keys
+        r
+        for r in results
+        if (r.get("run_id", "run_000 (legacy)"), r.get("mas_id"), r.get("prompt_id"))
+        in visible_keys
     ]
 
     unique_mas = df_filtered["mas_id"].dropna().unique()
@@ -272,12 +291,24 @@ def _render_summary_metrics(df: pd.DataFrame) -> None:
 
 def _render_filters(df: pd.DataFrame) -> pd.DataFrame:
     """Render filter widgets and return the filtered DataFrame."""
-    col1, col2, col3 = st.columns(3)
+    col0, col1, col2, col3 = st.columns(4)
+    with col0:
+        available_runs = sorted(df["run_id"].unique(), reverse=True)
+        run_options = ["All"] + available_runs
+        # Default to the latest run (index 1) when runs exist
+        default_run_idx = 1 if len(available_runs) > 0 else 0
+        selected_run = st.selectbox(
+            "Run",
+            options=run_options,
+            index=default_run_idx,
+            key="baseline_filter_run",
+        )
     with col1:
+        run_df = df if selected_run == "All" else df[df["run_id"] == selected_run]
         configs = st.multiselect(
             "MAS Config",
-            options=sorted(df["mas_id"].unique()),
-            default=sorted(df["mas_id"].unique()),
+            options=sorted(run_df["mas_id"].unique()),
+            default=sorted(run_df["mas_id"].unique()),
             key="baseline_filter_configs",
         )
     with col2:
@@ -299,6 +330,8 @@ def _render_filters(df: pd.DataFrame) -> pd.DataFrame:
         )
 
     filtered = df[df["mas_id"].isin(configs) & df["category"].isin(categories)]
+    if selected_run != "All":
+        filtered = filtered[filtered["run_id"] == selected_run]
     if status == "Passed":
         filtered = filtered[filtered["success"]]
     elif status == "Failed":
@@ -348,8 +381,15 @@ def _render_detail_panel(results: list[dict], df_filtered: pd.DataFrame) -> None
     if df_filtered.empty:
         return
 
-    visible_keys = set(zip(df_filtered["mas_id"], df_filtered["prompt_id"]))
-    visible = [r for r in results if (r["mas_id"], r["prompt_id"]) in visible_keys]
+    visible_run_keys = set(
+        zip(df_filtered["run_id"], df_filtered["mas_id"], df_filtered["prompt_id"])
+    )
+    visible = [
+        r
+        for r in results
+        if (r.get("run_id", "run_000 (legacy)"), r["mas_id"], r["prompt_id"])
+        in visible_run_keys
+    ]
 
     cat_rank = {c: i for i, c in enumerate(_CATEGORY_ORDER)}
     visible.sort(
@@ -373,10 +413,11 @@ def _render_detail_panel(results: list[dict], df_filtered: pd.DataFrame) -> None
         with st.expander(label, expanded=False):
             st.markdown(f"**Prompt:** {r.get('prompt_text', '(no prompt text)')}")
 
-            c1, c2, c3 = st.columns(3)
+            c1, c2, c3, c4 = st.columns(4)
             c1.markdown(f"**Category:** `{r.get('prompt_category', '?')}`")
-            c2.markdown(f"**Stub:** {'Yes' if run_metadata.get('stub_mode') else 'No'}")
-            c3.markdown(f"**Agents:** {execution.get('agent_count', '?')}")
+            c2.markdown(f"**Run:** `{r.get('run_id', '?')}`")
+            c3.markdown(f"**Stub:** {'Yes' if run_metadata.get('stub_mode') else 'No'}")
+            c4.markdown(f"**Agents:** {execution.get('agent_count', '?')}")
             st.caption(f"Run at {run_metadata.get('timestamp', 'unknown')}")
 
             agent_outputs = r.get("agent_outputs", {})


### PR DESCRIPTION
### This PR introduces the following changes

* **Baseline Runner — two-level prompt selection:** Replaces the flat category filter with a full checkbox hierarchy. Each category (Benign, Edge Case, Violating) has a header checkbox that cascades to all child prompts, plus per-category Select All / Deselect All buttons. A live count caption and a disabled Run button (when 0 prompts selected) make the selection state always visible.

* **Attack Suite — YAML config selector:** Adds a file-picker dropdown at the top of the Attack Suite sidebar (mirroring the Baseline Runner), so any example YAML can be loaded directly without going through the AETHER visualizer. Config pushed via "Send to Attack Suite" continues to work as before; the `yaml_path` is now stored in session state and forwarded through `push_config_to_attack_state()` and `_on_send_to_attack()`.

* **Attack Suite — two-level payload selection (main area):** Adds a suite-level / payload-level checkbox hierarchy in the main content area covering all five suites (Prompt Injection, Jailbreak, Memory Poisoning, Bias Inheritance, Agent Impersonation). Each payload displays a severity badge (`[HIGH]` / `[MED]` / `[LOW]`). Suite headers, Select All / Deselect All buttons, and individual payload checkboxes all sync bidirectionally using the same stateless pattern as the Baseline Runner.

* **Attack Suite — batch run execution:** A dynamic "▶ Run N attack(s) across M suite(s)" button runs all selected payloads in one pass via `run_suite()`, with a live progress bar and per-suite status rows. Results are written to disk and visible in the Attack Results viewer. The single-payload exploratory attack flow (sidebar) is preserved unchanged.

* **Fix: `run_suite()` hang in Streamlit:** `run_suite()` is a CLI tool that calls `sys.exit()` after writing results. When invoked from Streamlit, `SystemExit` escaped the `except Exception` block and stalled the UI indefinitely. The batch runner now catches `SystemExit` after results are safely on disk, allowing execution to continue normally. CLI usage is unaffected.

* **New example preset — `deliberative_consensus.yaml`:** Adds a generic academic paper review MAS with a fan-out / fan-in topology (moderator → three independent reviewers in parallel → arbiter). All agents use `model_name: null` for stub-compatible execution out of the box.

* **Test + docstring fixes:** Updates `test_baseline_runner.py` to reference the public `run_one` / `write_result` names (following an earlier rename from the underscore-prefixed private versions), and corrects a stale docstring in `baseline_runner_page.py`.

---

### Steps to Review

1. Checkout the `66-task-27-v2-document-aether-architecture-implementation-polish-functionalities` branch on your local machine
2. Start the Streamlit app (`streamlit` alias inside the container, or `python -m streamlit run bili/streamlit_app.py`)
3. Navigate to **AEGIS Baseline Runner** — confirm all prompts are checked by default, category headers cascade correctly to children, Select All / Deselect All work per category, and the run count caption updates as you toggle prompts
4. Run the baseline in stub mode with a subset of prompts selected; verify only the selected prompts execute and results are written to `bili/aegis/suites/baseline/results/`
5. Navigate to **AEGIS Attack Suite** — confirm the YAML config selector appears at the top of the sidebar and loads a config when a file is chosen
6. Verify the two-level payload hierarchy renders in the main area with severity badges, and that suite header checkboxes cascade to their child payloads
7. Run a batch attack in stub mode with a single suite selected; confirm the progress bar advances, the suite completes without hanging, and results appear in the Attack Results viewer
8. Use the single-payload "Run Attack" flow in the sidebar to confirm the existing exploratory attack path still works end-to-end
9. Open `bili/aether/config/examples/deliberative_consensus.yaml` in the AETHER visualizer; verify the graph renders with the correct fan-out topology and stub execution succeeds
10. Run `pytest bili/aegis/tests/test_baseline_runner.py` and confirm all six tests pass
