### PR TITLE
Fail security-review job on silent scan failure (406)

### DIFF
--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -31,3 +31,27 @@ jobs:
           claude-model: claude-sonnet-4-5-20250929
           claudecode-timeout: 20
           exclude-directories: node_modules,dist,.git,venv,__pycache__,build
+
+      # The action above swallows scan failures: when it can't fetch the PR
+      # diff (e.g. a 406 because the diff is too large for GitHub's API) it
+      # writes an {"error": ...} results file, downgrades it to a ::warning::,
+      # reports findings_count=0, and the job goes GREEN. That is a false
+      # all-clear: nothing was actually scanned. This step turns that silent
+      # failure into a hard job failure so the PR check is red and a human
+      # knows to run a LOCAL security review (`/security-review`) before merge.
+      #
+      # It fails ONLY when the results file is present AND carries an .error,
+      # so a genuinely clean scan (no .error) and a marker-deduped re-run
+      # (no results file at all) both pass untouched.
+      - name: Fail on silent security-scan failure
+        if: always()
+        shell: bash
+        run: |
+          RESULTS="claudecode-results.json"
+          if [ -f "$RESULTS" ] && jq -e '.error' "$RESULTS" >/dev/null 2>&1; then
+            ERROR_MSG=$(jq -r '.error' "$RESULTS")
+            echo "::error title=Security scan did not run::$ERROR_MSG"
+            echo "::error::The automated security review FAILED to analyze this PR and covered nothing. A 406 here means the PR diff is too large for GitHub's API. Run a local '/security-review' on this branch before merging."
+            exit 1
+          fi
+          echo "No silent-failure signal: the security scan ran cleanly or was deduped."


### PR DESCRIPTION
## What

Make the `Claude Security Review` job fail loudly when the automated scan silently errors, instead of reporting a false all-clear.

## Why

The `anthropics/claude-code-security-review` action swallows scan failures. When it can't fetch the PR diff (commonly a **406 Not Acceptable** because the diff is too large for GitHub's API), it writes an `{"error": ...}` results file, downgrades it to a `::warning::`, reports `findings_count=0`, and the job exits **green**. The PR check passes, but nothing was actually scanned — a passing check then means "not scanned," indistinguishable from "scanned, clean."

This was observed on a large PR in another C3 Lab repo: the scan 406'd and reported "0 findings / success" while never analyzing a single file. This change brings the same protection here.

## How

A gate step after the action fails the job when `claudecode-results.json` (which the action always copies to the workspace root) is present **and** carries an `.error` field. Precisely scoped:

- Clean scan (no `.error`) → passes.
- Marker-deduped re-run (no results file at all) → passes.
- Silent failure (results file with `.error`, e.g. a 406) → **red**, with an annotation telling the maintainer to run a local `/security-review` on the branch before merging.

Verified on the source repos: the gate parses and passes on a clean scan, and `exit 1`s on an `.error` results file.

## Scope

Independent of any feature work. Touches only `.github/workflows/claude-security-review.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
