### PR TITLE
chore(governance,ci): OSS policy docs + SHA-pin actions + author_association gate (Phases 1+2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,38 @@
+# Code owners for sensitive paths in bili-core.
+#
+# CODEOWNERS enforces required reviews on the listed paths via branch protection.
+# Anyone listed here must be a direct collaborator on this repository (inherited
+# permissions silently fail to enforce CODEOWNERS rules).
+#
+# Format: <path-pattern> <@owner1> <@owner2> ...
+
+# Default owner for everything not matched below
+*                                 @daniel-pittman
+
+# CI/CD workflows can exfiltrate secrets or weaken the deploy pipeline
+/.github/                         @daniel-pittman
+/.github/workflows/               @daniel-pittman
+/.github/dependabot.yml           @daniel-pittman
+/.github/CODEOWNERS               @daniel-pittman
+
+# Build, packaging, and dependency manifests cross the supply chain
+/setup.py                         @daniel-pittman
+/requirements.txt                 @daniel-pittman
+/Dockerfile                       @daniel-pittman
+/docker-compose.yml               @daniel-pittman
+/run_python_formatters.sh         @daniel-pittman
+/.pre-commit-config.yaml          @daniel-pittman
+/.pylintrc                        @daniel-pittman
+
+# Project governance documents
+/SECURITY.md                      @daniel-pittman
+/CONTRIBUTING.md                  @daniel-pittman
+/LICENSE                          @daniel-pittman
+/CLAUDE.md                        @daniel-pittman
+
+# Authentication and authorization paths
+/bili/auth/                       @daniel-pittman
+/bili/flask_api/                  @daniel-pittman
+
+# AEGIS security framework
+/bili/aegis/                      @daniel-pittman

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Report a defect in bili-core
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please do not use this
+        template for security vulnerabilities. See [SECURITY.md](https://github.com/msu-denver/bili-core/blob/develop/SECURITY.md)
+        for the private disclosure process.
+
+  - type: input
+    id: version
+    attributes:
+      label: bili-core version
+      description: Release tag, branch, or commit SHA where you observed the issue.
+      placeholder: "v5.1.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of bili-core does this affect?
+      options:
+        - IRIS (single-agent RAG)
+        - AETHER (multi-agent orchestration)
+        - AEGIS (security and adversarial evaluation)
+        - Authentication (bili/auth)
+        - Flask API
+        - Streamlit UI
+        - Container / build / deploy
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps so a maintainer can hit the same failure.
+      placeholder: |
+        1. Start the container with `./scripts/development/start-container.sh`
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and stack traces
+      description: Paste relevant log output. Redact any credentials or personal data.
+      render: shell
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version, container vs. host, GPU vs. CPU.
+      placeholder: |
+        - OS: macOS 14.5
+        - Python: 3.11.7
+        - Mode: container (CPU profile)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/msu-denver/bili-core/security/advisories/new
+    about: |
+      Please do NOT report security vulnerabilities through public issues.
+      Use Private Vulnerability Reporting (PVR) instead. See SECURITY.md
+      for full disclosure policy and what to include.
+  - name: Question or discussion
+    url: https://github.com/msu-denver/bili-core/discussions
+    about: |
+      For open-ended questions, design discussions, or asking how to use
+      bili-core, please start a Discussion instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: Feature request
+description: Propose a new feature or enhancement for bili-core
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of bili-core would this affect?
+      options:
+        - IRIS (single-agent RAG)
+        - AETHER (multi-agent orchestration)
+        - AEGIS (security and adversarial evaluation)
+        - Authentication (bili/auth)
+        - Flask API
+        - Streamlit UI
+        - Container / build / deploy
+        - Cross-cutting / new component
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve? Who is the user, and what are they trying to do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: A clear description of the feature and how it should behave.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why you preferred this one.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Mockups, links to related issues, references to upstream literature, or anything else useful.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,72 @@
+# Dependabot configuration for bili-core.
+#
+# Tracks updates for:
+#   - Python packages declared in requirements.txt
+#   - GitHub Actions referenced in .github/workflows/
+#
+# Dependabot opens one PR per outdated dependency, grouped where it makes sense
+# to keep review burden manageable. Security updates run independently of this
+# schedule via the "Dependabot security updates" repo setting.
+
+version: 2
+updates:
+  # Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "America/Denver"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      langchain-ecosystem:
+        patterns:
+          - "langchain*"
+          - "langgraph*"
+      llm-providers:
+        patterns:
+          - "langchain-aws"
+          - "langchain-anthropic"
+          - "langchain-openai"
+          - "langchain-google-vertexai"
+          - "langchain-huggingface"
+      ml-frameworks:
+        patterns:
+          - "torch*"
+          - "transformers"
+          - "accelerate"
+          - "sentence-transformers"
+          - "tensorflow*"
+          - "tf-keras"
+          - "keras"
+      dev-tooling:
+        patterns:
+          - "black"
+          - "isort"
+          - "autoflake"
+          - "pylint*"
+          - "pre-commit"
+          - "pytest*"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "America/Denver"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,11 +12,11 @@ jobs:
         steps:
             # Checkout code
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
             # Set up Python
             - name: Set up Python
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
               with:
                 python-version: '3.11'
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -14,13 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 2
 
       - name: Run Claude Security Review
-        uses: anthropics/claude-code-security-review@main
+        # Pinned to main HEAD as of 2026-02-11. The security-review action
+        # does not currently publish semver tags; track the SHA and bump
+        # manually after auditing main history.
+        uses: anthropics/claude-code-security-review@0c6a49f1fa56a1d472575da86a94dbc1edb78eda
         with:
           claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           comment-pr: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,26 @@ on:
 
 jobs:
   claude:
+    # Restrict the @claude bot to users with write access on this repository.
+    # OWNER / MEMBER / COLLABORATOR all have write; CONTRIBUTOR (anyone with a
+    # merged PR) is deliberately excluded to bound credit-burn from drive-by
+    # mentions. The outside-collaborator approval gate (Settings -> Actions)
+    # is the upstream cost-control layer; this gate is the application-level
+    # backstop.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR' ||
+       github.event.review.author_association == 'OWNER' ||
+       github.event.review.author_association == 'MEMBER' ||
+       github.event.review.author_association == 'COLLABORATOR' ||
+       github.event.issue.author_association == 'OWNER' ||
+       github.event.issue.author_association == 'MEMBER' ||
+       github.event.issue.author_association == 'COLLABORATOR') &&
+      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -26,13 +41,13 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           include_fix_links: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to bili-core
+
+Thank you for your interest in contributing. bili-core is an open-source research framework, and contributions of all kinds are welcome: bug reports, fixes, new features, documentation improvements, and adversarial test payloads for AEGIS.
+
+This document covers how to file issues, the contribution workflow, and a few rules that apply to anything that lands in the public repository.
+
+## Reporting bugs and requesting features
+
+- Use [GitHub Issues](https://github.com/msu-denver/bili-core/issues) for bug reports, feature requests, and questions.
+- **Do not report security vulnerabilities in public issues.** Use the process described in [SECURITY.md](SECURITY.md) instead.
+- When reporting a bug, include the version of bili-core (release tag, branch, or commit SHA), the relevant component (IRIS, AETHER, AEGIS, auth, Flask, Streamlit), and a minimal reproduction.
+
+## Development workflow
+
+bili-core uses a GitFlow-shaped branching model.
+
+- The default branch is `develop`. Feature work targets `develop`.
+- `main` only receives merges from `develop` as part of a tagged release.
+- Feature branches use the prefix `feat/`, `fix/`, `chore/`, or `docs/` followed by a short descriptive slug (e.g. `feat/aegis-new-attack-suite`, `fix/checkpoint-race`).
+
+### Setting up the development environment
+
+The container-based development environment is the supported path. See the top-level [README.md](README.md) for the full setup walkthrough.
+
+```bash
+cd scripts/development
+./start-container.sh
+./attach-container.sh
+```
+
+Inside the container, `streamlit` starts the UI on port 8501 and `flask` starts the API on port 5001.
+
+### Code quality
+
+Before opening a pull request:
+
+- Run `./run_python_formatters.sh` to apply Black, Autoflake, and Isort.
+- Run `pylint bili/ --fail-under=9` to confirm the lint score is at least 9.0.
+- Add tests for new functionality. Existing test conventions for each component live under `bili/<component>/tests/`.
+- Use type hints throughout new code.
+
+The pre-commit hooks enforce most of the above automatically.
+
+### Opening a pull request
+
+- Target `develop`, not `main`.
+- Reference the issue your PR addresses, if applicable.
+- Write a PR body that summarizes the change in 2–3 sentences and lists any user-visible behavior changes.
+- The Claude code review workflow will run automatically on every push and post a review comment. Address the substantive findings before requesting human review.
+- Conversations on PR comments must be marked as resolved before the PR is merged.
+
+## Automated review
+
+Three Claude-driven review workflows run on PRs in this repository:
+
+- **Claude Code Review** runs on every PR push and posts a single review comment surfacing correctness, style, and small-scale design issues.
+- **Claude Security Review** runs on PRs targeting `main` or `develop` and performs a deeper pass focused on security-relevant changes (input handling, authentication paths, secret handling, supply-chain regressions).
+- **@claude bot** is available in PR and issue comments for follow-up questions and targeted fixes. The bot only responds to comments from users with write access to the repository.
+
+The reviews are best treated as a strong first pass, not a substitute for human review of substantive changes. Address the substantive findings; a final summary line from the reviewer noting that remaining items are "low-severity wording quibbles, none block merge" is a reasonable place to stop iterating.
+
+## No personal data in public code
+
+bili-core is a public repository. Test fixtures, example configurations, comments, and documentation must not include real personal names, real institutional abbreviations beyond MSU Denver itself, or real email addresses.
+
+Use these substitutions:
+
+- Personal names: Alice Garcia, Bob Jones, Carol Lee, Maria A. Smith. Generic enough not to identify anyone.
+- Institutional abbreviations in examples: ZX, YW, FOO, BAR.
+- Email addresses: `@example.com` or `@example.edu` (RFC-reserved domains).
+
+The discipline is to apply the substitution at the moment of writing the test, not after the fact. Force-pushing a feature branch to scrub a commit that already contains real names is possible but is best avoided.
+
+## License
+
+bili-core is licensed under the MIT License (see [LICENSE](LICENSE)). By contributing, you agree that your contributions are licensed under the same terms.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+bili-core uses GitHub's Private Vulnerability Reporting (PVR) for confidential disclosure.
+
+### How to report
+
+- Go to the [Security tab](https://github.com/msu-denver/bili-core/security/advisories/new) of this repository and open a new private advisory.
+- Alternatively, email `dpittma8@msudenver.edu` with the subject line `bili-core security report`.
+
+### What to include
+
+- A description of the issue and its potential impact (which component, what an attacker could achieve).
+- Steps to reproduce, ideally with a minimal proof-of-concept.
+- The version of bili-core where you observed the issue (release tag, branch, or commit SHA).
+- Any suggested mitigation if you have one.
+
+### What to expect
+
+- Acknowledgement within 5 business days.
+- A coordinated disclosure timeline once the maintainers have triaged the report. We aim to ship a fix within 30 days for high-severity issues; lower-severity issues may be batched into the next release.
+- Credit in the release notes for the fix, if you would like to be acknowledged.
+
+## Supported Versions
+
+bili-core is research software; security fixes ship on the current major version line. Versions older than the current major are not supported.
+
+| Version | Supported |
+|---------|-----------|
+| 5.x     | ✓         |
+| < 5.0   | ✗         |
+
+## Scope
+
+This policy covers the bili-core framework code in this repository:
+
+- IRIS, AETHER, and AEGIS components and their supporting infrastructure (`bili/`)
+- Authentication and authorization paths (`bili/auth/`, `bili/flask_api/`)
+- The Streamlit and Flask interfaces
+- CI/CD workflows and build / packaging scripts
+- Container build configuration
+
+The following are explicitly out of scope:
+
+- Vulnerabilities in upstream dependencies that are tracked by Dependabot and have not yet been triaged. Please report those to the upstream project.
+- Adversarial behavior of LLM models invoked by bili-core. AEGIS exists specifically to study LLM adversarial robustness; reports of model misbehavior are research findings rather than vulnerabilities in this framework.
+- Issues that require physical or root access to the host running bili-core.
+- Misconfiguration of downstream deployments using bili-core as a library. Please report those to the deployment owner.
+
+## Threat Model
+
+bili-core is intended to run in research or evaluation environments. Production deployments must implement their own controls for credential management, network egress, and tenant isolation. The framework provides primitives; the deployment is responsible for hardening.


### PR DESCRIPTION
## Summary

First half of the OSS hardening pass against the [secure_cicd_approach methodology](https://github.com/anthropics/secure_cicd_approach) (Track A — library/CLI, no cloud deploy). Combines policy docs (originally Phase 1) with workflow hardening (originally Phase 2). Phase 2 was pulled forward because the existing tag-pinned workflows were already silently broken: the repo-level "Require actions to be pinned to a full-length commit SHA" setting is enabled, which means the previous `@v4` / `@v1` / `@main` references were refused at workflow startup. None of the Claude reviews have actually been running on PRs.

This PR makes the workflows compatible with the SHA-pin enforcement so review actually fires (it should run on this PR's own latest commit).

## What this adds

### Phase 1 — Governance documents (commit `14ebb0b`)
- **`SECURITY.md`** — vulnerability disclosure policy. Routes reporters to GitHub Private Vulnerability Reporting. Carves out adversarial LLM behavior as AEGIS research output rather than a framework vulnerability.
- **`CONTRIBUTING.md`** — GitFlow workflow (target `develop`), code-quality requirements, descriptions of the three Claude review workflows from a contributor's perspective, and the no-personal-data rule with fictional-substitution defaults.
- **`.github/CODEOWNERS`** — required-review enforcement on `.github/`, build/packaging manifests, governance docs, `bili/auth/`, `bili/flask_api/`, and `bili/aegis/`. Owner is `@daniel-pittman`, verified as a direct collaborator (the direct-membership requirement silently fails to enforce if violated).
- **`.github/dependabot.yml`** — weekly pip and github-actions update schedule, grouped to keep review burden manageable.
- **`.github/ISSUE_TEMPLATE/config.yml`** — routes security reports to PVR.
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** and **`feature_request.yml`** — structured templates with IRIS / AETHER / AEGIS component selector.

### Phase 2 — Workflow hardening (commit `2b3c4a9`)
- **SHA-pinned all GitHub Actions** across all four workflows (`ci-cd.yml`, `claude-code-review.yml`, `claude-security-review.yml`, `claude.yml`). Each pin includes a `# v<version>` comment so reviewers can sanity-check the version.
- **`anthropics/claude-code-security-review`** moved from `@main` (HEAD-tracking, worse than tag-pinning) to a specific SHA from main as of 2026-02-11.
- **`author_association` gate added to the `@claude` bot** in `claude.yml`. Only users with write access (OWNER / MEMBER / COLLABORATOR) can summon Claude. CONTRIBUTOR (anyone with a merged PR ever) is deliberately excluded.

## What remains for later PRs

- **Phase 3**: Enable repo-level secret scanning, push protection, and Dependabot security updates via the GitHub API. Add branch protection to `main` and `develop` with `enforce_admins: false`. Set `delete_branch_on_merge: true`.
- **Phase 4**: Trim badges (drop static `tests-6900+` and `coverage-90%`, prune stack-disclosure shields). Add social preview image at `docs/img/social-preview.png` and upload via Settings → General.

## Test plan

- [ ] Claude Code Review fires on this PR's latest push (it should now, since the workflow YAML in HEAD has SHA pins).
- [ ] Claude Security Review fires on this PR's latest push (same).
- [ ] `actions/checkout` and `actions/setup-python` resolve cleanly in `ci-cd.yml` and the lint job runs.
- [ ] No source code is modified; CI should pass without behavioral changes.
- [ ] `.github/CODEOWNERS` parses cleanly (will be exercised under branch protection in Phase 3).
- [ ] `.github/dependabot.yml` parses cleanly (will be exercised when GitHub schedules the first run after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)