### PR TITLE
fix(packaging): exclude test packages from the wheel and sdist (v5.2.3)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,19 @@ def read_http_git_requirements():
 
 setup(
     name="bili-core",
-    version="5.2.2",
-    packages=find_packages(),  # Automatically detect all packages
+    version="5.2.3",
+    # Detect runtime packages while excluding every test subpackage. Without
+    # the exclude, find_packages() bundles 200+ .py test modules (under
+    # bili/<component>/tests/ and bili/<component>/<subcomponent>/tests/)
+    # into the wheel and sdist as a side effect of having __init__.py in
+    # each tests/ dir. The exclude patterns match full dotted package paths:
+    # "*.tests" catches packages like bili.aegis.tests and bili.aether.tests,
+    # and "*.tests.*" catches their subpackages (bili.aegis.tests.injection,
+    # bili.aegis.tests.injection.payloads, and so on). No runtime code
+    # imports from any bili.*.tests module (verified by grep), so dropping
+    # them from the distribution is safe; pytest still discovers them at
+    # the source-tree level when developers run the suite locally or in CI.
+    packages=find_packages(exclude=["*.tests", "*.tests.*", "tests", "tests.*"]),
     # find_packages() only collects .py modules, so non-Python runtime data
     # (prompts, images, aether example configs) must be declared explicitly or
     # the wheel ships without them and import-time file reads crash. These globs


### PR DESCRIPTION
## Summary

Closes #177. Follow-up to PR #176's data-file packaging fix: drops 208 .py test modules from the wheel and sdist that were silently bundled because ``find_packages()`` was called with no ``exclude``.

## What was wrong

Every ``bili/<component>/tests/`` and ``bili/<component>/<subcomponent>/tests/`` directory carries an ``__init__.py`` (artifact of the v5.0.0 namespace refactor), so ``find_packages()`` treated all 17 test packages as shippable. The v5.2.2 wheel contained:

- 208 .py test modules (conftest, pytest fixtures, payload modules, suite runners)
- Spread across `bili.aegis.tests`, `bili.aether.tests`, `bili.iris.checkpointers.tests`, `bili.iris.config.tests`, `bili.iris.graph_builder.tests`, `bili.iris.loaders.tests`, `bili.iris.nodes.tests`, `bili.iris.tools.tests`, `bili.auth.tests`, `bili.utils.tests`, `bili.streamlit_ui.tests`, `bili.flask_api.tests`, and pre-refactor leftovers under `bili.checkpointers.tests`, `bili.config.tests`, `bili.nodes.tests`, `bili.tools.tests`

## Fix

```python
find_packages(exclude=["*.tests", "*.tests.*", "tests", "tests.*"])
```

The patterns match full dotted package paths: ``*.tests`` catches packages like ``bili.aegis.tests``, and ``*.tests.*`` catches their subpackages.

## Risk audit (before applying)

`grep -rnE "from bili\.[a-z_]+(\.[a-z_]+)*\.tests|import bili\.[a-z_]+(\.[a-z_]+)*\.tests" bili/ --include='*.py' | grep -v /tests/` returned zero matches. No non-test code in the codebase imports from any ``bili.*.tests`` module. Exclusion is safe.

## Verification (clean-venv rebuild)

| Check | Before | After |
|---|---|---|
| Test ``.py`` files in wheel | 208 | **0** |
| Runtime data files (PR #176) | 24 | **24** (preserved) |
| Runtime package ``__init__.py`` (spot-checked 10) | all present | **all present** |
| Wheel size | 2.05 MB | **1.46 MB** (28% smaller) |
| Local pytest collection | 2,532 | **2,532** (unchanged) |

Clean-venv install test: ``bili`` imports from the installed wheel, ``default_prompts.json`` loads correctly via ``importlib.resources``, and the three excluded test packages I spot-checked (``bili.aegis.tests``, ``bili.aether.tests``, ``bili.iris.checkpointers.tests``) correctly raise ``ImportError``.

## Operational gotcha worth flagging

A stale ``bili_core.egg-info/SOURCES.txt`` from a previous build silently overrides ``find_packages`` exclude results in dev rebuilds. ``find_packages`` returned the correct 56-package list (zero test packages), but the wheel build used the cached SOURCES manifest and re-bundled the tests. ``rm -rf bili_core.egg-info build dist`` before each verification rebuild is the workaround. ``*.egg-info/`` and ``build/`` were already in ``.gitignore``, so this only affects dev workflow, not CI (which always builds clean).

## Version bump

5.2.2 to 5.2.3 (patch). Companion to v5.2.2, completing the packaging-correctness story.

## Test plan

- [ ] CI passes (build-application, test-application, claude-review, security-review).
- [ ] No new findings on review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)