### PR TITLE
docs(readme): trim README badge collection to the four reality-backed badges

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -5,30 +5,10 @@
 # BiliCore: An Open-Source LLM Framework
 
 <p align="center">
-  <a href="https://github.com/msu-denver/bili-core/actions"><img src="https://github.com/msu-denver/bili-core/actions/workflows/ci-cd.yml/badge.svg?branch=develop" alt="CI/CD"></a>
+  <a href="https://github.com/msu-denver/bili-core/actions/workflows/ci-cd.yml"><img src="https://github.com/msu-denver/bili-core/actions/workflows/ci-cd.yml/badge.svg?branch=develop" alt="CI/CD"></a>
   <a href="https://github.com/msu-denver/bili-core/releases/latest"><img src="https://img.shields.io/github/v/release/msu-denver/bili-core" alt="Latest Release"></a>
-  <img src="https://img.shields.io/badge/python-3.11+-blue.svg" alt="Python 3.11+">
-  <img src="https://img.shields.io/badge/tests-6900%2B%20passing-brightgreen.svg" alt="6900+ Tests">
-  <img src="https://img.shields.io/badge/coverage-90%25-brightgreen.svg" alt="Coverage">
-  <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
-</p>
-
-<p align="center">
-  <img src="https://img.shields.io/badge/LangChain-framework-orange.svg" alt="LangChain">
-  <img src="https://img.shields.io/badge/LangGraph-orchestration-orange.svg" alt="LangGraph">
-  <img src="https://img.shields.io/badge/Streamlit-UI-red.svg" alt="Streamlit">
-  <img src="https://img.shields.io/badge/Flask-API-lightgrey.svg" alt="Flask">
-  <img src="https://img.shields.io/badge/Docker-containerized-blue.svg" alt="Docker">
-  <img src="https://img.shields.io/badge/PostgreSQL-state-336791.svg" alt="PostgreSQL">
-  <img src="https://img.shields.io/badge/MongoDB-state-47A248.svg" alt="MongoDB">
-</p>
-
-<p align="center">
-  <img src="https://img.shields.io/badge/AWS_Bedrock-supported-FF9900.svg" alt="AWS Bedrock">
-  <img src="https://img.shields.io/badge/Google_Vertex_AI-supported-4285F4.svg" alt="Google Vertex AI">
-  <img src="https://img.shields.io/badge/Azure_OpenAI-supported-0078D4.svg" alt="Azure OpenAI">
-  <img src="https://img.shields.io/badge/OpenAI-supported-412991.svg" alt="OpenAI">
-  <img src="https://img.shields.io/badge/Ollama-supported-000000.svg" alt="Ollama">
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.11+-blue.svg" alt="Python 3.11+"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
 </p>
 
 **BiliCore** is an open-source, domain-agnostic framework for building and testing LLM-powered applications. It provides single-agent orchestration, multi-agent system creation, and adversarial security testing in one modular package.


### PR DESCRIPTION
## Summary

Phase 4 of the OSS hardening pass. Trims the README badge collection from 18 badges down to 4, keeping only the ones that reflect live or reality-pinned facts.

## What stays (4 badges)

- **CI/CD** — live Actions status badge. Real, live, updates on every build.
- **Latest Release** — live shields.io badge that updates when a new tag is cut.
- **Python 3.11+** — language minimum version requirement.
- **License: MIT** — standard OSI shield with a click-through to opensource.org.

## What's removed (14 badges)

**Stale or unsourced status claims (2):**
- ``6900+ Tests`` — hardcoded count, no live source, goes stale on every test edit.
- ``Coverage 90%`` — hardcoded percentage with no codecov or shields.io endpoint behind it.

**Stack-disclosure shields (7):** LangChain, LangGraph, Streamlit, Flask, Docker, PostgreSQL, MongoDB. These communicate what is in the toolbox but are not status badges. The Architecture section of the README covers the same ground in more detail.

**LLM-provider disclosure shields (5):** AWS Bedrock, Google Vertex AI, Azure OpenAI, OpenAI, Ollama. Same pattern. Provider support is documented in the LLM Configuration section.

## Minor improvements on the badges that stay

- CI/CD badge now links directly to the workflow's runs page rather than the generic Actions tab.
- License badge upgraded to the canonical ``License: MIT`` yellow shield (was ``license-MIT`` green) with a link to opensource.org.
- Python and License badges gained click-through links.

## Test plan

- [ ] All 4 remaining badges render in the GitHub README view.
- [ ] CI/CD badge shows the current live status of the develop branch.
- [ ] Latest Release badge shows the latest release tag.
- [ ] Click-throughs land on the right pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)