### PR TITLE
chore(ci): trigger build-application on pull_request and protected-branch push

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,9 +1,14 @@
 name: Bili Core CI/CD Pipeline
 
 on:
+    # Run on PRs against any branch (gates merges via branch protection's
+    # required status check), and on direct pushes to the protected branches
+    # main and develop (covers post-merge runs and admin-bypass pushes).
+    # Feature-branch pushes do not double-trigger CI; the pull_request
+    # event covers them once a PR is open.
+    pull_request:
     push:
-        branches:
-            - '*'  # Trigger on any branch
+        branches: [main, develop]
 
 jobs:
     # Build the application on any branch commit

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,15 @@ on:
     push:
         branches: [main, develop]
 
+# Default GITHUB_TOKEN permissions for every job in this workflow. Limited to
+# contents:read so an attacker who modifies a script that runs in CI (such as
+# scripts/build/build-and-test.sh) cannot use the token to write to the repo,
+# even on internal-collaborator PRs that bypass the outside-collaborator
+# approval gate. Fork PRs already get a read-only token by GitHub default;
+# this block extends that default to internal PRs as well.
+permissions:
+    contents: read
+
 jobs:
     # Build the application on any branch commit
     build-application:


### PR DESCRIPTION
## Summary

Prerequisite for Phase 3 of the OSS hardening pass. Two reasons for the change:

1. Phase 3's branch protection will add `build-application` as a required status check on `main` and `develop`. The previous `push: branches: ['*']` trigger only catches the check on the PR's HEAD SHA via the upstream feature-branch push, which is fragile and does not cover fork PRs at all (fork pushes run in the fork's own Actions, not in the parent repo's). Adding `pull_request:` makes the required check fire reliably on every PR.

2. Switching to `pull_request:` + `push: [main, develop]` removes the double-trigger that would have occurred if both `push: [*]` and `pull_request:` were active. Feature-branch direct pushes no longer get CI, but those branches get CI the moment a PR is opened (which is when the check actually matters).

The "Require approval for all outside collaborators" gate (Settings → Actions) remains the cost-control layer for fork PR pushes — CI will only run after maintainer approval for outside contributors.

## Secondary purpose

This PR is also a real end-to-end test of the Claude review pipeline now that the SHA-pinned workflow YAML is on `develop`. The first PR to test that the review actually runs on a non-workflow-modifying change.

## Test plan

- [ ] `claude-review` and `security-review` checks fire on this PR's push.
- [ ] `build-application` check fires on this PR (via the new `pull_request` trigger).
- [ ] All three checks complete successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)