### PR TITLE
feat(iris): port Lombe's Vertex AI retry and checkpoint downgrade guard from pre-v5 branches

### DIFF
--- a/bili/iris/checkpointers/versioning.py
+++ b/bili/iris/checkpointers/versioning.py
@@ -357,6 +357,21 @@ class VersionedCheckpointerMixin(ABC):
 
         # Check version
         doc_version = self._get_document_version(document)
+
+        # If the document version is HIGHER than the current format version,
+        # the schema was likely downgraded intentionally (e.g. as a workaround
+        # for an upstream serializer bug). Skip migration and use the document
+        # as-is rather than entering a migration loop that the registry cannot
+        # resolve.
+        if doc_version > self.format_version:
+            LOGGER.debug(
+                "Document version %d > current format version %d. "
+                "Skipping migration (likely intentional downgrade).",
+                doc_version,
+                self.format_version,
+            )
+            return False
+
         if doc_version < self.format_version:
             return True
 

--- a/bili/iris/loaders/llm_loader.py
+++ b/bili/iris/loaders/llm_loader.py
@@ -463,6 +463,7 @@ def load_remote_gcp_vertex_model(
     response_mime_type=None,
     additional_headers=None,
     location=None,
+    max_retries=3,
 ):
     """
     Loads a remote GCP Vertex AI model with the specified configuration parameters.
@@ -471,6 +472,11 @@ def load_remote_gcp_vertex_model(
     initializes a ChatVertexAI instance with it. Optional parameters such as
     top_p, top_k, and seed can be added to further customize the model setup.
     A debug log of the initialized model is generated before returning the model.
+
+    When max_retries > 0, the model is wrapped with exponential backoff retry
+    logic to handle transient errors such as 429 (rate limit) and 503 (service
+    unavailable). This follows Google's recommended approach for handling
+    Vertex AI quota errors.
 
     :param model_name: The name of the model to be loaded.
     :type model_name: str
@@ -493,8 +499,11 @@ def load_remote_gcp_vertex_model(
         Defaults to us-central1. Use "global" for models that require it
         (e.g., gemini-3-flash-preview).
     :type location: str, optional
+    :param max_retries: Maximum number of retries for transient errors (429, 503).
+        Set to 0 to disable retry logic. Default is 3.
+    :type max_retries: int, optional
     :return: An instance of the ChatVertexAI model initialized with the
-             specified configuration.
+             specified configuration, optionally wrapped with retry logic.
     :rtype: ChatVertexAI
     """
 
@@ -524,6 +533,23 @@ def load_remote_gcp_vertex_model(
 
     # Print the model for debugging purposes
     LOGGER.debug(llm)
+
+    # Wrap the model with retry logic for transient Vertex AI errors.
+    # Uses exponential backoff as recommended by Google for handling
+    # 429 ResourceExhausted and 503 ServiceUnavailable responses.
+    if max_retries and max_retries > 0:
+        # Imported lazily so the module loads cleanly on environments
+        # that do not have google-api-core installed.
+        # pylint: disable=import-outside-toplevel
+        from google.api_core.exceptions import ResourceExhausted, ServiceUnavailable
+
+        llm = llm.with_retry(
+            stop_after_attempt=max_retries,
+            retry_if_exception_type=(ResourceExhausted, ServiceUnavailable),
+        )
+        LOGGER.info(
+            "Vertex AI model wrapped with retry logic (max_retries=%d)", max_retries
+        )
 
     return llm
 


### PR DESCRIPTION
## Summary

Resurrects two pieces of valuable work from Lombe Chileshe that pre-dated the v5.0.0 three-component refactor and were stranded on the pre-refactor paths. Each is ported to the post-v5.0.0 location, with Lombe credited as co-author on the relevant commit.

Closes the two source branches (`feature/vertex-retry-handling` and `fix/checkpoint-version-downgrade`); they should be deleted from `origin` once this PR merges, since their content is fully captured here.

## Commit 1 — Vertex AI retry handling

Originally authored by Lombe on `feature/vertex-retry-handling` (commit `74b7c5a`, 2026-02-25). Wraps the `ChatVertexAI` returned by `load_remote_gcp_vertex_model()` with exponential-backoff retry logic for the two transient error classes that Google explicitly recommends retrying on Vertex AI quota pressure: `ResourceExhausted` (HTTP 429) and `ServiceUnavailable` (HTTP 503).

- New `max_retries` parameter (default 3); set to 0 to disable
- `google.api_core.exceptions` imported lazily so the module loads cleanly on environments without `google-api-core` installed
- Follows Google's documented best practice for Vertex AI clients

Ported to the current path `bili/iris/loaders/llm_loader.py`.

## Commit 2 — Checkpoint migration downgrade guard

Originally authored by Lombe on `fix/checkpoint-version-downgrade` (commit `2ceca8d`, 2026-01-19). Adds a defensive check in `VersionedCheckpointerMixin._needs_migration()`: when a stored document's version is **higher** than the current `CURRENT_FORMAT_VERSION`, return `False` (no migration) rather than entering a migration path the registry cannot resolve. This makes future version downgrades (whatever the motivation) safe to apply without manually clearing checkpoint state.

**What is intentionally not ported:** Lombe's original commit also reverted `CURRENT_FORMAT_VERSION` from 2 to 1 to dodge a LangGraph `dumps_metadata` msgpack bug. That revert is **not** ported here because v5.0.0 / v5.0.1 / v5.1.0 / v5.2.0 have all shipped at version 2 with no reports of the underlying corruption, indicating the upstream LangGraph bug has been resolved since January. Only the defensive downgrade-handling logic is preserved.

Ported to the current path `bili/iris/checkpointers/versioning.py`.

## Credit

Lombe Chileshe authored the original implementations of both changes against the pre-refactor `bili/loaders/` and `bili/checkpointers/` paths. This PR ports the work to the current paths and is co-authored to preserve attribution. Thank you, Lombe.

## Test plan

- [ ] CI passes (lint + pylint score ≥ 9).
- [ ] Claude code review and security review have no blocking findings.
- [ ] After merge, the source branches `feature/vertex-retry-handling` and `fix/checkpoint-version-downgrade` are deleted from `origin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)