### PR TITLE
chore(ci,tests): address non-blocking review findings from PR #172

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,15 @@ on:
     push:
         branches: [main, develop]
 
+# Auto-cancel superseded in-progress runs for the same PR/ref so a rapid
+# series of pushes doesn't queue redundant heavy test runs. Cancellation is
+# scoped to pull_request events only: pushes to the protected branches
+# main/develop always run to completion so a release-path run is never
+# cancelled mid-flight.
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Default GITHUB_TOKEN permissions for every job in this workflow. Limited to
 # contents:read so an attacker who modifies a script that runs in CI (such as
 # scripts/build/build-and-test.sh) cannot use the token to write to the repo,
@@ -23,6 +32,7 @@ jobs:
     # Build the application on any branch commit
     build-application:
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         steps:
             # Checkout code
             - name: Checkout code
@@ -68,6 +78,7 @@ jobs:
     # required status checks.
     test-application:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         steps:
             - name: Checkout code
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/bili/aegis/tests/agent_impersonation/conftest.py
+++ b/bili/aegis/tests/agent_impersonation/conftest.py
@@ -26,7 +26,7 @@ Usage
 Run the suite first, then run the structural tests:
 
     python bili/aegis/suites/agent_impersonation/run_agent_impersonation_suite.py --stub
-    pytest bili/aegis/suites/agent_impersonation/test_agent_impersonation_structural.py -v
+    pytest bili/aegis/tests/agent_impersonation/test_agent_impersonation_structural.py -v
 """
 
 import json

--- a/bili/aegis/tests/baseline/test_baseline_structural.py
+++ b/bili/aegis/tests/baseline/test_baseline_structural.py
@@ -12,7 +12,7 @@ The ``baseline_result`` fixture (from conftest.py) is parametrized over every
 JSON file in ``results/``.  When the directory is empty, all tests are skipped.
 
 Run:
-    python -m pytest bili/aegis/suites/baseline/ -v
+    python -m pytest bili/aegis/tests/baseline/ -v
 """
 
 import pytest

--- a/bili/aegis/tests/bias_inheritance/conftest.py
+++ b/bili/aegis/tests/bias_inheritance/conftest.py
@@ -26,7 +26,7 @@ Usage
 Run the suite first, then run the structural tests:
 
     python bili/aegis/suites/bias_inheritance/run_bias_inheritance_suite.py --stub
-    pytest bili/aegis/suites/bias_inheritance/test_bias_inheritance_structural.py -v
+    pytest bili/aegis/tests/bias_inheritance/test_bias_inheritance_structural.py -v
 """
 
 import json

--- a/bili/aegis/tests/cross_model/conftest.py
+++ b/bili/aegis/tests/cross_model/conftest.py
@@ -22,7 +22,7 @@ Usage
 Run the suite first, then run the structural tests:
 
     python bili/aegis/suites/cross_model/run_cross_model_suite.py --stub
-    pytest bili/aegis/suites/cross_model/test_cross_model_structural.py -v
+    pytest bili/aegis/tests/cross_model/test_cross_model_structural.py -v
 """
 
 import json

--- a/bili/aegis/tests/injection/conftest.py
+++ b/bili/aegis/tests/injection/conftest.py
@@ -26,7 +26,7 @@ Usage
 Run the suite first, then run the structural tests:
 
     python bili/aegis/suites/injection/run_injection_suite.py --stub
-    pytest bili/aegis/suites/injection/test_injection_structural.py -v
+    pytest bili/aegis/tests/injection/test_injection_structural.py -v
 """
 
 import json

--- a/bili/aegis/tests/jailbreak/conftest.py
+++ b/bili/aegis/tests/jailbreak/conftest.py
@@ -26,7 +26,7 @@ Usage
 Run the suite first, then run the structural tests:
 
     python bili/aegis/suites/jailbreak/run_jailbreak_suite.py --stub
-    pytest bili/aegis/suites/jailbreak/test_jailbreak_structural.py -v
+    pytest bili/aegis/tests/jailbreak/test_jailbreak_structural.py -v
 """
 
 import json

--- a/bili/aegis/tests/memory_poisoning/conftest.py
+++ b/bili/aegis/tests/memory_poisoning/conftest.py
@@ -26,7 +26,7 @@ Usage
 Run the suite first, then run the structural tests:
 
     python bili/aegis/suites/memory_poisoning/run_memory_poisoning_suite.py --stub
-    pytest bili/aegis/suites/memory_poisoning/test_memory_poisoning_structural.py -v
+    pytest bili/aegis/tests/memory_poisoning/test_memory_poisoning_structural.py -v
 """
 
 import json

--- a/bili/aegis/tests/persistence/conftest.py
+++ b/bili/aegis/tests/persistence/conftest.py
@@ -27,7 +27,7 @@ Run the suite first (requires a persistent checkpointer), then run the
 structural tests:
 
     python bili/aegis/suites/persistence/run_persistence_suite.py
-    pytest bili/aegis/suites/persistence/test_persistence_structural.py -v
+    pytest bili/aegis/tests/persistence/test_persistence_structural.py -v
 """
 
 import json
@@ -63,72 +63,6 @@ _RESULTS_DIR = Path(__file__).parent / "results"
 _FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
-def _synthetic_persistence_result() -> dict:
-    """Build a minimal synthetic persistence result for structural tests.
-
-    Used when no real result files exist (e.g. no persistent checkpointer
-    is configured). This ensures structural tests always run and validate
-    the expected schema shape.
-    """
-    return {
-        "payload_id": "synthetic_persistence_001",
-        "injection_type": "session_fabrication",
-        "severity": "high",
-        "mas_id": "synthetic_test",
-        "injection_phase": "checkpoint_injection",
-        "attack_suite": "persistence",
-        "execution": {
-            "success": True,
-            "duration_ms": 100.0,
-            "agent_count": 2,
-            "message_count": 4,
-        },
-        "propagation_path": ["agent_a"],
-        "influenced_agents": [],
-        "resistant_agents": ["agent_a"],
-        "run_metadata": {
-            "stub_mode": True,
-            "timestamp": "2026-01-01T00:00:00Z",
-            "tier3_score": "",
-            "tier3_confidence": "",
-            "tier3_reasoning": "",
-        },
-        "target_agent_id": "agent_a",
-        "config_fingerprint": {
-            "config_path": "bili/aether/config/examples/simple_chain.yaml",
-            "yaml_hash": "synthetic",
-        },
-    }
-
-
-def _ensure_synthetic_files() -> None:
-    """Create synthetic result files so structural tests always run.
-
-    When no real result files exist (e.g. no persistent checkpointer
-    is configured), this creates a minimal JSON result plus the log
-    files that the structural tests expect to find on disk.
-    """
-    synthetic_dir = _RESULTS_DIR / "synthetic_test"
-    result_file = synthetic_dir / "synthetic_persistence_001_checkpoint.json"
-    if result_file.exists():
-        return
-    synthetic_dir.mkdir(parents=True, exist_ok=True)
-    result_file.write_text(
-        json.dumps(_synthetic_persistence_result()), encoding="utf-8"
-    )
-    (synthetic_dir / "attack_log.ndjson").write_text(
-        json.dumps({"attack_id": "synthetic", "success": True}) + "\n",
-        encoding="utf-8",
-    )
-    (synthetic_dir / "security_events.ndjson").write_text(
-        json.dumps({"event_type": "ATTACK_DETECTED", "severity": "low"}) + "\n",
-        encoding="utf-8",
-    )
-
-
-_ensure_synthetic_files()
-
-
 def _collect_result_files() -> list:
     """Return all JSON result file paths under fixtures/ and results/."""
     files = []
@@ -161,4 +95,9 @@ def log_dir(persistence_result: dict) -> Path:
     points to that directory so structural tests can assert log file existence.
     """
     mas_id = persistence_result["mas_id"]
+    # Prefer the committed fixtures log dir when it carries the companion
+    # ndjson log files; otherwise fall back to live run output in results/.
+    fixture_log_dir = _FIXTURES_DIR / mas_id
+    if (fixture_log_dir / "security_events.ndjson").exists():
+        return fixture_log_dir
     return _RESULTS_DIR / mas_id

--- a/bili/aegis/tests/persistence/conftest.py
+++ b/bili/aegis/tests/persistence/conftest.py
@@ -1,13 +1,16 @@
 """Pytest fixtures for the AETHER persistence attack test suite.
 
-The ``persistence_result`` fixture is parametrized over every JSON file
-in ``results/``.  When the directory is empty (i.e.
-``run_persistence_suite.py`` has not yet been run), the fixture yields no
-parameters and all structural tests are automatically skipped.
+The ``persistence_result`` fixture is parametrized over every JSON file in
+``fixtures/`` and ``results/``.  Committed sample fixtures under ``fixtures/``
+mean the suite always has at least one well-formed result to validate, so the
+structural tests run regardless of whether ``run_persistence_suite.py`` has
+populated ``results/`` with live output.
 
 The ``log_dir`` fixture derives the per-config log directory from the
-``mas_id`` field in the loaded result dict.  Log files (``attack_log.ndjson``
-and ``security_events.ndjson``) are written there by the runner.
+``mas_id`` field in the loaded result dict, preferring the committed
+``fixtures/`` companion logs (``attack_log.ndjson`` and
+``security_events.ndjson``) and falling back to live runner output in
+``results/``.
 
 Note on ``_find_repo_root``
 ---------------------------
@@ -80,8 +83,9 @@ def _collect_result_files() -> list:
 def persistence_result(request) -> dict:
     """Load one persistence result JSON file.
 
-    Parametrized over all result files present at collection time,
-    including synthetic files generated when no real results exist.
+    Parametrized over all result files present at collection time: the
+    committed sample fixtures under ``fixtures/`` plus any live runner
+    output under ``results/``.
     """
     return json.loads(request.param.read_text(encoding="utf-8"))
 

--- a/bili/aegis/tests/persistence/fixtures/synthetic_test/attack_log.ndjson
+++ b/bili/aegis/tests/persistence/fixtures/synthetic_test/attack_log.ndjson
@@ -1,0 +1,1 @@
+{"attack_id": "synthetic", "success": true}

--- a/bili/aegis/tests/persistence/fixtures/synthetic_test/security_events.ndjson
+++ b/bili/aegis/tests/persistence/fixtures/synthetic_test/security_events.ndjson
@@ -1,0 +1,1 @@
+{"event_type": "ATTACK_DETECTED", "severity": "low"}

--- a/bili/aegis/tests/persistence/test_persistence_structural.py
+++ b/bili/aegis/tests/persistence/test_persistence_structural.py
@@ -1,12 +1,14 @@
 """Tier 1 structural assertions for the AETHER persistence attack test suite.
 
 These tests are CI-safe and stub-mode compatible: they make no LLM calls,
-perform no semantic reasoning, and rely only on the JSON result files
-written by ``run_persistence_suite.py``.
+perform no semantic reasoning, and rely only on JSON result files.
 
 All tests are parametrized via the ``persistence_result`` fixture in
-``conftest.py``.  When ``results/`` is empty the tests are automatically
-skipped — run the suite first (requires a persistent checkpointer):
+``conftest.py``, which collects committed sample fixtures under ``fixtures/``
+plus any live runner output under ``results/``.  Because ``fixtures/`` always
+carries a well-formed sample, the tests run without first executing the suite.
+To validate live output, run the suite first (requires a persistent
+checkpointer):
 
     python bili/aegis/suites/persistence/run_persistence_suite.py
     pytest bili/aegis/tests/persistence/test_persistence_structural.py -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ pillow~=10.4.0
 autoflake==2.3.1
 black==24.10.0
 isort==5.13.2
-mongomock~=4.3.0
+mongomock==4.3.0
 pre-commit==4.0.1
 pylint==3.3.1
 pympler==1.1


### PR DESCRIPTION
## Summary

Batched non-blocking cleanups from the Claude review on PR #172 (the CI-wiring PR), landing before the next release since they're all value-add.

## Changes

- **Pin `mongomock` exactly** (`==4.3.0`, was `~=4.3.0`). The async checkpointer test shim monkeypatches private mongomock internals (`_Parser.parse`, `_parse_basic_expression`, `Collection.list_indexes`/`create_index`), so a patch release could silently break it. Matches the exact-pin discipline of the other dev/test tools.

- **Align the persistence suite with the other 7 AEGIS suites.** Removed the runtime `_ensure_synthetic_files()` generator (and its `_synthetic_persistence_result()` helper); committed the companion `attack_log.ndjson` + `security_events.ndjson` under `fixtures/synthetic_test/` and made `log_dir` prefer the fixtures dir. Persistence no longer writes into `results/` at import time, and structural assertions run once against committed fixtures instead of twice (fixture + generated copy).

- **Fix stale docstring pytest paths** in 8 files: `pytest bili/aegis/suites/<suite>/test_*` → `.../tests/<suite>/...`. Test files live under `tests/`; the `suites/` dir holds the runnable `run_*_suite.py` scripts, whose paths were left correct.

- **CI job timeouts + concurrency** in `ci-cd.yml`: `timeout-minutes` 15 (build) / 30 (test) so a hung heavy install fails fast instead of running to the 6h default; a `concurrency` group that auto-cancels superseded in-progress runs for `pull_request` events only (pushes to main/develop always finish).

Review finding #4 needed no change — it's a calibration note (the cross-tenant *attack* tests short-circuit on `PermissionError` before any DB query, so mongomock fidelity isn't what makes those specific tests pass; the claim holds for the *isolation* tests which do query).

## Test plan

- [ ] `test-application` passes (and should be faster than #172's cold-cache 9 min, now that the pip cache is warm).
- [ ] Persistence structural tests still pass (8) with the generator removed.
- [ ] No Claude review / security findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)