### PR TITLE
fix(packaging): bundle runtime data files in the wheel/sdist (v5.2.2)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,16 @@
+# Ship the non-Python runtime data files that live inside the bili package.
+#
+# setup.py uses find_packages(), which only collects Python modules (.py). By
+# default setuptools does NOT bundle data files such as JSON, images, or YAML,
+# so the wheel/sdist omitted them entirely. Code that reads these files at
+# import time then crashed with FileNotFoundError once bili-core was installed
+# from a wheel (e.g. bili/streamlit_ui/ui/configuration_panels.py and
+# bili/flask_app.py both load bili/prompts/default_prompts.json on import).
+#
+# These directives are intentionally targeted at the three directories that
+# hold runtime data so the distribution does NOT also pull in the aegis test
+# fixtures or the Markdown docs under the package tree. Keep this in sync with
+# the package_data globs in setup.py.
+include bili/prompts/*.json
+recursive-include bili/images *
+recursive-include bili/aether/config/examples *.yaml

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,19 @@ setup(
     name="bili-core",
     version="5.2.1",
     packages=find_packages(),  # Automatically detect all packages
+    # find_packages() only collects .py modules, so non-Python runtime data
+    # (prompts, images, aether example configs) must be declared explicitly or
+    # the wheel ships without them and import-time file reads crash. These globs
+    # are relative to the bili/ package directory and intentionally targeted so
+    # the distribution does not also bundle the aegis test fixtures or docs.
+    # Keep in sync with MANIFEST.in (which controls the sdist).
+    package_data={
+        "bili": [
+            "prompts/*.json",
+            "images/*",
+            "aether/config/examples/*.yaml",
+        ],
+    },
     install_requires=read_requirements(),  # Load only standard dependencies
     cmdclass={
         "install": PostInstallCommand,

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ def read_http_git_requirements():
 
 setup(
     name="bili-core",
-    version="5.2.1",
+    version="5.2.2",
     packages=find_packages(),  # Automatically detect all packages
     # find_packages() only collects .py modules, so non-Python runtime data
     # (prompts, images, aether example configs) must be declared explicitly or


### PR DESCRIPTION
## What's broken

`bili-core` ships as a Python package, but its built **wheel** (the artifact `pip install` actually downloads and installs) was missing every non-`.py` file. That includes `bili/prompts/default_prompts.json`, `bili/images/logo.png`, and the `bili/aether/config/examples/*.yaml` configs.

The symptom: `bili/streamlit_ui/ui/configuration_panels.py` and `bili/flask_app.py` both **read `bili/prompts/default_prompts.json` at import time**. When `bili-core` is installed from a wheel (which is how `pip install git+...` installs it everywhere except an editable local checkout), that file isn't there, so importing the package raises:

```
FileNotFoundError: .../site-packages/bili/prompts/default_prompts.json
```

This surfaced in the **sustainability-hub-engine** test suite: `test_streamlit_app` couldn't even be collected in CI because importing `engine.streamlit_app` pulls in `bili.streamlit_ui.ui`, whose package `__init__` eagerly imports `configuration_panels`. It was invisible in local dev because an *editable* checkout (`pip install -e`) leaves the real source tree in place, data files and all, so the file is found.

## Why it happened (the teaching bit)

`setup.py` builds the package list with `find_packages()`. That helper only finds **Python packages** (directories with an `__init__.py`) and, by default, setuptools bundles **only `.py` files**. Data files (JSON, images, YAML) are ignored unless you tell setuptools about them. There was no `package_data`, no `include_package_data`, and no `MANIFEST.in`, so the data files were silently dropped from the distribution.

Two setuptools knobs control this, and they cover different artifacts:
- **`package_data`** (in `setup.py`) controls what goes into the **wheel** (the binary install artifact).
- **`MANIFEST.in`** controls what goes into the **sdist** (the source archive). A wheel built *from* an sdist can only include files the sdist carried.

This PR sets both, kept in sync, so the data files ship no matter how the package is built.

## The fix

- **`MANIFEST.in`** (new) and **`package_data`** in `setup.py`, both targeting the three directories that hold files read at runtime:
  - `bili/prompts/*.json` — `default_prompts.json`, read by `flask_app.py` and `configuration_panels.py`
  - `bili/images/*` — `logo.png`, read by `streamlit_app.py` and the aether UI pages
  - `bili/aether/config/examples/*.yaml` — referenced by the aegis suite runners
- The globs are **deliberately targeted** rather than a blanket `recursive-include bili *`. A blanket include (or `include_package_data=True`) would also sweep the `bili/aegis/tests/**` fixtures and the Markdown docs into every install. We only want the runtime data.
- **Version bump to `5.2.2`** (patch) in a separate commit, so this is ready to tag as a release.

## Verification

Built the wheel from this branch and confirmed:
- All three runtime data dirs are present in the wheel (`default_prompts.json`, `logo.png`, 22 example YAMLs).
- **Zero** test-fixture or doc *data* files leaked in.
- Installed the wheel `--no-deps` into a clean venv: `bili/prompts/default_prompts.json` resolves at the exact path the importing code reads, and `json.load()` succeeds.

## Follow-up (not in this PR)

`find_packages()` also bundles the `bili/aegis/tests/**` **Python test modules** into the wheel (pre-existing behavior, unrelated to this data-file bug). Shipping test code in a library is mildly undesirable; excluding it (`find_packages(exclude=[...])`) is a separate, slightly riskier change worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)