### PR TITLE
Bump version to 5.2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ def read_http_git_requirements():
 
 setup(
     name="bili-core",
-    version="5.2.0",
+    version="5.2.1",
     packages=find_packages(),  # Automatically detect all packages
     install_requires=read_requirements(),  # Load only standard dependencies
     cmdclass={


### PR DESCRIPTION
Release-prep PR. Bumps setup.py 5.2.0 -> 5.2.1.

Patch release covering the CI/test-infrastructure work since v5.2.0 (PRs #172, #173): pytest wired into CI as a required gate, all skips/errors eliminated via mongomock + committed AEGIS fixtures, root pytest.ini, CI timeouts/concurrency/pip-cache, persistence-suite alignment, exact mongomock pin. No user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)