### PR TITLE
Enforce per-file ≥90% coverage gate; raise all runtime files and fix 5 surfaced bugs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,29 @@
+# Coverage configuration for bili-core.
+#
+# Scopes measurement to runtime code only. The test tree lives inside the
+# bili package (bili/<component>/tests/), and test files execute at close to
+# 100% by definition, so including them inflates the headline coverage number.
+# Omitting them here means the reported percentage is the coverage of the code
+# that actually ships.
+#
+# The per-file 90% floor is enforced by scripts/check_coverage.py (run in CI
+# after pytest), not by a global [report] fail_under, because the project goal
+# is that EVERY runtime file clears 90%, not that the average does.
+
+[run]
+source = bili
+branch = False
+omit =
+    */tests/*
+    */test_*.py
+    */conftest.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise NotImplementedError
+    if __name__ == .__main__.:
+    if TYPE_CHECKING:
+    @(abc\.)?abstractmethod
+show_missing = True

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -101,10 +101,21 @@ jobs:
                 pip install -r requirements.txt
               shell: bash
 
-            # Run the full test suite. No skips or errors are tolerated; the
-            # mongomock-backed checkpointer tests and the AEGIS structural
-            # fixtures mean the suite runs fully without external services.
-            - name: Run pytest
+            # Run the full test suite with coverage. No skips or errors are
+            # tolerated; the mongomock-backed checkpointer tests and the AEGIS
+            # structural fixtures mean the suite runs fully without external
+            # services. Coverage is scoped to runtime code via .coveragerc
+            # (the test tree is omitted so it cannot inflate the numbers).
+            - name: Run pytest with coverage
               run: |
-                pytest bili/ -q --tb=short
+                pytest bili/ -q --tb=short \
+                  --cov=bili --cov-report=json:coverage.json
+              shell: bash
+
+            # Per-file coverage gate: every runtime file must reach >= 90% line
+            # coverage. This is a required check, not an average; a single file
+            # below threshold fails the build. See scripts/check_coverage.py.
+            - name: Enforce per-file coverage gate (>= 90%)
+              run: |
+                python scripts/check_coverage.py
               shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -316,3 +316,4 @@ bili/aegis/tests/*/results/**/*.html
 
 bili/aegis/logs/*
 bili/aegis/attacks/logs/*
+coverage.json

--- a/bili/__init__.py
+++ b/bili/__init__.py
@@ -4,16 +4,18 @@ Subpackages are loaded lazily (PEP 562) to avoid importing heavy dependencies
 (langgraph, torch, cloud SDKs, etc.) when only lightweight modules are needed.
 """
 
+# The lazily loadable top-level subpackages. These must be real importable
+# packages under bili/. The v5.0.0 refactor moved the former top-level
+# checkpointers/config/graph_builder/loaders/nodes/tools packages under
+# bili/iris/, so the lazy list is the three components (iris, aether, aegis)
+# plus the shared subpackages.
 _LAZY_SUBMODULES = {
+    "aegis",
     "aether",
     "auth",
-    "checkpointers",
-    "config",
     "flask_api",
-    "graph_builder",
-    "loaders",
-    "nodes",
-    "tools",
+    "iris",
+    "streamlit_ui",
     "utils",
 }
 

--- a/bili/__init__.py
+++ b/bili/__init__.py
@@ -34,15 +34,8 @@ def __dir__():
     return list(_LAZY_SUBMODULES)
 
 
-__all__ = [
-    "aether",
-    "auth",
-    "checkpointers",
-    "config",
-    "flask_api",
-    "graph_builder",
-    "loaders",
-    "nodes",
-    "tools",
-    "utils",
-]
+# Keep __all__ in sync with _LAZY_SUBMODULES: `from bili import *` iterates
+# __all__ and resolves each name via __getattr__, so any name not in
+# _LAZY_SUBMODULES would raise AttributeError. The v5.0.0 refactor moved
+# checkpointers/config/graph_builder/loaders/nodes/tools under bili/iris/.
+__all__ = sorted(_LAZY_SUBMODULES)

--- a/bili/aegis/attacks/strategies/tests/__init__.py
+++ b/bili/aegis/attacks/strategies/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the aegis.attacks.strategies package."""

--- a/bili/aegis/attacks/strategies/tests/test_mid_execution.py
+++ b/bili/aegis/attacks/strategies/tests/test_mid_execution.py
@@ -1,0 +1,108 @@
+"""Tests for the mid-execution injection strategy.
+
+Covers the branches of run_with_mid_execution_injection that are hard to
+reach through the higher-level runners: the get_state() fallback on the
+early-return path, the NodeInterrupt path (missing node attribute and node
+mismatch), and the _get_interrupt_state helper.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from langgraph.errors import NodeInterrupt
+
+from bili.aegis.attacks.strategies.mid_execution import (
+    _get_interrupt_state,
+    run_with_mid_execution_injection,
+)
+
+
+def _agent(agent_id, role="worker"):
+    """Build a minimal agent spec stand-in with id and role attributes."""
+    return SimpleNamespace(agent_id=agent_id, role=role)
+
+
+def _compiled_mas(graph, agent_ids=("target",)):
+    """Build a compiled-MAS stand-in whose compile_graph returns *graph*."""
+    config = SimpleNamespace(agents=[_agent(a) for a in agent_ids])
+    mas = MagicMock()
+    mas.config = config
+    mas.compile_graph.return_value = graph
+    return mas
+
+
+class TestEarlyReturnPath:
+    """LangGraph >= 1.x returns early from invoke() rather than raising."""
+
+    def test_falls_back_to_invoke_result_when_get_state_fails(self):
+        """A get_state() failure falls back to the invoke() return dict."""
+        graph = MagicMock()
+        graph.invoke.return_value = {"messages": []}
+        # get_state raising a generic error triggers the fallback branch.
+        graph.get_state.side_effect = ValueError("no checkpointer")
+        graph.stream.return_value = []
+
+        result = run_with_mid_execution_injection(
+            compiled_mas=_compiled_mas(graph),
+            input_data={"messages": []},
+            target_agent_id="target",
+            payload="INJECT",
+            tracker=MagicMock(),
+        )
+
+        # The injected payload is present in the accumulated state messages.
+        assert any(getattr(m, "content", None) == "INJECT" for m in result["messages"])
+
+
+class TestNodeInterruptPath:
+    """Older LangGraph raises NodeInterrupt from invoke()."""
+
+    def test_missing_node_attribute_skips_validation(self):
+        """A NodeInterrupt without a .node attribute proceeds without raising."""
+        graph = MagicMock()
+        graph.invoke.side_effect = NodeInterrupt("paused")
+        graph.get_state.return_value = SimpleNamespace(values={"messages": []})
+        graph.stream.return_value = []
+
+        result = run_with_mid_execution_injection(
+            compiled_mas=_compiled_mas(graph),
+            input_data={"messages": []},
+            target_agent_id="target",
+            payload="INJECT",
+            tracker=MagicMock(),
+        )
+
+        assert any(getattr(m, "content", None) == "INJECT" for m in result["messages"])
+
+    def test_node_mismatch_raises_runtime_error(self):
+        """A NodeInterrupt at a different node raises a descriptive RuntimeError."""
+        exc = NodeInterrupt("paused")
+        exc.node = "some_other_node"
+        graph = MagicMock()
+        graph.invoke.side_effect = exc
+
+        with pytest.raises(RuntimeError, match="Expected NodeInterrupt at 'target'"):
+            run_with_mid_execution_injection(
+                compiled_mas=_compiled_mas(graph),
+                input_data={"messages": []},
+                target_agent_id="target",
+                payload="INJECT",
+                tracker=MagicMock(),
+            )
+
+
+class TestGetInterruptState:
+    """_get_interrupt_state reads the snapshot or degrades to an empty dict."""
+
+    def test_returns_snapshot_values(self):
+        """A successful get_state returns the snapshot values as a dict."""
+        graph = MagicMock()
+        graph.get_state.return_value = SimpleNamespace(values={"k": "v"})
+        assert _get_interrupt_state(graph, {}) == {"k": "v"}
+
+    def test_returns_empty_on_error(self):
+        """A get_state failure degrades to an empty dict, not an exception."""
+        graph = MagicMock()
+        graph.get_state.side_effect = RuntimeError("unavailable")
+        assert _get_interrupt_state(graph, {}) == {}

--- a/bili/aegis/tests/test_attacks_cli.py
+++ b/bili/aegis/tests/test_attacks_cli.py
@@ -4,15 +4,19 @@ Covers argument parsing, payload resolution, and output formatting.
 All external dependencies (MASExecutor, AttackInjector, etc.) are mocked.
 """
 
+import os
 import sys
+import types
 from types import SimpleNamespace
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
+from bili.aegis.attacks import cli as cli_module
 from bili.aegis.attacks.cli import (
     _build_parser,
     _build_payload,
+    _ensure_bili_stub,
     _format_attack_result,
     _row,
 )
@@ -384,6 +388,60 @@ class TestMainEntryPoint:
     @patch("bili.aegis.attacks.AttackInjector")
     @patch("bili.aether.runtime.executor.MASExecutor")
     @patch("bili.aether.config.loader.load_mas_from_yaml")
+    def test_main_async_submission_exits_zero(
+        self,
+        mock_load,
+        mock_executor_cls,
+        mock_injector_cls,
+        mock_logger_cls,
+    ):
+        """An async submission (no completed_at, no error) exits with code 0."""
+        mock_load.return_value = MagicMock()
+        mock_executor_cls.return_value = MagicMock()
+
+        mock_injector = MagicMock()
+        mock_injector.__enter__ = MagicMock(return_value=mock_injector)
+        mock_injector.__exit__ = MagicMock(return_value=False)
+        mock_injector.inject_attack.return_value = SimpleNamespace(
+            success=False,
+            attack_id="atk-async",
+            mas_id="test-mas",
+            target_agent_id="agent_a",
+            attack_type="prompt_injection",
+            injection_phase="pre_execution",
+            error=None,
+            completed_at=None,
+            propagation_path=[],
+            influenced_agents=[],
+            resistant_agents=[],
+        )
+        mock_injector_cls.return_value = mock_injector
+
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "cli.py",
+                "config.yaml",
+                "--agent-id",
+                "agent_a",
+                "--attack-type",
+                "prompt_injection",
+                "--payload",
+                "test",
+            ],
+        ):
+            from bili.aegis.attacks.cli import main
+
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            # Async submission succeeds even though success is False.
+            assert exc_info.value.code == 0
+
+    @patch("bili.aegis.attacks.logger.AttackLogger")
+    @patch("bili.aegis.attacks.AttackInjector")
+    @patch("bili.aether.runtime.executor.MASExecutor")
+    @patch("bili.aether.config.loader.load_mas_from_yaml")
     def test_main_value_error_exits_one(
         self,
         mock_load,
@@ -421,3 +479,25 @@ class TestMainEntryPoint:
             with pytest.raises(SystemExit) as exc_info:
                 main()
             assert exc_info.value.code == 1
+
+
+class TestEnsureBiliStub:
+    """_ensure_bili_stub adds the project root to sys.path and stubs bili."""
+
+    def test_inserts_root_and_creates_stub(self):
+        """When bili lacks a __path__, a lightweight package stub is installed."""
+        expected_root = os.path.dirname(
+            os.path.dirname(
+                os.path.dirname(os.path.dirname(os.path.abspath(cli_module.__file__)))
+            )
+        )
+        # A bili module without __path__ forces the stub-creation branch, and a
+        # sys.path missing the root forces the path-insertion branch.
+        with patch.object(sys, "path", ["/unrelated/path"]), patch.dict(
+            sys.modules, {"bili": types.ModuleType("bili")}
+        ):
+            _ensure_bili_stub()
+            assert expected_root in sys.path
+            stub = sys.modules["bili"]
+            assert hasattr(stub, "__path__")
+            assert stub.__path__ == [os.path.join(expected_root, "bili")]

--- a/bili/aegis/tests/test_attacks_injector.py
+++ b/bili/aegis/tests/test_attacks_injector.py
@@ -562,3 +562,108 @@ def test_invalid_injection_phase_raises(tmp_path):
             payload=_PAYLOAD,
             injection_phase="not_a_phase",
         )
+
+
+# =========================================================================
+# _create_checkpointer
+# =========================================================================
+
+
+def _checkpoint_config(ctype="postgres", enabled=True):
+    """Build a MASConfig with checkpoint settings for checkpointer tests."""
+    return MASConfig(
+        mas_id="ckpt_mas",
+        name="Checkpoint MAS",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_agent("agent_a"), _agent("agent_b")],
+        checkpoint_enabled=enabled,
+        checkpoint_config={"type": ctype},
+    )
+
+
+def test_create_checkpointer_defaults_to_memory_saver(tmp_path):
+    """A disabled-checkpoint config resolves to an in-process MemorySaver."""
+    from langgraph.checkpoint.memory import MemorySaver
+
+    injector = _make_injector(_seq_config(), log_path=tmp_path / "log.ndjson")
+    assert isinstance(injector._create_checkpointer(), MemorySaver)
+
+
+def test_create_checkpointer_uses_factory_when_configured(tmp_path):
+    """An enabled non-memory config delegates to the checkpointer factory."""
+    injector = _make_injector(
+        _checkpoint_config("postgres"), log_path=tmp_path / "log.ndjson"
+    )
+    sentinel = object()
+    with patch(
+        "bili.aether.integration.checkpointer_factory.create_checkpointer_from_config",
+        return_value=sentinel,
+    ) as mock_factory:
+        result = injector._create_checkpointer()
+    assert result is sentinel
+    mock_factory.assert_called_once()
+
+
+def test_create_checkpointer_falls_back_when_factory_raises(tmp_path):
+    """A factory failure logs a warning and falls back to MemorySaver."""
+    from langgraph.checkpoint.memory import MemorySaver
+
+    injector = _make_injector(
+        _checkpoint_config("postgres"), log_path=tmp_path / "log.ndjson"
+    )
+    with patch(
+        "bili.aether.integration.checkpointer_factory.create_checkpointer_from_config",
+        side_effect=RuntimeError("backend down"),
+    ):
+        result = injector._create_checkpointer()
+    assert isinstance(result, MemorySaver)
+
+
+# =========================================================================
+# _run_checkpoint_execution
+# =========================================================================
+
+
+def test_run_checkpoint_execution_rejects_memory_saver(tmp_path):
+    """A resolved MemorySaver is refused because it is in-process only."""
+    injector = _make_injector(_seq_config(), log_path=tmp_path / "log.ndjson")
+    with pytest.raises(RuntimeError, match="MemorySaver"):
+        injector._run_checkpoint_execution(
+            agent_id="agent_a",
+            attack_type=AttackType.MEMORY_POISONING,
+            payload=_PAYLOAD,
+            tracker=None,
+        )
+
+
+def test_run_checkpoint_execution_injects_and_observes(tmp_path):
+    """The persistence flow injects via the checkpointer and observes each agent."""
+    from langchain_core.messages import AIMessage
+
+    config = _seq_config()
+    injector = _make_injector(config, log_path=tmp_path / "log.ndjson")
+
+    graph = MagicMock()
+    graph.invoke.return_value = {"messages": [AIMessage(content="poisoned reply")]}
+    compiled = MagicMock()
+    compiled.compile_graph.return_value = graph
+
+    tracker = MagicMock()
+    with patch.object(
+        injector, "_create_checkpointer", return_value=MagicMock()
+    ), patch("bili.aether.compiler.compile_mas", return_value=compiled), patch(
+        "bili.aegis.attacks.strategies.persistence.inject_persistence"
+    ) as mock_inject:
+        thread_id = injector._run_checkpoint_execution(
+            agent_id="agent_a",
+            attack_type=AttackType.MEMORY_POISONING,
+            payload=_PAYLOAD,
+            tracker=tracker,
+        )
+
+    assert isinstance(thread_id, str)
+    mock_inject.assert_called_once()
+    # Every agent in the config is observed with the poisoned output excerpt.
+    assert tracker.observe.call_count == len(config.agents)
+    observed = tracker.observe.call_args.kwargs
+    assert observed["output_state"]["output"] == "poisoned reply"

--- a/bili/aegis/tests/test_cross_model_runner.py
+++ b/bili/aegis/tests/test_cross_model_runner.py
@@ -9,10 +9,79 @@ All external dependencies (LLM calls, file I/O, YAML loading) are mocked.
 # pylint: disable=protected-access
 
 import csv
+import datetime
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+_MODULE = "bili.aegis.suites.cross_model.run_cross_model_suite"
+
+
+def _fake_payload(payload_id="pi_001"):
+    """Build a minimal payload namespace."""
+    return SimpleNamespace(
+        payload_id=payload_id,
+        injection_type="prompt_injection",
+        severity="high",
+        payload="evil text",
+    )
+
+
+def _fake_attack_result(success=True, influenced=None, resistant=None):
+    """Build a minimal attack result namespace with a 1s duration."""
+    now = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+    return SimpleNamespace(
+        success=success,
+        target_agent_id="agent_a",
+        propagation_path=["agent_a"],
+        influenced_agents=influenced if influenced is not None else [],
+        resistant_agents=resistant if resistant is not None else ["agent_b"],
+        injected_at=now,
+        completed_at=now + datetime.timedelta(seconds=1),
+    )
+
+
+class _FakeAgent(SimpleNamespace):
+    """Agent stub that mimics ``AgentSpec.model_copy`` for patch testing."""
+
+    def model_copy(self, update=None):
+        """Return a copy with the given field updates applied."""
+        data = dict(self.__dict__)
+        data.update(update or {})
+        return _FakeAgent(**data)
+
+
+class _FakeConfig(SimpleNamespace):
+    """Config stub that mimics ``MASConfig.model_copy`` for patch testing."""
+
+    def model_copy(self, update=None):
+        """Return a copy with the given field updates applied."""
+        data = dict(self.__dict__)
+        data.update(update or {})
+        return _FakeConfig(**data)
+
+
+def _fake_config():
+    """Build a minimal MAS config that supports ``model_copy``."""
+    agent = _FakeAgent(agent_id="agent_a", model_name="m", temperature=0.2)
+    return _FakeConfig(mas_id="test_mas", entry_point=None, agents=[agent])
+
+
+def _patched_injector(attack_result=None, side_effect=None):
+    """Build a context-manager MagicMock that mimics AttackInjector."""
+    injector = MagicMock()
+    injector.__enter__ = MagicMock(return_value=injector)
+    injector.__exit__ = MagicMock(return_value=False)
+    if side_effect is not None:
+        injector.inject_attack.side_effect = side_effect
+    else:
+        injector.inject_attack.return_value = (
+            attack_result if attack_result is not None else _fake_attack_result()
+        )
+    return injector
+
 
 # -----------------------------------------------------------------------
 # Lazy-import helpers — the module performs sys.path manipulation and
@@ -212,6 +281,44 @@ class TestLoadBaseline:
         result = mod._load_baseline(tmp_path, "mas1")
         assert result == data
 
+    def test_returns_none_on_corrupt_json(self, tmp_path):
+        """Returns None and warns when the baseline JSON cannot be parsed."""
+        mod = _import_module()
+        mas_dir = tmp_path / "mas1"
+        mas_dir.mkdir()
+        (mas_dir / "bad.json").write_text("{not valid json")
+        assert mod._load_baseline(tmp_path, "mas1") is None
+
+
+# =========================================================================
+# _find_repo_root
+# =========================================================================
+
+
+class TestFindRepoRoot:
+    """Tests for the inlined bootstrap _find_repo_root helper."""
+
+    def test_walks_up_to_git_dir(self, tmp_path, monkeypatch):
+        """Returns the first ancestor directory containing a .git dir."""
+        mod = _import_module()
+        nested = tmp_path / "a" / "b" / "c"
+        nested.mkdir(parents=True)
+        (tmp_path / ".git").mkdir()
+        fake_file = nested / "run.py"
+        monkeypatch.setattr(mod, "__file__", str(fake_file))
+        assert mod._find_repo_root() == tmp_path
+
+    def test_raises_when_no_git_dir(self, tmp_path, monkeypatch):
+        """Raises RuntimeError when no .git directory exists above the file."""
+        mod = _import_module()
+        isolated = tmp_path / "no_git_here" / "pkg"
+        isolated.mkdir(parents=True)
+        monkeypatch.setattr(mod, "__file__", str(isolated / "run.py"))
+        # No .git is created anywhere from tmp_path up to the filesystem root,
+        # so the walk exhausts and raises.
+        with pytest.raises(RuntimeError, match="repo root"):
+            mod._find_repo_root()
+
 
 # =========================================================================
 # _patch_config_model
@@ -326,3 +433,328 @@ class TestMain:
         with pytest.raises(SystemExit) as exc_info:
             mod.main()
         assert exc_info.value.code == 1
+
+    @patch(f"{_MODULE}.argparse.ArgumentParser.parse_args")
+    @patch(f"{_MODULE}._run_config_for_model")
+    def test_default_model_matrix_used(self, mock_run, mock_args):
+        """Without --models the full MODEL_MATRIX is iterated in non-stub mode."""
+        mod = _import_module()
+        mock_args.return_value = MagicMock(
+            stub=False,
+            configs=["a.yaml"],
+            models=None,
+            payloads=None,
+            phases=["pre_execution"],
+            baseline_results=None,
+            log_level="WARNING",
+        )
+        with patch("bili.aegis.evaluator.SemanticEvaluator", return_value=MagicMock()):
+            mock_run.return_value = ([], None)
+            with pytest.raises(SystemExit) as exc_info:
+                mod.main()
+        # 0 ran rows -> exit 0; called once per model in the default matrix.
+        assert exc_info.value.code == 0
+        assert mock_run.call_count == len(mod.MODEL_MATRIX)
+        # The model_id of the first call is the first matrix entry's id.
+        assert mock_run.call_args_list[0][1]["model_id"] == mod.MODEL_MATRIX[0][0]
+
+    @patch(f"{_MODULE}.argparse.ArgumentParser.parse_args")
+    @patch(f"{_MODULE}._run_config_for_model")
+    def test_missing_baseline_dir_clears_to_none(self, mock_run, mock_args, capsys):
+        """A nonexistent baseline dir warns and is passed through as None."""
+        mod = _import_module()
+        mock_args.return_value = MagicMock(
+            stub=True,
+            configs=["a.yaml"],
+            models=None,
+            payloads=None,
+            phases=["pre_execution"],
+            baseline_results="/no/such/baseline",
+            log_level="WARNING",
+        )
+        mock_run.return_value = ([], None)
+        with pytest.raises(SystemExit):
+            mod.main()
+        err = capsys.readouterr().err
+        assert "baseline results dir not found" in err
+        assert mock_run.call_args[1]["baseline_results_dir"] is None
+
+    @patch(f"{_MODULE}.argparse.ArgumentParser.parse_args")
+    @patch(f"{_MODULE}._run_config_for_model")
+    def test_semantic_evaluator_error_handled(self, mock_run, mock_args):
+        """A failing SemanticEvaluator init in non-stub mode is tolerated."""
+        mod = _import_module()
+        mock_args.return_value = MagicMock(
+            stub=False,
+            configs=["a.yaml"],
+            models=["us.anthropic.claude-3-5-haiku-20241022-v1:0"],
+            payloads=None,
+            phases=["pre_execution"],
+            baseline_results=None,
+            log_level="WARNING",
+        )
+        with patch(
+            "bili.aegis.evaluator.SemanticEvaluator",
+            side_effect=RuntimeError("no creds"),
+        ):
+            mock_run.return_value = ([], None)
+            with pytest.raises(SystemExit):
+                mod.main()
+        assert mock_run.call_args[1]["semantic_evaluator"] is None
+
+
+# =========================================================================
+# _run_config_for_model
+# =========================================================================
+
+
+class TestRunConfigForModel:
+    """Tests for the per-config per-model runner loop."""
+
+    @patch(f"{_MODULE}.SecurityEventLogger")
+    @patch(f"{_MODULE}.SecurityEventDetector")
+    @patch(f"{_MODULE}.AttackInjector")
+    @patch(f"{_MODULE}.load_mas_from_yaml")
+    def test_skips_missing_config(self, mock_load, _inj, _det, _log, tmp_path):
+        """Returns empty rows and None run_dir when the YAML path is missing."""
+        mod = _import_module()
+        rows, run_dir = mod._run_config_for_model(
+            yaml_path="missing.yaml",
+            model_id=None,
+            model_display_name="stub",
+            payloads=[_fake_payload()],
+            phases=["pre_execution"],
+            stub_mode=True,
+            semantic_evaluator=None,
+            baseline_results_dir=None,
+            results_dir=tmp_path / "results",
+            repo_root=tmp_path,
+        )
+        assert rows == []
+        assert run_dir is None
+        mock_load.assert_not_called()
+
+    @patch(f"{_MODULE}.SecurityEventLogger")
+    @patch(f"{_MODULE}.SecurityEventDetector")
+    @patch(f"{_MODULE}.AttackInjector")
+    @patch(f"{_MODULE}.load_mas_from_yaml")
+    def test_writes_result_and_matrix_row(
+        self, mock_load, mock_injector_cls, _det, _log, tmp_path
+    ):
+        """A successful injection writes a JSON result and a non-skipped row."""
+        mod = _import_module()
+        config = _fake_config()
+        mock_load.return_value = config
+        mock_injector_cls.return_value = _patched_injector(
+            _fake_attack_result(influenced=["agent_a"])
+        )
+
+        (tmp_path / "t.yaml").write_text("x")
+        rows, run_dir = mod._run_config_for_model(
+            yaml_path="t.yaml",
+            model_id=None,
+            model_display_name="stub",
+            payloads=[_fake_payload("pi_001")],
+            phases=["pre_execution"],
+            stub_mode=True,
+            semantic_evaluator=None,
+            baseline_results_dir=None,
+            results_dir=tmp_path / "results",
+            repo_root=tmp_path,
+        )
+
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["skipped"] == "false"
+        assert row["tier1_pass"] == "true"
+        assert row["model_id"] == "stub"
+        assert row["tier2_influenced"] == json.dumps(["agent_a"])
+        # JSON result file was written under the run_dir/model_safe directory.
+        written = list(run_dir.glob("**/pi_001_pre_execution.json"))
+        assert written, "expected a per-case JSON result file"
+        data = json.loads(written[0].read_text())
+        assert data["execution"]["success"] is True
+        assert data["execution"]["duration_ms"] == pytest.approx(1000.0)
+
+    @patch(f"{_MODULE}.SecurityEventLogger")
+    @patch(f"{_MODULE}.SecurityEventDetector")
+    @patch(f"{_MODULE}.AttackInjector")
+    @patch(f"{_MODULE}.load_mas_from_yaml")
+    def test_inject_error_produces_skip_row(
+        self, mock_load, mock_injector_cls, _det, _log, tmp_path
+    ):
+        """A raised inject_attack records a skipped row with a skip_reason."""
+        mod = _import_module()
+        mock_load.return_value = _fake_config()
+        mock_injector_cls.return_value = _patched_injector(
+            side_effect=RuntimeError("no creds")
+        )
+
+        (tmp_path / "t.yaml").write_text("x")
+        rows, _run_dir = mod._run_config_for_model(
+            yaml_path="t.yaml",
+            model_id="amazon.nova-pro-v1:0",
+            model_display_name="Nova",
+            payloads=[_fake_payload("pi_001")],
+            phases=["pre_execution"],
+            stub_mode=False,
+            semantic_evaluator=None,
+            baseline_results_dir=None,
+            results_dir=tmp_path / "results",
+            repo_root=tmp_path,
+        )
+
+        assert len(rows) == 1
+        assert rows[0]["skipped"] == "true"
+        assert "RuntimeError" in rows[0]["skip_reason"]
+        assert rows[0]["provider_family"] == "amazon_bedrock"
+
+    @patch(f"{_MODULE}._load_baseline")
+    @patch(f"{_MODULE}.SecurityEventLogger")
+    @patch(f"{_MODULE}.SecurityEventDetector")
+    @patch(f"{_MODULE}.AttackInjector")
+    @patch(f"{_MODULE}.load_mas_from_yaml")
+    def test_tier3_evaluation_records_best_score(
+        self, mock_load, mock_injector_cls, _det, _log, mock_baseline, tmp_path
+    ):
+        """Non-stub run with a baseline records the best Tier-3 score."""
+        mod = _import_module()
+        mock_load.return_value = _fake_config()
+        mock_injector_cls.return_value = _patched_injector(_fake_attack_result())
+        mock_baseline.return_value = {"baseline": True}
+
+        evaluator = MagicMock()
+        evaluator.evaluate.return_value = [
+            SimpleNamespace(score=1, confidence="low", reasoning="r1"),
+            SimpleNamespace(score=3, confidence="high", reasoning="r3"),
+        ]
+
+        (tmp_path / "t.yaml").write_text("x")
+        rows, _run_dir = mod._run_config_for_model(
+            yaml_path="t.yaml",
+            model_id="gemini-2.0-flash",
+            model_display_name="Gemini",
+            payloads=[_fake_payload("pi_001")],
+            phases=["pre_execution"],
+            stub_mode=False,
+            semantic_evaluator=evaluator,
+            baseline_results_dir=tmp_path / "baseline",
+            results_dir=tmp_path / "results",
+            repo_root=tmp_path,
+        )
+
+        evaluator.evaluate.assert_called_once()
+        assert rows[0]["tier3_score"] == "3"
+        assert rows[0]["tier3_confidence"] == "high"
+        assert rows[0]["tier3_reasoning"] == "r3"
+
+    @patch(f"{_MODULE}._load_baseline")
+    @patch(f"{_MODULE}.SecurityEventLogger")
+    @patch(f"{_MODULE}.SecurityEventDetector")
+    @patch(f"{_MODULE}.AttackInjector")
+    @patch(f"{_MODULE}.load_mas_from_yaml")
+    def test_tier3_evaluator_error_swallowed(
+        self, mock_load, mock_injector_cls, _det, _log, mock_baseline, tmp_path
+    ):
+        """A failing evaluator leaves Tier-3 columns empty but records the row."""
+        mod = _import_module()
+        mock_load.return_value = _fake_config()
+        mock_injector_cls.return_value = _patched_injector(_fake_attack_result())
+        mock_baseline.return_value = {"baseline": True}
+
+        evaluator = MagicMock()
+        evaluator.evaluate.side_effect = RuntimeError("judge down")
+
+        (tmp_path / "t.yaml").write_text("x")
+        rows, _run_dir = mod._run_config_for_model(
+            yaml_path="t.yaml",
+            model_id="gemini-2.0-flash",
+            model_display_name="Gemini",
+            payloads=[_fake_payload("pi_001")],
+            phases=["pre_execution"],
+            stub_mode=False,
+            semantic_evaluator=evaluator,
+            baseline_results_dir=tmp_path / "baseline",
+            results_dir=tmp_path / "results",
+            repo_root=tmp_path,
+        )
+
+        assert rows[0]["tier3_score"] == ""
+
+
+# =========================================================================
+# run_cross_model_suite (programmatic API)
+# =========================================================================
+
+
+class TestRunCrossModelSuite:
+    """Tests for the non-exiting programmatic entry point."""
+
+    @patch(f"{_MODULE}._write_csv")
+    @patch(f"{_MODULE}._run_config_for_model")
+    def test_aggregates_and_writes_csv(self, mock_run, mock_write_csv, tmp_path):
+        """Aggregates rows across the model x config grid and writes a CSV."""
+        mod = _import_module()
+        mock_run.side_effect = [
+            (
+                [
+                    {
+                        "skipped": "false",
+                        "tier1_pass": "true",
+                        "tier2_influenced": '["agent_a"]',
+                        "payload_id": "pi_001",
+                        "phase": "pre_execution",
+                        "provider_family": "anthropic_bedrock",
+                    }
+                ],
+                tmp_path / "run_003",
+            ),
+            (
+                [
+                    {
+                        "skipped": "false",
+                        "tier1_pass": "false",
+                        "tier2_influenced": "[]",
+                        "payload_id": "pi_001",
+                        "phase": "pre_execution",
+                        "provider_family": "google_vertex",
+                    }
+                ],
+                tmp_path / "run_004",
+            ),
+        ]
+        mock_write_csv.return_value = tmp_path / "out.csv"
+
+        rows, first_run = mod.run_cross_model_suite(
+            payloads=[_fake_payload()],
+            config_paths=["a.yaml"],
+            phases=["pre_execution"],
+            model_matrix=[("mA", "A"), ("mB", "B")],
+            stub_mode=False,
+            semantic_evaluator=None,
+            baseline_results_dir=None,
+            results_dir=tmp_path,
+            repo_root=tmp_path,
+        )
+
+        assert len(rows) == 2
+        assert first_run == "run_003"
+        assert mock_write_csv.call_args[0][2] == "cross_model_matrix_run_003.csv"
+
+    @patch(f"{_MODULE}._run_config_for_model", return_value=([], None))
+    def test_no_rows_returns_empty(self, _mock_run, tmp_path):
+        """With no rows the function returns empty results and no run dir."""
+        mod = _import_module()
+        rows, first_run = mod.run_cross_model_suite(
+            payloads=[_fake_payload()],
+            config_paths=["a.yaml"],
+            phases=["pre_execution"],
+            model_matrix=[(None, "stub")],
+            stub_mode=True,
+            semantic_evaluator=None,
+            baseline_results_dir=None,
+            results_dir=tmp_path,
+            repo_root=tmp_path,
+        )
+        assert rows == []
+        assert first_run is None

--- a/bili/aegis/tests/test_generate_stats.py
+++ b/bili/aegis/tests/test_generate_stats.py
@@ -4,10 +4,20 @@ Tests the statistics computation and report formatting
 without touching the filesystem.
 """
 
+# Tests exercise private helpers (_load_suite, _SUITE_DIRS, etc.)
+# pylint: disable=protected-access
+
+import json
+from unittest.mock import MagicMock, patch
+
 import pytest
 
+from bili.aegis.suites.analysis import generate_stats as _stats_mod
 from bili.aegis.suites.analysis.generate_stats import (
+    _load_suite,
     _payload_succeeded,
+    _pct,
+    _score,
     _tier1_pass,
     _tier3_score,
     compute_persistence_stats,
@@ -15,6 +25,8 @@ from bili.aegis.suites.analysis.generate_stats import (
     compute_transferability_stats,
     format_report,
 )
+
+_MODULE = "bili.aegis.suites.analysis.generate_stats"
 
 
 class TestTier3Score:
@@ -266,6 +278,248 @@ class TestComputeTransferabilityStats:
         stats = compute_transferability_stats(results)
         rate = stats["per_model_success_rate"]["modelA"]
         assert rate == pytest.approx(0.5)
+
+
+class TestLoadSuite:
+    """Tests for _load_suite filesystem loading and run-dir selection."""
+
+    def test_returns_empty_when_dir_missing(self, tmp_path):
+        """Returns an empty list when the suite directory does not exist."""
+        assert _load_suite(tmp_path / "nope") == []
+
+    def test_loads_latest_run_dir_by_default(self, tmp_path):
+        """Default mode loads only the latest run_NNN directory per mas_id."""
+        mas = tmp_path / "mas_a"
+        (mas / "run_001").mkdir(parents=True)
+        (mas / "run_002").mkdir(parents=True)
+        (mas / "run_001" / "old.json").write_text(json.dumps({"v": "old"}))
+        (mas / "run_002" / "new.json").write_text(json.dumps({"v": "new"}))
+        results = _load_suite(tmp_path)
+        assert len(results) == 1
+        assert results[0]["v"] == "new"
+        assert results[0]["run_id"] == "run_002"
+
+    def test_loads_flat_legacy_layout(self, tmp_path):
+        """Falls back to the flat legacy layout when no run dirs exist."""
+        mas = tmp_path / "mas_a"
+        mas.mkdir(parents=True)
+        (mas / "r.json").write_text(json.dumps({"v": "flat"}))
+        results = _load_suite(tmp_path)
+        assert len(results) == 1
+        assert results[0]["run_id"] == "run_000 (legacy)"
+
+    def test_specific_run_selector(self, tmp_path):
+        """The run= selector loads only the named run dir, skipping absent ones."""
+        mas_a = tmp_path / "mas_a"
+        (mas_a / "run_001").mkdir(parents=True)
+        (mas_a / "run_001" / "a.json").write_text(json.dumps({"v": "a1"}))
+        mas_b = tmp_path / "mas_b"
+        (mas_b / "run_002").mkdir(parents=True)
+        (mas_b / "run_002" / "b.json").write_text(json.dumps({"v": "b2"}))
+        results = _load_suite(tmp_path, run="run_001")
+        assert len(results) == 1
+        assert results[0]["v"] == "a1"
+
+    def test_all_runs_aggregates(self, tmp_path):
+        """all_runs=True aggregates across every run dir, tagging run_id."""
+        mas = tmp_path / "mas_a"
+        (mas / "run_001").mkdir(parents=True)
+        (mas / "run_002").mkdir(parents=True)
+        (mas / "run_001" / "a.json").write_text(json.dumps({"v": 1}))
+        (mas / "run_002" / "b.json").write_text(json.dumps({"v": 2}))
+        results = _load_suite(tmp_path, all_runs=True)
+        assert {r["v"] for r in results} == {1, 2}
+        assert {r["run_id"] for r in results} == {"run_001", "run_002"}
+
+    def test_all_runs_flat_legacy(self, tmp_path):
+        """all_runs=True over a flat layout tags the legacy run_id."""
+        mas = tmp_path / "mas_a"
+        mas.mkdir(parents=True)
+        (mas / "x.json").write_text(json.dumps({"v": 9}))
+        results = _load_suite(tmp_path, all_runs=True)
+        assert results[0]["run_id"] == "run_000 (legacy)"
+
+    def test_skips_non_directory_entries(self, tmp_path):
+        """Non-directory entries directly under the suite dir are ignored."""
+        (tmp_path / "stray.txt").write_text("not a dir")
+        mas = tmp_path / "mas_a"
+        mas.mkdir()
+        (mas / "r.json").write_text(json.dumps({"v": "ok"}))
+        results = _load_suite(tmp_path)
+        assert len(results) == 1
+
+    def test_warns_on_corrupt_json(self, tmp_path):
+        """A corrupt JSON file is skipped with a warning, others still load."""
+        mas = tmp_path / "mas_a"
+        mas.mkdir(parents=True)
+        (mas / "bad.json").write_text("{not json")
+        (mas / "good.json").write_text(json.dumps({"v": "good"}))
+        results = _load_suite(tmp_path)
+        assert len(results) == 1
+        assert results[0]["v"] == "good"
+
+
+class TestPctAndScore:
+    """Tests for the _pct and _score formatting helpers."""
+
+    def test_pct_none(self):
+        """_pct returns 'N/A' for None."""
+        assert _pct(None) == "N/A"
+
+    def test_pct_value(self):
+        """_pct renders a fraction as a one-decimal percentage."""
+        assert _pct(0.5) == "50.0%"
+
+    def test_score_none(self):
+        """_score returns 'N/A' for None."""
+        assert _score(None) == "N/A"
+
+    def test_score_value(self):
+        """_score renders a float to two decimals."""
+        assert _score(1.5) == "1.50"
+
+
+class TestFormatReportPerConfig:
+    """Tests for format_report's per-config rendering branch."""
+
+    def test_renders_per_config_rows(self):
+        """Per-config rows appear under the suite section."""
+        stats = {
+            "injection": {
+                "suite": "injection",
+                "total": 2,
+                "tier1_success_rate": 0.5,
+                "avg_tier3_score": 1.0,
+                "tier3_evaluated": 2,
+                "per_config": {
+                    "mas_a": {"tier1_success_rate": 1.0, "avg_tier3_score": 2.0},
+                    "mas_b": {"tier1_success_rate": 0.0, "avg_tier3_score": None},
+                },
+            },
+        }
+        report = format_report(stats)
+        assert "Per config:" in report
+        assert "mas_a: T1=100.0%" in report
+        assert "mas_b: T1=0.0%" in report
+        # mas_b has no tier3 average, so the score renders as N/A.
+        assert "T3=N/A" in report
+
+
+class TestMain:
+    """Tests for the main() entry point."""
+
+    @patch(f"{_MODULE}.argparse.ArgumentParser.parse_args")
+    def test_prints_report_and_excludes_stub(self, mock_args, tmp_path, capsys):
+        """main loads each suite, excludes stub rows by default, and prints."""
+        injection_dir = tmp_path / "injection"
+        mas = injection_dir / "mas_a" / "run_001"
+        mas.mkdir(parents=True)
+        (mas / "real.json").write_text(
+            json.dumps(
+                {
+                    "mas_id": "mas_a",
+                    "execution": {"success": True},
+                    "run_metadata": {"tier3_score": 2, "stub_mode": False},
+                }
+            )
+        )
+        (mas / "stub.json").write_text(
+            json.dumps(
+                {
+                    "mas_id": "mas_a",
+                    "execution": {"success": True},
+                    "run_metadata": {"tier3_score": 2, "stub_mode": True},
+                }
+            )
+        )
+        suite_dirs = {"injection": injection_dir}
+
+        mock_args.return_value = MagicMock(
+            output=None, include_stub=False, run=None, all_runs=False
+        )
+        with patch.dict(_stats_mod._SUITE_DIRS, suite_dirs, clear=True):
+            _stats_mod.main()
+
+        out = capsys.readouterr().out
+        assert "AETHER RESULTS" in out
+        # Only the one real (non-stub) row is counted.
+        assert "Total runs:        1" in out
+
+    @patch(f"{_MODULE}.argparse.ArgumentParser.parse_args")
+    def test_include_stub_and_output_file(self, mock_args, tmp_path):
+        """--include-stub keeps stub rows and --output writes the report file."""
+        injection_dir = tmp_path / "injection"
+        mas = injection_dir / "mas_a" / "run_001"
+        mas.mkdir(parents=True)
+        (mas / "stub.json").write_text(
+            json.dumps(
+                {
+                    "mas_id": "mas_a",
+                    "execution": {"success": True},
+                    "run_metadata": {"tier3_score": 2, "stub_mode": True},
+                }
+            )
+        )
+        out_file = tmp_path / "report.txt"
+        mock_args.return_value = MagicMock(
+            output=str(out_file), include_stub=True, run=None, all_runs=False
+        )
+        with patch.dict(
+            _stats_mod._SUITE_DIRS, {"injection": injection_dir}, clear=True
+        ):
+            _stats_mod.main()
+
+        assert out_file.exists()
+        assert "AETHER RESULTS" in out_file.read_text()
+
+    @patch(f"{_MODULE}.argparse.ArgumentParser.parse_args")
+    def test_cross_model_and_persistence_dispatch(self, mock_args, tmp_path):
+        """main routes cross_model and persistence suites to their stat builders."""
+        cm_dir = tmp_path / "cross_model"
+        cm_mas = cm_dir / "mas_a" / "run_001"
+        cm_mas.mkdir(parents=True)
+        (cm_mas / "r.json").write_text(
+            json.dumps(
+                {
+                    "payload_id": "p1",
+                    "mas_id": "mas_a",
+                    "injection_phase": "pre",
+                    "model_id": "modelA",
+                    "execution": {"success": True},
+                    "run_metadata": {"tier3_score": 3, "stub_mode": False},
+                }
+            )
+        )
+        pers_dir = tmp_path / "persistence"
+        pers_mas = pers_dir / "mas_a" / "run_001"
+        pers_mas.mkdir(parents=True)
+        (pers_mas / "r.json").write_text(
+            json.dumps(
+                {
+                    "mas_id": "mas_a",
+                    "execution": {"success": True},
+                    "run_metadata": {"tier3_score": 1, "stub_mode": False},
+                }
+            )
+        )
+        mock_args.return_value = MagicMock(
+            output=None, include_stub=False, run=None, all_runs=False
+        )
+        captured = {}
+        with patch.dict(
+            _stats_mod._SUITE_DIRS,
+            {"cross_model": cm_dir, "persistence": pers_dir},
+            clear=True,
+        ):
+            with patch(
+                f"{_MODULE}.format_report",
+                side_effect=lambda s: captured.setdefault("stats", s) or "report",
+            ):
+                _stats_mod.main()
+
+        stats = captured["stats"]
+        assert stats["cross_model"]["total_results"] == 1
+        assert stats["persistence"]["suite"] == "persistence"
 
 
 class TestFormatReport:

--- a/bili/aegis/tests/test_helpers.py
+++ b/bili/aegis/tests/test_helpers.py
@@ -5,9 +5,12 @@ import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from bili.aegis.suites._helpers import (
     CONFIG_PATHS,
     config_fingerprint,
+    find_repo_root,
     model_id_safe,
     yaml_hash,
 )
@@ -30,6 +33,30 @@ class TestConfigPaths:
         """Every entry in CONFIG_PATHS ends with .yaml."""
         for path in CONFIG_PATHS:
             assert path.endswith(".yaml")
+
+
+class TestFindRepoRoot:
+    """Tests for find_repo_root()."""
+
+    def test_locates_real_repo_root(self):
+        """Returns a directory that contains a .git directory."""
+        root = find_repo_root()
+        assert (root / ".git").is_dir()
+        # The repo root must contain the bili package this module lives in.
+        assert (root / "bili" / "aegis" / "suites" / "_helpers.py").is_file()
+
+    def test_raises_when_no_git_dir_found(self, tmp_path, monkeypatch):
+        """Raises RuntimeError when no .git directory exists above the file."""
+        import bili.aegis.suites._helpers as helpers_mod
+
+        nested = tmp_path / "a" / "b" / "c"
+        nested.mkdir(parents=True)
+        fake_file = nested / "_helpers.py"
+        fake_file.write_text("# stub")
+        monkeypatch.setattr(helpers_mod, "__file__", str(fake_file))
+
+        with pytest.raises(RuntimeError, match="Could not locate repo root"):
+            find_repo_root()
 
 
 class TestYamlHash:

--- a/bili/aegis/tests/test_injection_runner.py
+++ b/bili/aegis/tests/test_injection_runner.py
@@ -7,7 +7,7 @@ All external dependencies are mocked.
 
 import sys
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -183,3 +183,77 @@ class TestInjectionRunnerMain:
 
         results_dir = mock_run_suite.call_args[1]["results_dir"]
         assert str(results_dir).endswith("injection/results")
+
+    @patch(f"{_MODULE}.run_suite")
+    @patch(f"{_MODULE}.INJECTION_PAYLOADS", [_fake_payload()])
+    @patch(f"{_MODULE}.CONFIG_PATHS", ["c.yaml"])
+    def test_non_stub_initializes_semantic_evaluator(self, mock_run_suite, tmp_path):
+        """Non-stub mode builds a SemanticEvaluator and an existing baseline dir."""
+        baseline_dir = tmp_path / "baseline"
+        baseline_dir.mkdir()
+        fake_eval = MagicMock(name="SemanticEvaluator")
+        with patch(
+            "bili.aegis.evaluator.SemanticEvaluator", return_value=fake_eval
+        ), patch.object(
+            sys,
+            "argv",
+            [
+                "run_injection_suite.py",
+                "--baseline-results",
+                str(baseline_dir),
+            ],
+        ):
+            from bili.aegis.suites.injection.run_injection_suite import main
+
+            mock_run_suite.side_effect = SystemExit(0)
+            with pytest.raises(SystemExit):
+                main()
+
+        call_kwargs = mock_run_suite.call_args[1]
+        assert call_kwargs["stub"] is False
+        assert call_kwargs["semantic_evaluator"] is fake_eval
+        assert call_kwargs["baseline_results_dir"] == baseline_dir
+
+    @patch(f"{_MODULE}.run_suite")
+    @patch(f"{_MODULE}.INJECTION_PAYLOADS", [_fake_payload()])
+    @patch(f"{_MODULE}.CONFIG_PATHS", ["c.yaml"])
+    def test_missing_baseline_dir_warns_and_clears(self, mock_run_suite, capsys):
+        """A nonexistent baseline dir is reported and reset to None."""
+        fake_eval = MagicMock(name="SemanticEvaluator")
+        with patch(
+            "bili.aegis.evaluator.SemanticEvaluator", return_value=fake_eval
+        ), patch.object(
+            sys,
+            "argv",
+            [
+                "run_injection_suite.py",
+                "--baseline-results",
+                "/no/such/dir",
+            ],
+        ):
+            from bili.aegis.suites.injection.run_injection_suite import main
+
+            mock_run_suite.side_effect = SystemExit(0)
+            with pytest.raises(SystemExit):
+                main()
+
+        err = capsys.readouterr().err
+        assert "baseline results dir not found" in err
+        assert mock_run_suite.call_args[1]["baseline_results_dir"] is None
+
+    @patch(f"{_MODULE}.run_suite")
+    @patch(f"{_MODULE}.INJECTION_PAYLOADS", [_fake_payload()])
+    @patch(f"{_MODULE}.CONFIG_PATHS", ["c.yaml"])
+    def test_semantic_evaluator_import_error_handled(self, mock_run_suite):
+        """A failing SemanticEvaluator init leaves the evaluator as None."""
+        with patch(
+            "bili.aegis.evaluator.SemanticEvaluator",
+            side_effect=ImportError("missing dep"),
+        ), patch.object(sys, "argv", ["run_injection_suite.py"]):
+            from bili.aegis.suites.injection.run_injection_suite import main
+
+            mock_run_suite.side_effect = SystemExit(0)
+            with pytest.raises(SystemExit):
+                main()
+
+        assert mock_run_suite.call_args[1]["semantic_evaluator"] is None

--- a/bili/aegis/tests/test_persistence_runner.py
+++ b/bili/aegis/tests/test_persistence_runner.py
@@ -5,11 +5,18 @@ helper functions, and summary printing.
 All external dependencies are mocked.
 """
 
+# Tests exercise private helpers (_CSV_COLUMNS, _run_persistence_config, etc.)
+# pylint: disable=protected-access
+
 import csv
+import datetime
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+_MODULE = "bili.aegis.suites.persistence.run_persistence_suite"
 
 
 def _import_module():
@@ -18,6 +25,56 @@ def _import_module():
     from bili.aegis.suites.persistence import run_persistence_suite as mod
 
     return mod
+
+
+def _fake_payload(payload_id="pe_001"):
+    """Build a minimal persistence payload namespace."""
+    return SimpleNamespace(
+        payload_id=payload_id,
+        injection_type="persistence",
+        severity="high",
+        payload="poisoned context",
+    )
+
+
+def _fake_attack_result(success=True, influenced=None, resistant=None):
+    """Build a minimal attack result namespace with a 1s duration."""
+    now = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+    return SimpleNamespace(
+        success=success,
+        target_agent_id="agent_a",
+        propagation_path=["agent_a"],
+        influenced_agents=influenced if influenced is not None else [],
+        resistant_agents=resistant if resistant is not None else ["agent_b"],
+        injected_at=now,
+        completed_at=now + datetime.timedelta(seconds=1),
+    )
+
+
+def _fake_config():
+    """Build a minimal MAS config namespace."""
+    agent = SimpleNamespace(agent_id="agent_a", model_name="m", temperature=0.2)
+    return SimpleNamespace(
+        mas_id="test_mas",
+        entry_point=None,
+        agents=[agent],
+        checkpoint_enabled=True,
+        checkpoint_config={"type": "postgres"},
+    )
+
+
+def _patched_injector(attack_result=None, side_effect=None):
+    """Build a context-manager MagicMock that mimics AttackInjector."""
+    injector = MagicMock()
+    injector.__enter__ = MagicMock(return_value=injector)
+    injector.__exit__ = MagicMock(return_value=False)
+    if side_effect is not None:
+        injector.inject_attack.side_effect = side_effect
+    else:
+        injector.inject_attack.return_value = (
+            attack_result if attack_result is not None else _fake_attack_result()
+        )
+    return injector
 
 
 # =========================================================================
@@ -85,6 +142,45 @@ class TestCheckpointerIsPersistent:
         ok, reason = mod._checkpointer_is_persistent(config)
         assert ok is True
         assert reason == ""
+
+    @patch(
+        "bili.aether.integration.checkpointer_factory"
+        ".create_checkpointer_from_config"
+    )
+    def test_returns_false_when_factory_falls_back_to_memorysaver(self, mock_factory):
+        """Returns (False, reason) when the factory hands back a MemorySaver."""
+        # pylint: disable=import-outside-toplevel
+        from langgraph.checkpoint.memory import MemorySaver
+
+        mod = _import_module()
+        mock_factory.return_value = MemorySaver()
+        config = MagicMock()
+        config.checkpoint_enabled = True
+        config.checkpoint_config = {"type": "postgres"}
+        ok, reason = mod._checkpointer_is_persistent(config)
+        assert ok is False
+        assert "MemorySaver at runtime" in reason
+
+    def test_returns_false_when_langgraph_missing(self):
+        """Returns (False, reason) when langgraph MemorySaver import fails."""
+        import builtins  # pylint: disable=import-outside-toplevel
+
+        mod = _import_module()
+        config = MagicMock()
+        config.checkpoint_enabled = True
+        config.checkpoint_config = {"type": "postgres"}
+
+        real_import = builtins.__import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "langgraph.checkpoint.memory":
+                raise ImportError("no langgraph")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=_fake_import):
+            ok, reason = mod._checkpointer_is_persistent(config)
+        assert ok is False
+        assert "langgraph not available" in reason
 
 
 # =========================================================================
@@ -200,6 +296,297 @@ class TestLoadBaseline:
         result = mod._load_baseline(tmp_path, "mas1")
         assert result == data
 
+    def test_returns_none_when_no_json_files(self, tmp_path):
+        """Returns None when the MAS directory has no JSON files."""
+        mod = _import_module()
+        (tmp_path / "mas1").mkdir()
+        assert mod._load_baseline(tmp_path, "mas1") is None
+
+    def test_returns_none_on_corrupt_json(self, tmp_path):
+        """Returns None and warns when the baseline JSON cannot be parsed."""
+        mod = _import_module()
+        mas_dir = tmp_path / "mas1"
+        mas_dir.mkdir()
+        (mas_dir / "bad.json").write_text("{not valid json")
+        assert mod._load_baseline(tmp_path, "mas1") is None
+
+
+# =========================================================================
+# _run_persistence_config
+# =========================================================================
+
+
+class TestRunPersistenceConfig:
+    """Tests for the per-config persistence runner loop."""
+
+    @patch(f"{_MODULE}.load_mas_from_yaml")
+    def test_skips_missing_config(self, mock_load, tmp_path):
+        """Returns empty rows and None run_dir when the YAML path is missing."""
+        mod = _import_module()
+        rows, run_dir = mod._run_persistence_config(
+            yaml_path="missing.yaml",
+            payloads=[_fake_payload()],
+            stub_mode=True,
+            semantic_evaluator=None,
+            baseline_results_dir=None,
+            results_dir=tmp_path / "results",
+            repo_root=tmp_path,
+        )
+        assert rows == []
+        assert run_dir is None
+        mock_load.assert_not_called()
+
+    @patch(f"{_MODULE}._checkpointer_is_persistent")
+    @patch(f"{_MODULE}.load_mas_from_yaml")
+    def test_skips_non_persistent_backend(self, mock_load, mock_persistent, tmp_path):
+        """Produces skip rows (one per payload) when no persistent backend."""
+        mod = _import_module()
+        mock_load.return_value = _fake_config()
+        mock_persistent.return_value = (False, "MemorySaver in use")
+
+        (tmp_path / "t.yaml").write_text("x")
+        rows, run_dir = mod._run_persistence_config(
+            yaml_path="t.yaml",
+            payloads=[_fake_payload("pe_001"), _fake_payload("pe_002")],
+            stub_mode=True,
+            semantic_evaluator=None,
+            baseline_results_dir=None,
+            results_dir=tmp_path / "results",
+            repo_root=tmp_path,
+        )
+        assert run_dir is None
+        assert len(rows) == 2
+        assert all(r["skipped"] == "true" for r in rows)
+        assert rows[0]["skip_reason"] == "MemorySaver in use"
+
+    @patch(f"{_MODULE}.SecurityEventLogger")
+    @patch(f"{_MODULE}.SecurityEventDetector")
+    @patch(f"{_MODULE}.AttackInjector")
+    @patch(f"{_MODULE}._checkpointer_is_persistent")
+    @patch(f"{_MODULE}.load_mas_from_yaml")
+    def test_stub_mode_nulls_model_and_writes_result(
+        self, mock_load, mock_persistent, mock_injector_cls, _det, _log, tmp_path
+    ):
+        """Stub mode nulls agent model_name, writes a JSON result, returns a row."""
+        mod = _import_module()
+        config = _fake_config()
+        mock_load.return_value = config
+        mock_persistent.return_value = (True, "")
+        mock_injector_cls.return_value = _patched_injector(
+            _fake_attack_result(influenced=["agent_a"])
+        )
+
+        (tmp_path / "t.yaml").write_text("x")
+        rows, run_dir = mod._run_persistence_config(
+            yaml_path="t.yaml",
+            payloads=[_fake_payload("pe_001")],
+            stub_mode=True,
+            semantic_evaluator=None,
+            baseline_results_dir=None,
+            results_dir=tmp_path / "results",
+            repo_root=tmp_path,
+        )
+
+        assert config.agents[0].model_name is None
+        assert len(rows) == 1
+        assert rows[0]["skipped"] == "false"
+        assert rows[0]["tier1_pass"] == "true"
+        assert rows[0]["tier2_influenced"] == json.dumps(["agent_a"])
+        written = list(run_dir.glob("pe_001_*.json"))
+        assert written, "expected a per-case JSON result file"
+        data = json.loads(written[0].read_text())
+        assert data["execution"]["success"] is True
+        assert data["execution"]["duration_ms"] == pytest.approx(1000.0)
+
+    @patch(f"{_MODULE}.SecurityEventLogger")
+    @patch(f"{_MODULE}.SecurityEventDetector")
+    @patch(f"{_MODULE}.AttackInjector")
+    @patch(f"{_MODULE}._checkpointer_is_persistent")
+    @patch(f"{_MODULE}.load_mas_from_yaml")
+    def test_inject_error_records_failure_row(
+        self, mock_load, mock_persistent, mock_injector_cls, _det, _log, tmp_path
+    ):
+        """A raised inject_attack records a tier1-fail row carrying the message."""
+        mod = _import_module()
+        mock_load.return_value = _fake_config()
+        mock_persistent.return_value = (True, "")
+        mock_injector_cls.return_value = _patched_injector(
+            side_effect=RuntimeError("boom")
+        )
+
+        (tmp_path / "t.yaml").write_text("x")
+        rows, _run_dir = mod._run_persistence_config(
+            yaml_path="t.yaml",
+            payloads=[_fake_payload("pe_001")],
+            stub_mode=True,
+            semantic_evaluator=None,
+            baseline_results_dir=None,
+            results_dir=tmp_path / "results",
+            repo_root=tmp_path,
+        )
+
+        assert len(rows) == 1
+        assert rows[0]["skipped"] == "false"
+        assert rows[0]["tier1_pass"] == "false"
+        assert rows[0]["tier3_reasoning"] == "boom"
+
+    @patch(f"{_MODULE}._load_baseline")
+    @patch(f"{_MODULE}.SecurityEventLogger")
+    @patch(f"{_MODULE}.SecurityEventDetector")
+    @patch(f"{_MODULE}.AttackInjector")
+    @patch(f"{_MODULE}._checkpointer_is_persistent")
+    @patch(f"{_MODULE}.load_mas_from_yaml")
+    def test_tier3_evaluation_records_best_score(
+        self,
+        mock_load,
+        mock_persistent,
+        mock_injector_cls,
+        _det,
+        _log,
+        mock_baseline,
+        tmp_path,
+    ):
+        """Non-stub run with a baseline records the best Tier-3 score."""
+        mod = _import_module()
+        mock_load.return_value = _fake_config()
+        mock_persistent.return_value = (True, "")
+        mock_injector_cls.return_value = _patched_injector(_fake_attack_result())
+        mock_baseline.return_value = {"baseline": True}
+
+        evaluator = MagicMock()
+        evaluator.evaluate.return_value = [
+            SimpleNamespace(score=1, confidence="low", reasoning="r1"),
+            SimpleNamespace(score=3, confidence="high", reasoning="r3"),
+        ]
+
+        (tmp_path / "t.yaml").write_text("x")
+        rows, _run_dir = mod._run_persistence_config(
+            yaml_path="t.yaml",
+            payloads=[_fake_payload("pe_001")],
+            stub_mode=False,
+            semantic_evaluator=evaluator,
+            baseline_results_dir=tmp_path / "baseline",
+            results_dir=tmp_path / "results",
+            repo_root=tmp_path,
+        )
+
+        evaluator.evaluate.assert_called_once()
+        assert rows[0]["tier3_score"] == "3"
+        assert rows[0]["tier3_confidence"] == "high"
+        assert rows[0]["tier3_reasoning"] == "r3"
+
+    @patch(f"{_MODULE}._load_baseline")
+    @patch(f"{_MODULE}.SecurityEventLogger")
+    @patch(f"{_MODULE}.SecurityEventDetector")
+    @patch(f"{_MODULE}.AttackInjector")
+    @patch(f"{_MODULE}._checkpointer_is_persistent")
+    @patch(f"{_MODULE}.load_mas_from_yaml")
+    def test_tier3_evaluator_error_swallowed(
+        self,
+        mock_load,
+        mock_persistent,
+        mock_injector_cls,
+        _det,
+        _log,
+        mock_baseline,
+        tmp_path,
+    ):
+        """A failing evaluator leaves Tier-3 columns empty but records the row."""
+        mod = _import_module()
+        mock_load.return_value = _fake_config()
+        mock_persistent.return_value = (True, "")
+        mock_injector_cls.return_value = _patched_injector(_fake_attack_result())
+        mock_baseline.return_value = {"baseline": True}
+
+        evaluator = MagicMock()
+        evaluator.evaluate.side_effect = RuntimeError("judge down")
+
+        (tmp_path / "t.yaml").write_text("x")
+        rows, _run_dir = mod._run_persistence_config(
+            yaml_path="t.yaml",
+            payloads=[_fake_payload("pe_001")],
+            stub_mode=False,
+            semantic_evaluator=evaluator,
+            baseline_results_dir=tmp_path / "baseline",
+            results_dir=tmp_path / "results",
+            repo_root=tmp_path,
+        )
+
+        assert rows[0]["tier3_score"] == ""
+        assert rows[0]["tier3_reasoning"] == ""
+
+
+# =========================================================================
+# run_persistence_suite (programmatic API)
+# =========================================================================
+
+
+class TestRunPersistenceSuite:
+    """Tests for the non-exiting programmatic entry point."""
+
+    @patch(f"{_MODULE}._write_csv")
+    @patch(f"{_MODULE}._run_persistence_config")
+    def test_aggregates_and_writes_versioned_csv(
+        self, mock_run, mock_write_csv, tmp_path
+    ):
+        """Aggregates rows across configs and writes a run-versioned CSV."""
+        mod = _import_module()
+        mock_run.side_effect = [
+            (
+                [
+                    {
+                        "skipped": "false",
+                        "tier1_pass": "true",
+                        "tier2_influenced": "[]",
+                    }
+                ],
+                tmp_path / "run_005",
+            ),
+            (
+                [
+                    {
+                        "skipped": "false",
+                        "tier1_pass": "false",
+                        "tier2_influenced": "[]",
+                    }
+                ],
+                tmp_path / "run_006",
+            ),
+        ]
+        mock_write_csv.return_value = tmp_path / "out.csv"
+
+        rows, first_run = mod.run_persistence_suite(
+            payloads=[_fake_payload()],
+            config_paths=["a.yaml", "b.yaml"],
+            stub_mode=False,
+            semantic_evaluator=None,
+            baseline_results_dir=None,
+            results_dir=tmp_path,
+            repo_root=tmp_path,
+        )
+
+        assert len(rows) == 2
+        assert first_run == "run_005"
+        assert (
+            mock_write_csv.call_args[0][2] == "persistence_results_matrix_run_005.csv"
+        )
+
+    @patch(f"{_MODULE}._run_persistence_config", return_value=([], None))
+    def test_no_rows_returns_empty(self, _mock_run, tmp_path):
+        """With no rows the function returns empty results and no run dir."""
+        mod = _import_module()
+        rows, first_run = mod.run_persistence_suite(
+            payloads=[_fake_payload()],
+            config_paths=["a.yaml"],
+            stub_mode=True,
+            semantic_evaluator=None,
+            baseline_results_dir=None,
+            results_dir=tmp_path,
+            repo_root=tmp_path,
+        )
+        assert rows == []
+        assert first_run is None
+
 
 # =========================================================================
 # main() — CLI parsing
@@ -301,3 +688,68 @@ class TestMain:
         with pytest.raises(SystemExit) as exc_info:
             mod.main()
         assert exc_info.value.code == 0
+
+    @patch(f"{_MODULE}.argparse.ArgumentParser.parse_args")
+    @patch(f"{_MODULE}._run_persistence_config")
+    def test_missing_baseline_dir_clears_to_none(self, mock_run, mock_args, capsys):
+        """A nonexistent baseline dir warns and is passed through as None."""
+        mod = _import_module()
+        mock_args.return_value = MagicMock(
+            stub=True,
+            configs=["a.yaml"],
+            payloads=None,
+            baseline_results="no/such/baseline/dir",
+            log_level="WARNING",
+        )
+        mock_run.return_value = ([], None)
+        with pytest.raises(SystemExit):
+            mod.main()
+        err = capsys.readouterr().err
+        assert "baseline results dir not found" in err
+        assert mock_run.call_args[1]["baseline_results_dir"] is None
+
+    @patch(f"{_MODULE}.argparse.ArgumentParser.parse_args")
+    @patch(f"{_MODULE}._run_persistence_config")
+    def test_non_stub_builds_semantic_evaluator(self, mock_run, mock_args):
+        """Non-stub mode constructs a persistence-tuned SemanticEvaluator."""
+        mod = _import_module()
+        mock_args.return_value = MagicMock(
+            stub=False,
+            configs=["a.yaml"],
+            payloads=None,
+            baseline_results=None,
+            log_level="WARNING",
+        )
+        mock_run.return_value = ([], None)
+        sentinel_evaluator = MagicMock(name="evaluator")
+        with patch(
+            "bili.aegis.evaluator.SemanticEvaluator",
+            return_value=sentinel_evaluator,
+        ) as mock_eval_cls:
+            with pytest.raises(SystemExit):
+                mod.main()
+        mock_eval_cls.assert_called_once()
+        assert mock_run.call_args[1]["semantic_evaluator"] is sentinel_evaluator
+
+    @patch(f"{_MODULE}.argparse.ArgumentParser.parse_args")
+    @patch(f"{_MODULE}._run_persistence_config")
+    def test_non_stub_semantic_evaluator_init_error_tolerated(
+        self, mock_run, mock_args
+    ):
+        """A failing SemanticEvaluator init in non-stub mode passes None through."""
+        mod = _import_module()
+        mock_args.return_value = MagicMock(
+            stub=False,
+            configs=["a.yaml"],
+            payloads=None,
+            baseline_results=None,
+            log_level="WARNING",
+        )
+        mock_run.return_value = ([], None)
+        with patch(
+            "bili.aegis.evaluator.SemanticEvaluator",
+            side_effect=RuntimeError("no creds"),
+        ):
+            with pytest.raises(SystemExit):
+                mod.main()
+        assert mock_run.call_args[1]["semantic_evaluator"] is None

--- a/bili/aegis/tests/test_remaining_runners.py
+++ b/bili/aegis/tests/test_remaining_runners.py
@@ -6,9 +6,10 @@ a main() function that parses CLI args and delegates to run_suite().
 All external dependencies are mocked.
 """
 
+import importlib
 import sys
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -439,6 +440,91 @@ class TestBiasInheritanceRunnerMain:
 
         kw = mock_run_suite.call_args[1]
         assert kw["phases"] == ["mid_execution"]
+
+
+# ===================================================================
+# Non-stub mode: baseline resolution + SemanticEvaluator init
+# ===================================================================
+
+# (module_path, payload_constant_name, script_name)
+_NON_STUB_RUNNERS = [
+    (_AI_MOD, "AGENT_IMPERSONATION_PAYLOADS", "run_agent_impersonation_suite.py"),
+    (_BI_MOD, "BIAS_INHERITANCE_PAYLOADS", "run_bias_inheritance_suite.py"),
+    (_JB_MOD, "JAILBREAK_PAYLOADS", "run_jailbreak_suite.py"),
+    (_MP_MOD, "MEMORY_POISONING_PAYLOADS", "run_memory_poisoning_suite.py"),
+]
+
+
+@pytest.mark.parametrize("mod_path,payload_const,script", _NON_STUB_RUNNERS)
+def test_non_stub_initializes_semantic_evaluator(
+    mod_path, payload_const, script, tmp_path, monkeypatch
+):
+    """Non-stub mode constructs a SemanticEvaluator and passes it to run_suite."""
+    mod = importlib.import_module(mod_path)
+    baseline_dir = tmp_path / "baseline"
+    baseline_dir.mkdir()
+    fake_eval = MagicMock(name="SemanticEvaluator")
+
+    with patch.object(mod, "run_suite", side_effect=SystemExit(0)) as mock_run, patch(
+        "bili.aegis.evaluator.SemanticEvaluator", return_value=fake_eval
+    ), patch.object(mod, payload_const, [_fake_payload()]), patch.object(
+        mod, "CONFIG_PATHS", ["c.yaml"]
+    ), patch.object(
+        sys,
+        "argv",
+        [script, "--baseline-results", str(baseline_dir)],
+    ):
+        with pytest.raises(SystemExit):
+            mod.main()
+
+    kw = mock_run.call_args[1]
+    assert kw["stub"] is False
+    assert kw["semantic_evaluator"] is fake_eval
+    assert kw["baseline_results_dir"] == baseline_dir
+
+
+@pytest.mark.parametrize("mod_path,payload_const,script", _NON_STUB_RUNNERS)
+def test_missing_baseline_dir_warns_and_clears(mod_path, payload_const, script, capsys):
+    """A nonexistent baseline dir is reported and reset to None."""
+    mod = importlib.import_module(mod_path)
+    fake_eval = MagicMock(name="SemanticEvaluator")
+
+    with patch.object(mod, "run_suite", side_effect=SystemExit(0)) as mock_run, patch(
+        "bili.aegis.evaluator.SemanticEvaluator", return_value=fake_eval
+    ), patch.object(mod, payload_const, [_fake_payload()]), patch.object(
+        mod, "CONFIG_PATHS", ["c.yaml"]
+    ), patch.object(
+        sys,
+        "argv",
+        [script, "--baseline-results", "/no/such/baseline/dir"],
+    ):
+        with pytest.raises(SystemExit):
+            mod.main()
+
+    err = capsys.readouterr().err
+    assert "baseline results dir not found" in err
+    assert mock_run.call_args[1]["baseline_results_dir"] is None
+
+
+@pytest.mark.parametrize("mod_path,payload_const,script", _NON_STUB_RUNNERS)
+def test_semantic_evaluator_import_error_is_handled(mod_path, payload_const, script):
+    """A failing SemanticEvaluator init leaves the evaluator as None."""
+    mod = importlib.import_module(mod_path)
+
+    with patch.object(mod, "run_suite", side_effect=SystemExit(0)) as mock_run, patch(
+        "bili.aegis.evaluator.SemanticEvaluator",
+        side_effect=RuntimeError("no credentials"),
+    ), patch.object(mod, payload_const, [_fake_payload()]), patch.object(
+        mod, "CONFIG_PATHS", ["c.yaml"]
+    ), patch.object(
+        sys,
+        "argv",
+        [script],
+    ):
+        with pytest.raises(SystemExit):
+            mod.main()
+
+    assert mock_run.call_args[1]["semantic_evaluator"] is None
 
 
 # ===================================================================

--- a/bili/aegis/tests/test_security_logger.py
+++ b/bili/aegis/tests/test_security_logger.py
@@ -2,6 +2,7 @@
 
 import json
 import threading
+from unittest.mock import patch
 
 from bili.aegis.security.logger import SecurityEventLogger
 from bili.aegis.security.models import SecurityEventType
@@ -150,6 +151,39 @@ def test_export_json_preserves_all_fields(tmp_path):
     assert entry["run_id"] == "run-xyz"
     assert entry["severity"] == "medium"
     assert entry["mas_id"] == "test_mas"
+
+
+def test_export_json_skips_blank_and_malformed_lines(tmp_path):
+    """Blank lines are ignored and malformed JSON lines are skipped with a warning."""
+    log_path = tmp_path / "events.ndjson"
+    logger = SecurityEventLogger(log_path=log_path)
+    logger.log(_event())
+    # Append a blank line and a malformed line after a valid record.
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write("\n")
+        handle.write("{ this is not valid json }\n")
+
+    with patch("bili.aegis.security.logger.LOGGER.warning") as mock_warning:
+        parsed = json.loads(logger.export_json())
+
+    # Only the one valid event survives; the malformed line triggered a warning.
+    assert len(parsed) == 1
+    mock_warning.assert_called_once()
+
+
+def test_export_json_warns_and_returns_empty_on_read_error(tmp_path):
+    """A read failure is logged and yields an empty array rather than raising."""
+    log_path = tmp_path / "events.ndjson"
+    logger = SecurityEventLogger(log_path=log_path)
+    logger.log(_event())
+
+    with patch(
+        "pathlib.Path.read_text", side_effect=OSError("permission denied")
+    ), patch("bili.aegis.security.logger.LOGGER.warning") as mock_warning:
+        result = logger.export_json()
+
+    assert json.loads(result) == []
+    mock_warning.assert_called_once()
 
 
 # =========================================================================

--- a/bili/aegis/tests/test_suite_runner.py
+++ b/bili/aegis/tests/test_suite_runner.py
@@ -16,6 +16,8 @@ import pytest
 
 from bili.aegis.suites._suite_runner import (
     _build_result_dict,
+    _load_baseline,
+    _print_summary,
     _run_config,
     _target_agent_id,
     _write_csv,
@@ -534,6 +536,266 @@ class TestRunSuite:
         # 1 pass out of 2 total -> exit(1)
         assert exc_info.value.code == 1
         assert mock_run_config.call_count == 2
+
+    @patch(f"{_MODULE}._print_summary")
+    @patch(f"{_MODULE}._write_csv")
+    @patch(f"{_MODULE}._run_config")
+    def test_versioned_csv_name_uses_first_run_dir(
+        self, mock_run_config, mock_write_csv, _mock_print
+    ):
+        """CSV filename is suffixed with the first config's run_dir name."""
+        mock_run_config.return_value = (
+            [{"tier1_pass": "true"}],
+            Path("/fake/run_007"),
+        )
+        mock_write_csv.return_value = Path("/fake.csv")
+
+        with pytest.raises(SystemExit):
+            run_suite(
+                payloads=[_fake_payload()],
+                attack_suite="test",
+                attack_type="prompt_injection",
+                csv_filename="injection_results_matrix.csv",
+                suite_name="Test",
+                results_dir=Path("/tmp/results"),
+                repo_root=Path("/tmp"),
+                config_paths=["a.yaml"],
+                phases=["pre_input"],
+                stub=True,
+            )
+
+        versioned_name = mock_write_csv.call_args[0][2]
+        assert versioned_name == "injection_results_matrix_run_007.csv"
+
+
+# =========================================================================
+# _print_summary
+# =========================================================================
+
+
+class TestPrintSummary:
+    """Tests for _print_summary."""
+
+    def test_counts_passes_and_influenced(self, capsys):
+        """Summary reports total, tier1 passes, and influenced cases."""
+        rows = [
+            {"tier1_pass": "true", "tier2_influenced": '["a"]'},
+            {"tier1_pass": "false", "tier2_influenced": "[]"},
+            {"tier1_pass": "true", "tier2_influenced": "[]"},
+        ]
+        _print_summary(rows, "My Suite")
+        out = capsys.readouterr().out
+        assert "My Suite Summary" in out
+        assert "Total test cases : 3" in out
+        assert "Tier 1 pass      : 2/3" in out
+        assert "1 cases had" in out
+
+
+# =========================================================================
+# _load_baseline
+# =========================================================================
+
+
+class TestLoadBaseline:
+    """Tests for _load_baseline in the shared suite runner."""
+
+    def test_returns_none_when_dir_is_none(self):
+        """Returns None when baseline_results_dir is None."""
+        assert _load_baseline(None, "mas1") is None
+
+    def test_returns_none_when_search_dir_missing(self, tmp_path):
+        """Returns None when the mas_id subdirectory does not exist."""
+        assert _load_baseline(tmp_path, "missing") is None
+
+    def test_returns_none_when_no_json(self, tmp_path):
+        """Returns None when the directory has no JSON files."""
+        (tmp_path / "mas1").mkdir()
+        assert _load_baseline(tmp_path, "mas1") is None
+
+    def test_loads_first_json_in_flat_layout(self, tmp_path):
+        """Loads the first JSON file from the flat (legacy) layout."""
+        mas_dir = tmp_path / "mas1"
+        mas_dir.mkdir()
+        (mas_dir / "a_result.json").write_text(json.dumps({"baseline": 1}))
+        assert _load_baseline(tmp_path, "mas1") == {"baseline": 1}
+
+    def test_prefers_latest_run_dir(self, tmp_path):
+        """Loads from the latest run_NNN directory when one exists."""
+        mas_dir = tmp_path / "mas1"
+        (mas_dir / "run_001").mkdir(parents=True)
+        (mas_dir / "run_002").mkdir(parents=True)
+        (mas_dir / "run_001" / "old.json").write_text(json.dumps({"v": "old"}))
+        (mas_dir / "run_002" / "new.json").write_text(json.dumps({"v": "new"}))
+        assert _load_baseline(tmp_path, "mas1") == {"v": "new"}
+
+    def test_returns_none_on_corrupt_json(self, tmp_path):
+        """Returns None and warns when the baseline JSON is invalid."""
+        mas_dir = tmp_path / "mas1"
+        mas_dir.mkdir()
+        (mas_dir / "bad.json").write_text("{not valid json")
+        assert _load_baseline(tmp_path, "mas1") is None
+
+
+# =========================================================================
+# _run_config — executor init and tier3 evaluation paths
+# =========================================================================
+
+
+class TestRunConfigExtended:
+    """Tests for _run_config branches not covered by the basic cases."""
+
+    @patch(f"{_MODULE}._write_result")
+    @patch(f"{_MODULE}.MASExecutor")
+    @patch(f"{_MODULE}.SecurityEventLogger")
+    @patch(f"{_MODULE}.SecurityEventDetector")
+    @patch(f"{_MODULE}.AttackInjector")
+    @patch(f"{_MODULE}.load_mas_from_yaml")
+    def test_initializes_executor_for_mid_execution(
+        self,
+        mock_load,
+        mock_injector_cls,
+        _mock_detector,
+        _mock_logger,
+        mock_executor_cls,
+        mock_write,
+    ):
+        """An executor is built and initialized when mid_execution is in phases."""
+        config = _fake_config()
+        mock_load.return_value = config
+        mock_executor = MagicMock()
+        mock_executor_cls.return_value = mock_executor
+
+        mock_injector = MagicMock()
+        mock_injector.__enter__ = MagicMock(return_value=mock_injector)
+        mock_injector.__exit__ = MagicMock(return_value=False)
+        mock_injector.inject_attack.return_value = _fake_attack_result()
+        mock_injector_cls.return_value = mock_injector
+        mock_write.return_value = Path("/fake/out.json")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "t.yaml").write_text("x")
+            rows, _run_dir = _run_config(
+                yaml_path="t.yaml",
+                payloads=[_fake_payload()],
+                phases=["mid_execution"],
+                stub_mode=True,
+                semantic_evaluator=None,
+                baseline_results_dir=None,
+                results_dir=root / "results",
+                repo_root=root,
+                attack_suite="injection",
+                attack_type="prompt_injection",
+            )
+
+        mock_executor_cls.assert_called_once_with(config)
+        mock_executor.initialize.assert_called_once()
+        # The executor instance is threaded into AttackInjector.
+        assert mock_injector_cls.call_args[0][1] is mock_executor
+        assert len(rows) == 1
+
+    @patch(f"{_MODULE}._load_baseline")
+    @patch(f"{_MODULE}._write_result")
+    @patch(f"{_MODULE}.SecurityEventLogger")
+    @patch(f"{_MODULE}.SecurityEventDetector")
+    @patch(f"{_MODULE}.AttackInjector")
+    @patch(f"{_MODULE}.load_mas_from_yaml")
+    def test_tier3_evaluation_populates_score(
+        self,
+        mock_load,
+        mock_injector_cls,
+        _mock_detector,
+        _mock_logger,
+        mock_write,
+        mock_load_baseline,
+    ):
+        """Non-stub run with a baseline evaluates Tier 3 and records the best score."""
+        config = _fake_config()
+        mock_load.return_value = config
+
+        mock_injector = MagicMock()
+        mock_injector.__enter__ = MagicMock(return_value=mock_injector)
+        mock_injector.__exit__ = MagicMock(return_value=False)
+        mock_injector.inject_attack.return_value = _fake_attack_result()
+        mock_injector_cls.return_value = mock_injector
+        mock_write.return_value = Path("/fake/out.json")
+        mock_load_baseline.return_value = {"baseline": True}
+
+        evaluator = MagicMock()
+        evaluator.evaluate.return_value = [
+            SimpleNamespace(score=1, confidence="low", reasoning="r1"),
+            SimpleNamespace(score=3, confidence="high", reasoning="r3"),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "t.yaml").write_text("x")
+            rows, _run_dir = _run_config(
+                yaml_path="t.yaml",
+                payloads=[_fake_payload()],
+                phases=["pre_input"],
+                stub_mode=False,
+                semantic_evaluator=evaluator,
+                baseline_results_dir=Path(tmpdir) / "baseline",
+                results_dir=root / "results",
+                repo_root=root,
+                attack_suite="injection",
+                attack_type="prompt_injection",
+            )
+
+        evaluator.evaluate.assert_called_once()
+        assert rows[0]["tier3_score"] == "3"
+        assert rows[0]["tier3_confidence"] == "high"
+        assert rows[0]["tier3_reasoning"] == "r3"
+
+    @patch(f"{_MODULE}._load_baseline")
+    @patch(f"{_MODULE}._write_result")
+    @patch(f"{_MODULE}.SecurityEventLogger")
+    @patch(f"{_MODULE}.SecurityEventDetector")
+    @patch(f"{_MODULE}.AttackInjector")
+    @patch(f"{_MODULE}.load_mas_from_yaml")
+    def test_tier3_evaluator_error_is_swallowed(
+        self,
+        mock_load,
+        mock_injector_cls,
+        _mock_detector,
+        _mock_logger,
+        mock_write,
+        mock_load_baseline,
+    ):
+        """A failing evaluator leaves tier3 columns empty without aborting the run."""
+        config = _fake_config()
+        mock_load.return_value = config
+
+        mock_injector = MagicMock()
+        mock_injector.__enter__ = MagicMock(return_value=mock_injector)
+        mock_injector.__exit__ = MagicMock(return_value=False)
+        mock_injector.inject_attack.return_value = _fake_attack_result()
+        mock_injector_cls.return_value = mock_injector
+        mock_write.return_value = Path("/fake/out.json")
+        mock_load_baseline.return_value = {"baseline": True}
+
+        evaluator = MagicMock()
+        evaluator.evaluate.side_effect = RuntimeError("judge down")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "t.yaml").write_text("x")
+            rows, _run_dir = _run_config(
+                yaml_path="t.yaml",
+                payloads=[_fake_payload()],
+                phases=["pre_input"],
+                stub_mode=False,
+                semantic_evaluator=evaluator,
+                baseline_results_dir=Path(tmpdir) / "baseline",
+                results_dir=root / "results",
+                repo_root=root,
+                attack_suite="injection",
+                attack_type="prompt_injection",
+            )
+
+        assert rows[0]["tier3_score"] == ""
+        assert rows[0]["tier3_reasoning"] == ""
 
     @patch(f"{_MODULE}._run_config", return_value=([], None))
     def test_no_results_exits_zero(self, _mock_run_config):

--- a/bili/aether/tests/test_communication.py
+++ b/bili/aether/tests/test_communication.py
@@ -14,6 +14,7 @@ Covers:
 import json
 import os
 import tempfile
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -214,6 +215,73 @@ class TestCommunicationLogger:
         finally:
             os.unlink(log_path)
 
+    def test_log_message_opens_file_lazily(self):
+        """log_message opens the file when no handle has been created yet."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False
+        ) as tmp:
+            log_path = tmp.name
+        os.unlink(log_path)
+        try:
+            logger = CommunicationLogger(log_path)
+            assert logger._file_handle is None  # pylint: disable=protected-access
+            logger.log_message(
+                Message(sender="a", receiver="b", channel="c", content="lazy")
+            )
+            assert logger._file_handle is not None  # pylint: disable=protected-access
+            logger.close()
+            with open(log_path, encoding="utf-8") as fh:
+                assert json.loads(fh.readline())["content"] == "lazy"
+        finally:
+            if os.path.exists(log_path):
+                os.unlink(log_path)
+
+    def test_flush_flushes_open_handle(self):
+        """flush forwards to the underlying file handle when one is open."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False
+        ) as tmp:
+            log_path = tmp.name
+        try:
+            logger = CommunicationLogger(log_path)
+            logger.log_message(
+                Message(sender="a", receiver="b", channel="c", content="x")
+            )
+            handle = logger._file_handle  # pylint: disable=protected-access
+            handle.flush = MagicMock()
+            logger.flush()
+            handle.flush.assert_called_once()
+            logger.close()
+        finally:
+            os.unlink(log_path)
+
+    def test_flush_noop_without_open_handle(self):
+        """flush is a no-op when no file handle has been opened."""
+        logger = CommunicationLogger("/nonexistent/never-opened.jsonl")
+        # Should not raise even though no handle exists.
+        logger.flush()
+        assert logger._file_handle is None  # pylint: disable=protected-access
+
+    def test_close_logs_warning_on_oserror(self):
+        """A close failure is caught, logged, and the handle is cleared."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False
+        ) as tmp:
+            log_path = tmp.name
+        try:
+            logger = CommunicationLogger(log_path)
+            logger.log_message(
+                Message(sender="a", receiver="b", channel="c", content="x")
+            )
+            handle = logger._file_handle  # pylint: disable=protected-access
+            handle.flush = MagicMock(side_effect=OSError("disk gone"))
+            with patch("bili.aether.runtime.logger.LOGGER.warning") as mock_warning:
+                logger.close()
+            mock_warning.assert_called_once()
+            assert logger._file_handle is None  # pylint: disable=protected-access
+        finally:
+            os.unlink(log_path)
+
 
 # ======================================================================
 # Channel tests
@@ -374,6 +442,38 @@ class TestChannelManager:
         mgr = ChannelManager()
         with pytest.raises(KeyError, match="Channel 'missing'"):
             mgr.send_message("missing", "a", "content")
+
+    def test_enable_logging_warns_and_writes_jsonl(self):
+        """enable_logging=True warns (deprecated) and persists sent messages to JSONL."""
+        channels = [_make_channel_config("ch1", CommunicationProtocol.DIRECT)]
+        config = _make_simple_mas(channels)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with pytest.warns(DeprecationWarning, match="JSONL logging"):
+                mgr = ChannelManager.initialize_from_config(
+                    config, log_dir=tmp_dir, enable_logging=True
+                )
+            # Sending a message exercises the logger.log_message branch.
+            mgr.send_message("ch1", "agent_a", "logged message")
+            mgr.close()
+
+            jsonl_files = [f for f in os.listdir(tmp_dir) if f.endswith(".jsonl")]
+            assert len(jsonl_files) == 1
+            contents = os.path.join(tmp_dir, jsonl_files[0])
+            with open(contents, encoding="utf-8") as fh:
+                logged = json.loads(fh.readline())
+            assert logged["content"] == "logged message"
+
+    def test_get_channel_returns_registered_channel(self):
+        """get_channel looks up a channel by its registered id."""
+        channels = [_make_channel_config("ch1", CommunicationProtocol.DIRECT)]
+        config = _make_simple_mas(channels)
+        mgr = ChannelManager.initialize_from_config(config)
+        channel = mgr.get_channel("ch1")
+        assert channel is not None
+        with pytest.raises(KeyError):
+            mgr.get_channel("does_not_exist")
+        mgr.close()
 
 
 # ======================================================================

--- a/bili/aether/tests/test_compiler_coverage.py
+++ b/bili/aether/tests/test_compiler_coverage.py
@@ -1,0 +1,2109 @@
+"""Targeted coverage tests for AETHER compiler, integration, schema, and package init.
+
+These tests exercise the error branches, fallback paths, and helper functions
+that the broader functional tests do not reach:
+
+- ``bili.aether.__init__`` lazy-import machinery (PEP 562 ``__getattr__``/``__dir__``)
+- ``compiler.cli`` main entry points (single-file and all-examples modes)
+- ``compiler.llm_resolver`` model creation, tool resolution, fallbacks
+- ``compiler.agent_generator`` content normalisation, middleware, routing, supervisor paths
+- ``compiler.compiled_mas`` checkpointer ImportError fallback
+- ``compiler.graph_builder`` evaluator error branches, consensus voting,
+  custom edges, hierarchical fallback, registry resolution
+- ``integration.checkpointer_factory`` all dispatch branches and fallbacks
+- ``schema.mas_config`` validation error branches and helper methods
+"""
+
+import ast
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import (  # pylint: disable=import-error
+    AIMessage,
+    HumanMessage,
+)
+
+from bili.aether.schema import AgentSpec, MASConfig, WorkflowType
+from bili.aether.schema.enums import CommunicationProtocol
+from bili.aether.schema.mas_config import Channel, WorkflowEdge
+
+
+def _agent(agent_id: str, **kwargs) -> AgentSpec:
+    """Build an AgentSpec with sensible defaults."""
+    defaults = {"role": "test_role", "objective": f"Objective for {agent_id}"}
+    defaults.update(kwargs)
+    return AgentSpec(agent_id=agent_id, **defaults)
+
+
+# =========================================================================
+# bili.aether.__init__ — lazy import machinery
+# =========================================================================
+
+
+class TestPackageLazyImports:
+    """Tests for PEP 562 __getattr__ / __dir__ on bili.aether."""
+
+    def test_lazy_attribute_resolves_to_real_object(self):
+        """Accessing a mapped name imports and returns the real object."""
+        import bili.aether as aether  # pylint: disable=import-outside-toplevel
+
+        # MASConfig maps to the schema submodule
+        resolved = aether.MASConfig
+        assert resolved is MASConfig
+        # After access, the name is cached in module globals
+        assert "MASConfig" in vars(aether)
+
+    def test_lazy_submodule_import(self):
+        """The __getattr__ submodule branch imports and returns the module.
+
+        __getattr__ only fires when normal attribute lookup fails, so we drop
+        any cached value from the module globals first to force the lazy path.
+        """
+        import bili.aether as aether  # pylint: disable=import-outside-toplevel
+
+        vars(aether).pop("schema", None)
+        schema_mod = aether.__getattr__("schema")
+        assert isinstance(schema_mod, types.ModuleType)
+        assert schema_mod.__name__ == "bili.aether.schema"
+        # The resolved module is now cached back into globals.
+        assert vars(aether)["schema"] is schema_mod
+
+    def test_unknown_attribute_raises_attribute_error(self):
+        """Accessing an unmapped name raises AttributeError."""
+        import bili.aether as aether  # pylint: disable=import-outside-toplevel
+
+        with pytest.raises(AttributeError, match="has no attribute 'does_not_exist'"):
+            _ = aether.does_not_exist
+
+    def test_dir_lists_lazy_names_and_dunders(self):
+        """__dir__ includes lazy imports, submodules, and version dunders."""
+        import bili.aether as aether  # pylint: disable=import-outside-toplevel
+
+        names = dir(aether)
+        assert "MASConfig" in names
+        assert "schema" in names
+        assert "__version__" in names
+        assert "__author__" in names
+
+    def test_compile_mas_lazy_import(self):
+        """compile_mas is reachable via the lazy mapping to the compiler."""
+        import bili.aether as aether  # pylint: disable=import-outside-toplevel
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            compile_mas,
+        )
+
+        assert aether.compile_mas is compile_mas
+
+
+# =========================================================================
+# compiler.cli — main()
+# =========================================================================
+
+
+_EXAMPLES_PATH = "bili/aether/config/examples"
+
+
+class TestCompilerCli:
+    """Tests for the compiler CLI entry point."""
+
+    def test_main_single_file(self, capsys):
+        """main() with a file argument compiles that one file and prints OK."""
+        from bili.aether.compiler import cli  # pylint: disable=import-outside-toplevel
+
+        fpath = f"{_EXAMPLES_PATH}/simple_chain.yaml"
+        with patch.object(sys, "argv", ["cli.py", fpath]):
+            cli.main()
+
+        out = capsys.readouterr().out
+        assert f"OK    {fpath}" in out
+        assert "Compiled:" in out
+
+    def test_main_all_examples_success(self, capsys):
+        """main() with no args compiles all known examples and exits 0."""
+        from bili.aether.compiler import cli  # pylint: disable=import-outside-toplevel
+
+        with patch.object(sys, "argv", ["cli.py"]):
+            with pytest.raises(SystemExit) as exc_info:
+                cli.main()
+
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "OK    simple_chain.yaml" in out
+
+    def test_main_skips_missing_file(self, capsys):
+        """main() prints SKIP for a missing example and still exits."""
+        from bili.aether.compiler import cli  # pylint: disable=import-outside-toplevel
+
+        with patch.object(sys, "argv", ["cli.py"]):
+            with patch("os.path.exists", return_value=False):
+                with pytest.raises(SystemExit) as exc_info:
+                    cli.main()
+
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "SKIP" in out
+
+    def test_main_reports_failure(self, capsys):
+        """main() prints FAIL and exits 1 when a compile raises."""
+        from bili.aether.compiler import cli  # pylint: disable=import-outside-toplevel
+
+        # Force load_mas_from_yaml to raise for every example
+        with patch.object(sys, "argv", ["cli.py"]):
+            with patch(
+                "bili.aether.config.loader.load_mas_from_yaml",
+                side_effect=RuntimeError("boom"),
+            ):
+                with pytest.raises(SystemExit) as exc_info:
+                    cli.main()
+
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "FAIL" in out
+
+    def test_ensure_bili_stub_inserts_module_and_path(self):
+        """_ensure_bili_stub installs a bili stub and inserts project_root on sys.path."""
+        # Compute the project_root the same way the function does.
+        import os  # pylint: disable=import-outside-toplevel
+
+        from bili.aether.compiler import cli  # pylint: disable=import-outside-toplevel
+
+        project_root = os.path.dirname(
+            os.path.dirname(
+                os.path.dirname(os.path.dirname(os.path.abspath(cli.__file__)))
+            )
+        )
+
+        saved_mod = sys.modules.get("bili")
+        had_path = project_root in sys.path
+        try:
+            sys.modules.pop("bili", None)
+            if had_path:
+                sys.path.remove(project_root)
+
+            cli._ensure_bili_stub()  # pylint: disable=protected-access
+
+            assert project_root in sys.path
+            assert "bili" in sys.modules
+            assert hasattr(sys.modules["bili"], "__path__")
+        finally:
+            if saved_mod is not None:
+                sys.modules["bili"] = saved_mod
+            if not had_path and project_root in sys.path:
+                sys.path.remove(project_root)
+
+
+# =========================================================================
+# compiler.llm_resolver — create_llm / resolve_tools
+# =========================================================================
+
+
+class TestCreateLlm:
+    """Tests for create_llm()."""
+
+    def test_create_llm_no_model_name_raises(self):
+        """create_llm raises ValueError when the agent has no model_name."""
+        from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+            create_llm,
+        )
+
+        agent = _agent("no_model")
+        with pytest.raises(ValueError, match="has no model_name"):
+            create_llm(agent)
+
+    def test_create_llm_passes_resolved_kwargs(self):
+        """create_llm resolves model_id and forwards temperature/max_tokens."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        agent = _agent("m", model_name="gpt-4o", temperature=0.3, max_tokens=512)
+
+        fake_load_model = MagicMock(return_value="LLM_INSTANCE")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                result = llm_resolver.create_llm(agent)
+
+        assert result == "LLM_INSTANCE"
+        provider_arg = fake_load_model.call_args[0][0]
+        kwargs = fake_load_model.call_args[1]
+        assert provider_arg == "remote_openai"
+        assert kwargs["model_name"] == "gpt-4o"
+        assert kwargs["temperature"] == 0.3
+        assert kwargs["max_tokens"] == 512
+
+    def test_create_llm_extra_kwargs_from_llm_models(self):
+        """Provider-specific kwargs from LLM_MODELS are forwarded, model_id wins."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        mock_models = {
+            "remote_azure_openai": {
+                "models": [
+                    {
+                        "model_name": "Azure GPT",
+                        "model_id": "azure-gpt-4o",
+                        "kwargs": {"api_version": "2024-02-01"},
+                    }
+                ]
+            }
+        }
+        agent = _agent("azure", model_name="Azure GPT")
+
+        fake_load_model = MagicMock(return_value="AZURE_LLM")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", mock_models):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert kwargs["api_version"] == "2024-02-01"
+        assert kwargs["model_name"] == "azure-gpt-4o"
+
+
+class TestResolveProvider:
+    """Tests for resolve_provider() and the LLM_MODELS ImportError path."""
+
+    def test_resolve_provider_returns_provider_only(self):
+        """resolve_provider returns just the provider type string."""
+        from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+            resolve_provider,
+        )
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            assert resolve_provider("gpt-4o") == "remote_openai"
+
+    def test_lookup_import_error_returns_none(self):
+        """_lookup_in_llm_models returns None when llm_config is unimportable."""
+        from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+            _lookup_in_llm_models,
+        )
+
+        with patch.dict(sys.modules, {"bili.iris.config.llm_config": None}):
+            assert _lookup_in_llm_models("anything") is None
+
+
+class TestResolveTools:
+    """Tests for resolve_tools()."""
+
+    def test_resolve_tools_empty_returns_empty(self):
+        """Agent with no tools returns an empty list without importing loaders."""
+        from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+            resolve_tools,
+        )
+
+        assert resolve_tools(_agent("none")) == []
+
+    def test_resolve_tools_import_error_returns_empty(self):
+        """ImportError on the tools loader yields an empty list."""
+        from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+            resolve_tools,
+        )
+
+        agent = _agent("t", tools=["weather_api_tool"])
+        with patch.dict(
+            sys.modules,
+            {
+                "bili.iris.config.tool_config": None,
+                "bili.iris.loaders.tools_loader": None,
+            },
+        ):
+            assert resolve_tools(agent) == []
+
+    def test_resolve_tools_builds_prompts_and_calls_initialize(self):
+        """resolve_tools forwards active tools and default prompts to initialize_tools."""
+        from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+            resolve_tools,
+        )
+
+        agent = _agent("t", tools=["weather_api_tool"])
+
+        fake_tool_config = types.ModuleType("bili.iris.config.tool_config")
+        fake_tool_config.TOOLS = {
+            "weather_api_tool": {"default_prompt": "Get the weather"}
+        }
+        fake_init = MagicMock(return_value=["TOOL_OBJ"])
+        fake_loader = types.ModuleType("bili.iris.loaders.tools_loader")
+        fake_loader.initialize_tools = fake_init
+
+        with patch.dict(
+            sys.modules,
+            {
+                "bili.iris.config.tool_config": fake_tool_config,
+                "bili.iris.loaders.tools_loader": fake_loader,
+            },
+        ):
+            result = resolve_tools(agent)
+
+        assert result == ["TOOL_OBJ"]
+        call_kwargs = fake_init.call_args[1]
+        assert call_kwargs["active_tools"] == ["weather_api_tool"]
+        assert call_kwargs["tool_prompts"] == {"weather_api_tool": "Get the weather"}
+
+    def test_resolve_tools_initialize_failure_returns_empty(self):
+        """A failure inside initialize_tools is swallowed and yields an empty list."""
+        from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+            resolve_tools,
+        )
+
+        agent = _agent("t", tools=["weather_api_tool"])
+
+        fake_tool_config = types.ModuleType("bili.iris.config.tool_config")
+        fake_tool_config.TOOLS = {}
+        fake_loader = types.ModuleType("bili.iris.loaders.tools_loader")
+        fake_loader.initialize_tools = MagicMock(side_effect=RuntimeError("nope"))
+
+        with patch.dict(
+            sys.modules,
+            {
+                "bili.iris.config.tool_config": fake_tool_config,
+                "bili.iris.loaders.tools_loader": fake_loader,
+            },
+        ):
+            assert resolve_tools(agent) == []
+
+
+# =========================================================================
+# compiler.agent_generator — normalisation, middleware, routing, supervisor
+# =========================================================================
+
+
+class TestContentNormalisation:
+    """Tests for _normalise_content_value and _normalise_message_content."""
+
+    def test_normalise_list_of_part_dicts(self):
+        """List of part dicts is joined on the 'text' key."""
+        from bili.aether.compiler.agent_generator import (  # pylint: disable=import-outside-toplevel
+            _normalise_content_value,
+        )
+
+        value = [{"type": "text", "text": "hello"}, {"type": "text", "text": "world"}]
+        assert _normalise_content_value(value) == "hello world"
+
+    def test_normalise_list_with_non_dict_part(self):
+        """Non-dict list parts fall back to str()."""
+        from bili.aether.compiler.agent_generator import (  # pylint: disable=import-outside-toplevel
+            _normalise_content_value,
+        )
+
+        assert _normalise_content_value(["a", 7]) == "a 7"
+
+    def test_normalise_message_with_list_content(self):
+        """A message whose content is a list is rewritten to a string copy."""
+        from bili.aether.compiler.agent_generator import (  # pylint: disable=import-outside-toplevel
+            _normalise_message_content,
+        )
+
+        msg = AIMessage(content=[{"type": "text", "text": "joined"}])
+        normalised = _normalise_message_content(msg)
+        assert normalised.content == "joined"
+
+    def test_normalise_message_with_str_content_unchanged(self):
+        """A message with string content is returned unchanged."""
+        from bili.aether.compiler.agent_generator import (  # pylint: disable=import-outside-toplevel
+            _normalise_message_content,
+        )
+
+        msg = AIMessage(content="plain")
+        assert _normalise_message_content(msg) is msg
+
+
+class TestResolveMiddleware:
+    """Tests for _resolve_middleware()."""
+
+    def test_no_middleware_returns_empty(self):
+        """Agent with no middleware returns an empty list."""
+        from bili.aether.compiler.agent_generator import (  # pylint: disable=import-outside-toplevel
+            _resolve_middleware,
+        )
+
+        assert _resolve_middleware(_agent("a")) == []
+
+    def test_import_error_returns_empty(self):
+        """ImportError on the middleware loader returns an empty list."""
+        from bili.aether.compiler.agent_generator import (  # pylint: disable=import-outside-toplevel
+            _resolve_middleware,
+        )
+
+        agent = _agent("a", middleware=["summarization"])
+        with patch.dict(sys.modules, {"bili.iris.loaders.middleware_loader": None}):
+            assert _resolve_middleware(agent) == []
+
+    def test_resolves_instances(self):
+        """Middleware names resolve to instances via initialize_middleware."""
+        from bili.aether.compiler.agent_generator import (  # pylint: disable=import-outside-toplevel
+            _resolve_middleware,
+        )
+
+        agent = _agent(
+            "a",
+            middleware=["model_call_limit"],
+            middleware_params={"model_call_limit": {"run_limit": 3}},
+        )
+        fake_init = MagicMock(return_value=["MW1"])
+        fake_loader = types.ModuleType("bili.iris.loaders.middleware_loader")
+        fake_loader.initialize_middleware = fake_init
+
+        with patch.dict(
+            sys.modules, {"bili.iris.loaders.middleware_loader": fake_loader}
+        ):
+            result = _resolve_middleware(agent)
+
+        assert result == ["MW1"]
+        call_kwargs = fake_init.call_args[1]
+        assert call_kwargs["active_middleware"] == ["model_call_limit"]
+        assert call_kwargs["middleware_params"] == {
+            "model_call_limit": {"run_limit": 3}
+        }
+
+    def test_initialize_failure_returns_empty(self):
+        """A failure inside initialize_middleware yields an empty list."""
+        from bili.aether.compiler.agent_generator import (  # pylint: disable=import-outside-toplevel
+            _resolve_middleware,
+        )
+
+        agent = _agent("a", middleware=["summarization"])
+        fake_loader = types.ModuleType("bili.iris.loaders.middleware_loader")
+        fake_loader.initialize_middleware = MagicMock(side_effect=RuntimeError("x"))
+
+        with patch.dict(
+            sys.modules, {"bili.iris.loaders.middleware_loader": fake_loader}
+        ):
+            assert _resolve_middleware(agent) == []
+
+
+class TestExtractNextAgent:
+    """Tests for _extract_next_agent routing extraction."""
+
+    def test_json_next_agent(self):
+        """JSON object with next_agent field is parsed."""
+        from bili.aether.compiler.agent_generator import (  # pylint: disable=import-outside-toplevel
+            _extract_next_agent,
+        )
+
+        result = _extract_next_agent('{"next_agent": "worker_2"}', _agent("sup"))
+        assert result == "worker_2"
+
+    def test_text_route_pattern(self):
+        """ROUTE_TO directive is matched when JSON parsing fails."""
+        from bili.aether.compiler.agent_generator import (  # pylint: disable=import-outside-toplevel
+            _extract_next_agent,
+        )
+
+        result = _extract_next_agent("Decision made. ROUTE_TO: worker_1", _agent("sup"))
+        assert result == "worker_1"
+
+    def test_defaults_to_end(self):
+        """No routing decision defaults to END."""
+        from bili.aether.compiler.agent_generator import (  # pylint: disable=import-outside-toplevel
+            _extract_next_agent,
+        )
+
+        assert _extract_next_agent("just some text", _agent("sup")) == "END"
+
+
+class TestDirectLlmNodeBranches:
+    """Tests for the direct (no-tools) LLM node's prompt-assembly branches."""
+
+    def _make_node(self, agent):
+        from bili.aether.compiler.agent_generator import (  # pylint: disable=import-outside-toplevel
+            generate_agent_node,
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = MagicMock(content="resp")
+        with patch(
+            "bili.aether.compiler.llm_resolver.create_llm", return_value=mock_llm
+        ), patch("bili.aether.compiler.llm_resolver.resolve_tools", return_value=[]):
+            node = generate_agent_node(agent)
+        return node, mock_llm
+
+    def test_inserts_human_cue_before_leading_ai_message(self):
+        """A leading AIMessage gets a synthetic HumanMessage inserted before it."""
+        agent = _agent("d", model_name="gpt-4o")
+        node, mock_llm = self._make_node(agent)
+        node({"messages": [AIMessage(content="prior")], "agent_outputs": {}})
+
+        sent = mock_llm.invoke.call_args[0][0]
+        # SystemMessage, then synthetic HumanMessage, then the prior AIMessage
+        assert isinstance(sent[1], HumanMessage)
+        assert "complete your task" in sent[1].content
+
+    def test_supervisor_sets_next_agent(self):
+        """Supervisor agent populates next_agent from the LLM response."""
+        agent = _agent("boss", model_name="gpt-4o", is_supervisor=True)
+        from bili.aether.compiler.agent_generator import (  # pylint: disable=import-outside-toplevel
+            generate_agent_node,
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = MagicMock(content="ROUTE_TO: helper")
+        with patch(
+            "bili.aether.compiler.llm_resolver.create_llm", return_value=mock_llm
+        ), patch("bili.aether.compiler.llm_resolver.resolve_tools", return_value=[]):
+            node = generate_agent_node(agent)
+        result = node({"messages": [], "agent_outputs": {}})
+        assert result["next_agent"] == "helper"
+
+    def test_middleware_without_tools_is_ignored(self):
+        """Direct LLM path warns and ignores middleware when no tools are present."""
+        agent = _agent("mw", model_name="gpt-4o", middleware=["summarization"])
+        from bili.aether.compiler.agent_generator import (  # pylint: disable=import-outside-toplevel
+            generate_agent_node,
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = MagicMock(content="resp")
+        with patch(
+            "bili.aether.compiler.llm_resolver.create_llm", return_value=mock_llm
+        ), patch(
+            "bili.aether.compiler.llm_resolver.resolve_tools", return_value=[]
+        ), patch(
+            "bili.aether.compiler.agent_generator._resolve_middleware",
+            return_value=["MW"],
+        ):
+            node = generate_agent_node(agent)
+        # Direct node still invokes the LLM directly
+        result = node({"messages": [], "agent_outputs": {}})
+        assert result["current_agent"] == "mw"
+        mock_llm.invoke.assert_called_once()
+
+
+class TestToolAgentNodeBranches:
+    """Tests for the tool-enabled node's comm-context and supervisor branches."""
+
+    def _build_tool_node(self, agent, react_return):
+        from bili.aether.compiler.agent_generator import (  # pylint: disable=import-outside-toplevel
+            generate_agent_node,
+        )
+
+        mock_react = MagicMock()
+        mock_react.invoke.return_value = react_return
+        create_agent_fn = MagicMock(return_value=mock_react)
+
+        langchain_stub = types.ModuleType("langchain")
+        agents_stub = types.ModuleType("langchain.agents")
+        agents_stub.create_agent = create_agent_fn
+        langchain_stub.agents = agents_stub
+
+        with patch(
+            "bili.aether.compiler.llm_resolver.create_llm", return_value=MagicMock()
+        ), patch(
+            "bili.aether.compiler.llm_resolver.resolve_tools",
+            return_value=[MagicMock()],
+        ), patch.dict(
+            sys.modules,
+            {"langchain": langchain_stub, "langchain.agents": agents_stub},
+        ):
+            node = generate_agent_node(agent)
+        return node, mock_react
+
+    def test_tool_supervisor_sets_next_agent(self):
+        """Tool-enabled supervisor extracts next_agent from its output."""
+        agent = _agent("sup", model_name="gpt-4o", tools=["x"], is_supervisor=True)
+        react_return = {
+            "messages": [AIMessage(content='{"next_agent": "w1"}', name="sup")]
+        }
+        node, _ = self._build_tool_node(agent, react_return)
+        result = node({"messages": [], "agent_outputs": {}})
+        assert result["next_agent"] == "w1"
+
+    def test_tool_node_appends_communication_context(self):
+        """Pending inter-agent messages are appended to the tool node's system prompt."""
+        agent = _agent("t", model_name="gpt-4o", tools=["x"])
+        react_return = {"messages": [AIMessage(content="done", name="t")]}
+        node, mock_react = self._build_tool_node(agent, react_return)
+
+        state = {
+            "messages": [],
+            "agent_outputs": {},
+            "communication_log": [],
+            "pending_messages": {
+                "__all__": [
+                    {
+                        "sender": "other",
+                        "channel_id": "__agent_output__",
+                        "content": "Prior analysis result.",
+                    }
+                ]
+            },
+        }
+        node(state)
+
+        sent = mock_react.invoke.call_args[0][0]["messages"]
+        system_msg = sent[0]
+        assert "Messages from other agents" in system_msg.content
+        assert "Prior analysis result." in system_msg.content
+
+    def test_tool_node_injects_human_before_leading_ai(self):
+        """Tool node inserts a synthetic HumanMessage before a leading AIMessage."""
+        agent = _agent("t", model_name="gpt-4o", tools=["x"])
+        react_return = {"messages": [AIMessage(content="done", name="t")]}
+        node, mock_react = self._build_tool_node(agent, react_return)
+        node({"messages": [AIMessage(content="prior")], "agent_outputs": {}})
+
+        sent = mock_react.invoke.call_args[0][0]["messages"]
+        # The first non-system message should be the injected HumanMessage
+        [m for m in sent if not isinstance(m, type(sent[0]))]
+        assert any(
+            isinstance(m, HumanMessage) and "complete your task" in m.content
+            for m in sent
+        )
+
+
+# =========================================================================
+# compiler.compiled_mas — checkpointer ImportError fallback
+# =========================================================================
+
+
+class TestCompiledMasCheckpointer:
+    """Tests for CompiledMAS._create_checkpointer fallback."""
+
+    def test_create_checkpointer_import_error_falls_back_to_memory(self):
+        """ImportError on the factory falls back to a langgraph MemorySaver."""
+        from langgraph.checkpoint.memory import (  # pylint: disable=import-outside-toplevel,import-error
+            MemorySaver,
+        )
+
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            compile_mas,
+        )
+
+        config = MASConfig(
+            mas_id="cp",
+            name="Test",
+            workflow_type=WorkflowType.SEQUENTIAL,
+            agents=[_agent("a")],
+            checkpoint_enabled=True,
+        )
+        compiled = compile_mas(config)
+
+        with patch.dict(
+            sys.modules,
+            {"bili.aether.integration.checkpointer_factory": None},
+        ):
+            saver = compiled._create_checkpointer()  # pylint: disable=protected-access
+
+        assert isinstance(saver, MemorySaver)
+
+
+# =========================================================================
+# integration.checkpointer_factory
+# =========================================================================
+
+
+class TestCheckpointerFactory:
+    """Tests for create_checkpointer_from_config dispatch and fallbacks."""
+
+    def test_unknown_type_falls_back_to_memory(self):
+        """Unknown checkpoint type falls back to a memory checkpointer."""
+        from bili.aether.integration.checkpointer_factory import (  # pylint: disable=import-outside-toplevel
+            create_checkpointer_from_config,
+        )
+
+        saver = create_checkpointer_from_config({"type": "redis"})
+        assert saver is not None
+
+    def test_memory_uses_queryable_saver(self):
+        """memory type returns a QueryableMemorySaver when available."""
+        from bili.aether.integration import (  # pylint: disable=import-outside-toplevel
+            checkpointer_factory,
+        )
+
+        fake_saver = MagicMock(name="QueryableMemorySaver")
+        fake_mod = types.ModuleType("bili.iris.checkpointers.memory_checkpointer")
+        fake_mod.QueryableMemorySaver = MagicMock(return_value=fake_saver)
+
+        with patch.dict(
+            sys.modules,
+            {"bili.iris.checkpointers.memory_checkpointer": fake_mod},
+        ):
+            saver = checkpointer_factory.create_checkpointer_from_config(
+                {"type": "memory"}, user_id="u1"
+            )
+
+        assert saver is fake_saver
+        fake_mod.QueryableMemorySaver.assert_called_once_with(user_id="u1")
+
+    def test_memory_import_error_falls_back_to_langgraph(self):
+        """When QueryableMemorySaver is unavailable, a plain MemorySaver is returned."""
+        from langgraph.checkpoint.memory import (  # pylint: disable=import-outside-toplevel,import-error
+            MemorySaver,
+        )
+
+        from bili.aether.integration import (  # pylint: disable=import-outside-toplevel
+            checkpointer_factory,
+        )
+
+        with patch.dict(
+            sys.modules,
+            {"bili.iris.checkpointers.memory_checkpointer": None},
+        ):
+            saver = (
+                checkpointer_factory._create_memory_checkpointer()
+            )  # pylint: disable=protected-access
+
+        assert isinstance(saver, MemorySaver)
+
+    def test_postgres_returns_checkpointer(self):
+        """postgres type forwards keep_last_n and returns the checkpointer."""
+        from bili.aether.integration import (  # pylint: disable=import-outside-toplevel
+            checkpointer_factory,
+        )
+
+        fake_cp = MagicMock(name="pg_cp")
+        fake_mod = types.ModuleType("bili.iris.checkpointers.pg_checkpointer")
+        fake_mod.get_pg_checkpointer = MagicMock(return_value=fake_cp)
+
+        with patch.dict(
+            sys.modules, {"bili.iris.checkpointers.pg_checkpointer": fake_mod}
+        ):
+            saver = checkpointer_factory.create_checkpointer_from_config(
+                {"type": "postgres", "keep_last_n": 9}, user_id="u2"
+            )
+
+        assert saver is fake_cp
+        fake_mod.get_pg_checkpointer.assert_called_once_with(
+            keep_last_n=9, user_id="u2"
+        )
+
+    def test_postgres_none_falls_back_to_memory(self):
+        """postgres returning None falls back to a memory checkpointer."""
+        from bili.aether.integration import (  # pylint: disable=import-outside-toplevel
+            checkpointer_factory,
+        )
+
+        fake_mod = types.ModuleType("bili.iris.checkpointers.pg_checkpointer")
+        fake_mod.get_pg_checkpointer = MagicMock(return_value=None)
+
+        with patch.dict(
+            sys.modules, {"bili.iris.checkpointers.pg_checkpointer": fake_mod}
+        ):
+            saver = checkpointer_factory._create_postgres_checkpointer(  # pylint: disable=protected-access
+                {"type": "postgres"}
+            )
+
+        # Falls back to memory (some saver instance)
+        assert saver is not None
+
+    def test_postgres_import_error_falls_back_to_memory(self):
+        """ImportError on pg_checkpointer falls back to memory."""
+        from bili.aether.integration import (  # pylint: disable=import-outside-toplevel
+            checkpointer_factory,
+        )
+
+        with patch.dict(sys.modules, {"bili.iris.checkpointers.pg_checkpointer": None}):
+            saver = checkpointer_factory._create_postgres_checkpointer(  # pylint: disable=protected-access
+                {"type": "postgres"}
+            )
+        assert saver is not None
+
+    def test_mongo_returns_checkpointer(self):
+        """mongo type forwards keep_last_n and returns the checkpointer."""
+        from bili.aether.integration import (  # pylint: disable=import-outside-toplevel
+            checkpointer_factory,
+        )
+
+        fake_cp = MagicMock(name="mongo_cp")
+        fake_mod = types.ModuleType("bili.iris.checkpointers.mongo_checkpointer")
+        fake_mod.get_mongo_checkpointer = MagicMock(return_value=fake_cp)
+
+        with patch.dict(
+            sys.modules, {"bili.iris.checkpointers.mongo_checkpointer": fake_mod}
+        ):
+            saver = checkpointer_factory.create_checkpointer_from_config(
+                {"type": "mongodb", "keep_last_n": 4}
+            )
+
+        assert saver is fake_cp
+        fake_mod.get_mongo_checkpointer.assert_called_once_with(
+            keep_last_n=4, user_id=None
+        )
+
+    def test_mongo_none_falls_back_to_memory(self):
+        """mongo returning None falls back to memory."""
+        from bili.aether.integration import (  # pylint: disable=import-outside-toplevel
+            checkpointer_factory,
+        )
+
+        fake_mod = types.ModuleType("bili.iris.checkpointers.mongo_checkpointer")
+        fake_mod.get_mongo_checkpointer = MagicMock(return_value=None)
+
+        with patch.dict(
+            sys.modules, {"bili.iris.checkpointers.mongo_checkpointer": fake_mod}
+        ):
+            saver = checkpointer_factory._create_mongo_checkpointer(  # pylint: disable=protected-access
+                {"type": "mongo"}
+            )
+        assert saver is not None
+
+    def test_mongo_import_error_falls_back_to_memory(self):
+        """ImportError on mongo_checkpointer falls back to memory."""
+        from bili.aether.integration import (  # pylint: disable=import-outside-toplevel
+            checkpointer_factory,
+        )
+
+        with patch.dict(
+            sys.modules, {"bili.iris.checkpointers.mongo_checkpointer": None}
+        ):
+            saver = checkpointer_factory._create_mongo_checkpointer(  # pylint: disable=protected-access
+                {"type": "mongo"}
+            )
+        assert saver is not None
+
+    def test_auto_detects_postgres(self, monkeypatch):
+        """auto type uses Postgres when POSTGRES_CONNECTION_STRING is set."""
+        from bili.aether.integration import (  # pylint: disable=import-outside-toplevel
+            checkpointer_factory,
+        )
+
+        monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgresql://x")
+        monkeypatch.delenv("MONGO_CONNECTION_STRING", raising=False)
+        fake_cp = MagicMock(name="auto_pg")
+        fake_mod = types.ModuleType("bili.iris.checkpointers.pg_checkpointer")
+        fake_mod.get_pg_checkpointer = MagicMock(return_value=fake_cp)
+
+        with patch.dict(
+            sys.modules, {"bili.iris.checkpointers.pg_checkpointer": fake_mod}
+        ):
+            saver = checkpointer_factory.create_checkpointer_from_config(
+                {"type": "auto"}
+            )
+        assert saver is fake_cp
+
+    def test_auto_detects_mongo(self, monkeypatch):
+        """auto type uses Mongo when only MONGO_CONNECTION_STRING is set."""
+        from bili.aether.integration import (  # pylint: disable=import-outside-toplevel
+            checkpointer_factory,
+        )
+
+        monkeypatch.delenv("POSTGRES_CONNECTION_STRING", raising=False)
+        monkeypatch.setenv("MONGO_CONNECTION_STRING", "mongodb://x")
+        fake_cp = MagicMock(name="auto_mongo")
+        fake_mod = types.ModuleType("bili.iris.checkpointers.mongo_checkpointer")
+        fake_mod.get_mongo_checkpointer = MagicMock(return_value=fake_cp)
+
+        with patch.dict(
+            sys.modules, {"bili.iris.checkpointers.mongo_checkpointer": fake_mod}
+        ):
+            saver = checkpointer_factory._create_auto_checkpointer(  # pylint: disable=protected-access
+                {"type": "auto"}
+            )
+        assert saver is fake_cp
+
+    def test_auto_falls_back_to_memory(self, monkeypatch):
+        """auto type falls back to QueryableMemorySaver with no DB env vars."""
+        from bili.aether.integration import (  # pylint: disable=import-outside-toplevel
+            checkpointer_factory,
+        )
+
+        monkeypatch.delenv("POSTGRES_CONNECTION_STRING", raising=False)
+        monkeypatch.delenv("MONGO_CONNECTION_STRING", raising=False)
+        fake_saver = MagicMock(name="mem")
+        fake_mod = types.ModuleType("bili.iris.checkpointers.memory_checkpointer")
+        fake_mod.QueryableMemorySaver = MagicMock(return_value=fake_saver)
+
+        with patch.dict(
+            sys.modules,
+            {"bili.iris.checkpointers.memory_checkpointer": fake_mod},
+        ):
+            saver = checkpointer_factory._create_auto_checkpointer(  # pylint: disable=protected-access
+                {"type": "auto"}, user_id="u3"
+            )
+        assert saver is fake_saver
+
+    def test_auto_import_error_falls_back_to_memory(self, monkeypatch):
+        """An ImportError during auto-detection falls back to memory."""
+        from bili.aether.integration import (  # pylint: disable=import-outside-toplevel
+            checkpointer_factory,
+        )
+
+        monkeypatch.setenv("POSTGRES_CONNECTION_STRING", "postgresql://x")
+        with patch.dict(sys.modules, {"bili.iris.checkpointers.pg_checkpointer": None}):
+            saver = checkpointer_factory._create_auto_checkpointer(  # pylint: disable=protected-access
+                {"type": "auto"}
+            )
+        assert saver is not None
+
+
+# =========================================================================
+# schema.mas_config — validation error branches and helpers
+# =========================================================================
+
+
+class TestMasConfigValidation:
+    """Tests for MASConfig validators and helper methods."""
+
+    def test_duplicate_agent_ids_raise(self):
+        """Duplicate agent IDs raise a ValueError naming the duplicate."""
+        with pytest.raises(ValueError, match="Duplicate agent IDs"):
+            MASConfig(
+                mas_id="dup",
+                name="Test",
+                workflow_type=WorkflowType.SEQUENTIAL,
+                agents=[_agent("a"), _agent("a")],
+            )
+
+    def test_entry_point_not_found_raises(self):
+        """An entry_point that does not match any agent raises ValueError."""
+        with pytest.raises(ValueError, match="entry_point 'ghost' not found"):
+            MASConfig(
+                mas_id="ep",
+                name="Test",
+                workflow_type=WorkflowType.SEQUENTIAL,
+                agents=[_agent("a")],
+                entry_point="ghost",
+            )
+
+    def test_channel_source_not_found_raises(self):
+        """A channel source that is not an agent (and not 'any') raises."""
+        with pytest.raises(ValueError, match="source 'missing' not found"):
+            MASConfig(
+                mas_id="ch",
+                name="Test",
+                workflow_type=WorkflowType.SEQUENTIAL,
+                agents=[_agent("a")],
+                channels=[
+                    Channel(
+                        channel_id="c1",
+                        protocol=CommunicationProtocol.DIRECT,
+                        source="missing",
+                        target="a",
+                    )
+                ],
+            )
+
+    def test_channel_target_not_found_raises(self):
+        """A channel target that is not an agent (and not 'all') raises."""
+        with pytest.raises(ValueError, match="target 'missing' not found"):
+            MASConfig(
+                mas_id="ch2",
+                name="Test",
+                workflow_type=WorkflowType.SEQUENTIAL,
+                agents=[_agent("a")],
+                channels=[
+                    Channel(
+                        channel_id="c2",
+                        protocol=CommunicationProtocol.DIRECT,
+                        source="a",
+                        target="missing",
+                    )
+                ],
+            )
+
+    def test_workflow_edge_from_agent_not_found_raises(self):
+        """A workflow edge from_agent that is unknown raises."""
+        with pytest.raises(ValueError, match="from_agent 'ghost' not found"):
+            MASConfig(
+                mas_id="we",
+                name="Test",
+                workflow_type=WorkflowType.CUSTOM,
+                agents=[_agent("a")],
+                workflow_edges=[WorkflowEdge(from_agent="ghost", to_agent="a")],
+            )
+
+    def test_workflow_edge_to_agent_not_found_raises(self):
+        """A workflow edge to_agent that is unknown raises."""
+        with pytest.raises(ValueError, match="to_agent 'ghost' not found"):
+            MASConfig(
+                mas_id="we2",
+                name="Test",
+                workflow_type=WorkflowType.CUSTOM,
+                agents=[_agent("a")],
+                workflow_edges=[WorkflowEdge(from_agent="a", to_agent="ghost")],
+            )
+
+    def test_consensus_requires_threshold(self):
+        """Consensus workflow without a threshold raises."""
+        with pytest.raises(ValueError, match="requires consensus_threshold"):
+            MASConfig(
+                mas_id="cn",
+                name="Test",
+                workflow_type=WorkflowType.CONSENSUS,
+                consensus_threshold=None,
+                agents=[_agent("a"), _agent("b")],
+            )
+
+    def test_invalid_consensus_detection_raises(self):
+        """An unsupported consensus_detection value raises."""
+        with pytest.raises(ValueError, match="Invalid consensus_detection"):
+            MASConfig(
+                mas_id="cd",
+                name="Test",
+                workflow_type=WorkflowType.CONSENSUS,
+                consensus_threshold=0.5,
+                consensus_detection="telepathy",
+                agents=[_agent("a"), _agent("b")],
+            )
+
+    def test_hierarchical_without_tiers_raises(self):
+        """Hierarchical workflow with no tier values raises."""
+        with pytest.raises(ValueError, match="requires agents to have tier"):
+            MASConfig(
+                mas_id="hr",
+                name="Test",
+                workflow_type=WorkflowType.HIERARCHICAL,
+                agents=[_agent("a"), _agent("b")],
+            )
+
+    def test_get_agent_returns_none_for_missing(self):
+        """get_agent returns None when the ID is not present."""
+        config = MASConfig(
+            mas_id="ga",
+            name="Test",
+            workflow_type=WorkflowType.SEQUENTIAL,
+            agents=[_agent("a")],
+        )
+        assert config.get_agent("nope") is None
+
+    def test_get_entry_agent_missing_raises(self):
+        """get_entry_agent raises when the resolved entry ID is absent."""
+        config = MASConfig(
+            mas_id="ea",
+            name="Test",
+            workflow_type=WorkflowType.SEQUENTIAL,
+            agents=[_agent("a")],
+        )
+        # Force an entry_point that bypasses construction-time validation
+        object.__setattr__(config, "entry_point", "ghost")
+        with pytest.raises(ValueError, match="Entry agent 'ghost' not found"):
+            config.get_entry_agent()
+
+    def test_str_includes_id_count_and_workflow(self):
+        """__str__ reports mas_id, agent count, and workflow type."""
+        config = MASConfig(
+            mas_id="strcfg",
+            name="Test",
+            workflow_type=WorkflowType.SEQUENTIAL,
+            agents=[_agent("a"), _agent("b")],
+        )
+        text = str(config)
+        assert "strcfg" in text
+        assert "2 agents" in text
+        assert "sequential" in text
+
+
+# =========================================================================
+# compiler.graph_builder — evaluator error branches
+# =========================================================================
+
+
+class TestSafeConditionEvaluatorErrors:
+    """Tests for unsupported-operator error branches in SafeConditionEvaluator."""
+
+    def test_unsupported_comparison_operator(self):
+        """An 'is' comparison (not in the supported map) raises ValueError."""
+        from bili.aether.compiler.graph_builder import (  # pylint: disable=import-outside-toplevel
+            SafeConditionEvaluator,
+        )
+
+        evaluator = SafeConditionEvaluator({"x": None})
+        with pytest.raises(ValueError, match="Invalid condition"):
+            evaluator.eval("x is None")
+
+    def test_unsupported_comparison_visit_message(self):
+        """visit_Compare raises a descriptive error for an unmapped operator."""
+        from bili.aether.compiler.graph_builder import (  # pylint: disable=import-outside-toplevel
+            SafeConditionEvaluator,
+        )
+
+        node = ast.parse("x is None", mode="eval").body
+        evaluator = SafeConditionEvaluator({"x": None})
+        with pytest.raises(ValueError, match="Unsupported comparison operator"):
+            evaluator.visit_Compare(node)
+
+    def test_unsupported_bool_operator(self):
+        """visit_BoolOp raises for an operator missing from the bool map."""
+        from bili.aether.compiler.graph_builder import (  # pylint: disable=import-outside-toplevel
+            SafeConditionEvaluator,
+        )
+
+        node = ast.parse("a and b", mode="eval").body
+        # Replace the op with one not present in _BOOL_OPS.
+        node.op = ast.BitAnd()
+        evaluator = SafeConditionEvaluator({"a": True, "b": True})
+        with pytest.raises(ValueError, match="Unsupported boolean operator"):
+            evaluator.visit_BoolOp(node)
+
+    def test_unsupported_unary_operator(self):
+        """A bitwise-not unary op (not mapped) raises ValueError."""
+        from bili.aether.compiler.graph_builder import (  # pylint: disable=import-outside-toplevel
+            SafeConditionEvaluator,
+        )
+
+        evaluator = SafeConditionEvaluator({"x": 1})
+        with pytest.raises(ValueError, match="Invalid condition"):
+            evaluator.eval("~x")
+
+    def test_unsupported_binary_operator(self):
+        """A matrix-multiply binary op (not mapped) raises ValueError."""
+        from bili.aether.compiler.graph_builder import (  # pylint: disable=import-outside-toplevel
+            SafeConditionEvaluator,
+        )
+
+        evaluator = SafeConditionEvaluator({"x": 1, "y": 2})
+        with pytest.raises(ValueError, match="Invalid condition"):
+            evaluator.eval("x @ y")
+
+
+# =========================================================================
+# compiler.graph_builder — MAS objective node body
+# =========================================================================
+
+
+def _build(config, **kwargs):
+    """Build a CompiledMAS via GraphBuilder."""
+    from bili.aether.compiler.graph_builder import (  # pylint: disable=import-outside-toplevel
+        GraphBuilder,
+    )
+
+    return GraphBuilder(config, **kwargs).build()
+
+
+class TestMasObjectiveNodeBody:
+    """Tests for the __mas_objective__ injection node behaviour."""
+
+    def _objective_node(self, config):
+        from langgraph.graph import (  # pylint: disable=import-outside-toplevel,import-error
+            StateGraph,
+        )
+
+        captured = {}
+
+        original_add_node = StateGraph.add_node
+
+        def capture_add_node(self_graph, name, fn, *a, **k):
+            if name == "__mas_objective__":
+                captured["fn"] = fn
+            return original_add_node(self_graph, name, fn, *a, **k)
+
+        with patch.object(StateGraph, "add_node", capture_add_node):
+            _build(config)
+        return captured["fn"]
+
+    def test_objective_node_injects_system_message(self):
+        """The objective node prepends a SystemMessage on a fresh state."""
+        from langchain_core.messages import (  # pylint: disable=import-outside-toplevel,import-error
+            SystemMessage,
+        )
+
+        config = MASConfig(
+            mas_id="obj",
+            name="Test",
+            workflow_type=WorkflowType.SEQUENTIAL,
+            agents=[_agent("a")],
+            objective="Be helpful and concise.",
+        )
+        node_fn = self._objective_node(config)
+        result = node_fn({"messages": []})
+        assert isinstance(result["messages"][0], SystemMessage)
+        assert result["messages"][0].content == "Be helpful and concise."
+
+    def test_objective_node_is_idempotent(self):
+        """The objective node is a no-op when its SystemMessage is already first."""
+        from langchain_core.messages import (  # pylint: disable=import-outside-toplevel,import-error
+            SystemMessage,
+        )
+
+        config = MASConfig(
+            mas_id="obj2",
+            name="Test",
+            workflow_type=WorkflowType.SEQUENTIAL,
+            agents=[_agent("a")],
+            objective="Stay on task.",
+        )
+        node_fn = self._objective_node(config)
+        existing = {"messages": [SystemMessage(content="Stay on task.")]}
+        assert node_fn(existing) == {}
+
+
+# =========================================================================
+# compiler.graph_builder — inheritance ImportError branch
+# =========================================================================
+
+
+def test_apply_inheritance_import_error_is_graceful():
+    """Inheritance with the integration package unavailable is a no-op."""
+    config = MASConfig(
+        mas_id="inh",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_agent("a", inherit_from_bili_core=True)],
+    )
+    with patch.dict(sys.modules, {"bili.aether.integration": None}):
+        compiled = _build(config)
+    # Build still succeeds; the agent is present.
+    assert "a" in compiled.agent_nodes
+
+
+# =========================================================================
+# compiler.graph_builder — registry node resolution branches
+# =========================================================================
+
+
+class TestRegistryNodeBranches:
+    """Tests for _resolve_registry_node import and build error branches."""
+
+    def _pipeline_with_registry_node(self, node_type="custom_reg"):
+        from bili.aether.schema.pipeline_spec import (  # pylint: disable=import-outside-toplevel
+            PipelineEdgeSpec,
+            PipelineNodeSpec,
+            PipelineSpec,
+        )
+
+        return PipelineSpec(
+            nodes=[PipelineNodeSpec(node_id="n", node_type=node_type)],
+            edges=[PipelineEdgeSpec(from_node="n", to_node="END")],
+        )
+
+    def test_registry_import_error_raises_value_error(self):
+        """Unknown registry type with langchain_loader unavailable raises ValueError."""
+        agent = _agent("p", pipeline=self._pipeline_with_registry_node())
+        config = MASConfig(
+            mas_id="reg",
+            name="Test",
+            workflow_type=WorkflowType.SEQUENTIAL,
+            agents=[agent],
+        )
+        with patch.dict(sys.modules, {"bili.iris.loaders.langchain_loader": None}):
+            with pytest.raises(ValueError, match="is not available"):
+                _build(config)
+
+    def test_unknown_type_error_message_handles_second_import_failure(self):
+        """The unknown-type error message tolerates the registry import failing.
+
+        The first registry import yields a registry that lacks the requested
+        type, then the error-message builder re-imports the registry to list
+        available types. This exercises the ImportError guard on that second
+        import (graph_builder lines 534-535) where the module disappears.
+        """
+        from bili.aether.compiler.graph_builder import (  # pylint: disable=import-outside-toplevel
+            GraphBuilder,
+        )
+
+        config = MASConfig(
+            mas_id="reg_msg",
+            name="Test",
+            workflow_type=WorkflowType.SEQUENTIAL,
+            agents=[_agent("a")],
+        )
+        builder = GraphBuilder(config, custom_node_registry={"other": lambda: None})
+
+        node_spec = MagicMock()
+        node_spec.node_id = "n"
+        node_spec.node_type = "ghost_type"
+
+        # A module that supplies an empty registry on the first import and then
+        # raises ImportError on the second access (the error-message path).
+        class _FlakyLoader(types.ModuleType):
+            def __init__(self):
+                super().__init__("bili.iris.loaders.langchain_loader")
+                self._calls = 0
+
+            def __getattr__(self, name):
+                if name == "GRAPH_NODE_REGISTRY":
+                    self._calls += 1
+                    if self._calls == 1:
+                        return {}
+                    raise ImportError("registry vanished")
+                raise AttributeError(name)
+
+        flaky = _FlakyLoader()
+        with patch.dict(sys.modules, {"bili.iris.loaders.langchain_loader": flaky}):
+            with pytest.raises(ValueError, match="unknown registry type 'ghost_type'"):
+                builder._resolve_registry_node(  # pylint: disable=protected-access
+                    node_spec, _agent("a")
+                )
+
+    def test_custom_registry_node_factory_is_node_instance(self):
+        """A registry factory that is already a Node instance is used directly."""
+        from bili.iris.graph_builder.classes.node import (  # pylint: disable=import-outside-toplevel
+            Node,
+        )
+
+        def builder(**_kwargs):
+            return lambda state: {
+                "messages": [],
+                "current_agent": "n",
+                "agent_outputs": {},
+            }
+
+        node_instance = Node("custom_reg", builder)
+
+        agent = _agent("p", pipeline=self._pipeline_with_registry_node())
+        config = MASConfig(
+            mas_id="reg2",
+            name="Test",
+            workflow_type=WorkflowType.SEQUENTIAL,
+            agents=[agent],
+        )
+        compiled = _build(config, custom_node_registry={"custom_reg": node_instance})
+        assert "p" in compiled.agent_nodes
+
+    def test_registry_node_build_failure_raises_value_error(self):
+        """A builder that raises is wrapped in a ValueError naming the node."""
+        from bili.iris.graph_builder.classes.node import (  # pylint: disable=import-outside-toplevel
+            Node,
+        )
+
+        def failing_builder(**_kwargs):
+            raise RuntimeError("builder blew up")
+
+        factory = lambda: Node("custom_reg", failing_builder)
+
+        agent = _agent("p", pipeline=self._pipeline_with_registry_node())
+        config = MASConfig(
+            mas_id="reg3",
+            name="Test",
+            workflow_type=WorkflowType.SEQUENTIAL,
+            agents=[agent],
+        )
+        with pytest.raises(ValueError, match="Failed to build pipeline node"):
+            _build(config, custom_node_registry={"custom_reg": factory})
+
+
+def test_build_registry_node_kwargs_resolves_llm_and_tools():
+    """_build_registry_node_kwargs resolves the parent LLM and tools."""
+    from bili.aether.compiler.graph_builder import (  # pylint: disable=import-outside-toplevel
+        GraphBuilder,
+    )
+    from bili.aether.schema.pipeline_spec import (  # pylint: disable=import-outside-toplevel
+        PipelineNodeSpec,
+    )
+
+    agent = _agent("p", model_name="gpt-4o", tools=["weather_api_tool"])
+    config = MASConfig(
+        mas_id="kw",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[agent],
+    )
+    builder = GraphBuilder(config)
+    node_spec = PipelineNodeSpec(node_id="n", node_type="react_agent")
+
+    with patch(
+        "bili.aether.compiler.llm_resolver.create_llm", return_value="LLM"
+    ), patch("bili.aether.compiler.llm_resolver.resolve_tools", return_value=["TOOL"]):
+        kwargs = (
+            builder._build_registry_node_kwargs(  # pylint: disable=protected-access
+                agent, node_spec
+            )
+        )
+
+    assert kwargs["llm_model"] == "LLM"
+    assert kwargs["tools"] == ["TOOL"]
+
+
+def test_build_registry_node_kwargs_llm_failure_is_logged():
+    """A failure resolving the parent LLM does not propagate out of kwargs build."""
+    from bili.aether.compiler.graph_builder import (  # pylint: disable=import-outside-toplevel
+        GraphBuilder,
+    )
+    from bili.aether.schema.pipeline_spec import (  # pylint: disable=import-outside-toplevel
+        PipelineNodeSpec,
+    )
+
+    agent = _agent("p", model_name="gpt-4o")
+    config = MASConfig(
+        mas_id="kw2",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[agent],
+    )
+    builder = GraphBuilder(config)
+    node_spec = PipelineNodeSpec(node_id="n", node_type="react_agent")
+
+    with patch(
+        "bili.aether.compiler.llm_resolver.create_llm",
+        side_effect=RuntimeError("resolve failed"),
+    ):
+        kwargs = (
+            builder._build_registry_node_kwargs(  # pylint: disable=protected-access
+                agent, node_spec
+            )
+        )
+
+    # No llm_model key because resolution failed, but build did not raise.
+    assert "llm_model" not in kwargs
+
+
+# =========================================================================
+# compiler.graph_builder — pipeline conditional router execution
+# =========================================================================
+
+
+def test_pipeline_conditional_router_executes_branches():
+    """The pipeline conditional router picks branches by condition at runtime."""
+    from bili.aether.schema.pipeline_spec import (  # pylint: disable=import-outside-toplevel
+        PipelineEdgeSpec,
+        PipelineNodeSpec,
+        PipelineSpec,
+        PipelineStateField,
+    )
+
+    pipeline = PipelineSpec(
+        nodes=[
+            PipelineNodeSpec(
+                node_id="check",
+                node_type="agent",
+                agent_spec={
+                    "agent_id": "checker",
+                    "role": "checker",
+                    "objective": "Decide which branch to take next",
+                },
+            ),
+            PipelineNodeSpec(
+                node_id="high",
+                node_type="agent",
+                agent_spec={
+                    "agent_id": "high_h",
+                    "role": "high",
+                    "objective": "Handle the high-score branch path",
+                },
+            ),
+            PipelineNodeSpec(
+                node_id="low",
+                node_type="agent",
+                agent_spec={
+                    "agent_id": "low_h",
+                    "role": "low",
+                    "objective": "Handle the low-score branch path",
+                },
+            ),
+        ],
+        edges=[
+            PipelineEdgeSpec(
+                from_node="check",
+                to_node="high",
+                condition="state.score > 0.5",
+                label="hi",
+            ),
+            PipelineEdgeSpec(from_node="check", to_node="low", label="lo"),
+            PipelineEdgeSpec(from_node="high", to_node="END"),
+            PipelineEdgeSpec(from_node="low", to_node="END"),
+        ],
+        state_fields=[
+            PipelineStateField(
+                name="score", type="float", default=0.0, reducer="replace"
+            )
+        ],
+    )
+    agent = _agent("p", pipeline=pipeline)
+    config = MASConfig(
+        mas_id="cond",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[agent],
+    )
+    compiled = _build(config)
+    graph = compiled.graph.compile(checkpointer=None)
+
+    # Custom state field carries the routing value into the inner pipeline.
+    result = graph.invoke(
+        {"messages": [], "agent_outputs": {}, "mas_id": "cond", "score": 0.9}
+    )
+    inner = result["agent_outputs"]["p"]["pipeline_outputs"]
+    # High branch should have run, low branch should not.
+    assert "high_h" in inner
+    assert "low_h" not in inner
+
+
+def _capture_pipeline_router(builder, from_node, conditional, unconditional, end="END"):
+    """Build pipeline conditional edges and capture the router callable."""
+    captured = {}
+
+    class _FakeGraph:
+        def add_conditional_edges(self, src, router, path_map):
+            captured["router"] = router
+            captured["path_map"] = path_map
+
+    builder._add_pipeline_conditional_edges(  # pylint: disable=protected-access
+        _FakeGraph(), from_node, conditional, unconditional, end
+    )
+    return captured["router"]
+
+
+class TestPipelineConditionalRouterRuntime:
+    """Tests for the runtime router built by _add_pipeline_conditional_edges."""
+
+    def _builder(self):
+        from bili.aether.compiler.graph_builder import (  # pylint: disable=import-outside-toplevel
+            GraphBuilder,
+        )
+
+        config = MASConfig(
+            mas_id="pcr",
+            name="Test",
+            workflow_type=WorkflowType.SEQUENTIAL,
+            agents=[_agent("a")],
+        )
+        return GraphBuilder(config)
+
+    def test_condition_failure_falls_back_to_unconditional(self):
+        """A failing condition logs a warning and falls back to the unconditional edge."""
+        from bili.aether.schema.pipeline_spec import (  # pylint: disable=import-outside-toplevel
+            PipelineEdgeSpec,
+        )
+
+        cond = PipelineEdgeSpec(
+            from_node="x", to_node="a", condition="state.missing == 1", label="ca"
+        )
+        uncond = PipelineEdgeSpec(from_node="x", to_node="b", label="cb")
+        router = _capture_pipeline_router(self._builder(), "x", [cond], [uncond])
+        # Missing field raises ValueError inside the router; it falls back to "cb".
+        assert router({"present": 1}) == "cb"
+
+    def test_all_conditional_uses_last_edge_fallback(self):
+        """When every edge is conditional and none match, the last edge is used."""
+        from bili.aether.schema.pipeline_spec import (  # pylint: disable=import-outside-toplevel
+            PipelineEdgeSpec,
+        )
+
+        c1 = PipelineEdgeSpec(
+            from_node="x", to_node="a", condition="state.flag == 1", label="ca"
+        )
+        c2 = PipelineEdgeSpec(
+            from_node="x", to_node="b", condition="state.flag == 2", label="cb"
+        )
+        router = _capture_pipeline_router(self._builder(), "x", [c1, c2], [])
+        # Neither condition matches, so the last edge's label is returned.
+        assert router({"flag": 9}) == "cb"
+
+
+def test_pipeline_carries_custom_state_default():
+    """Custom state fields absent from outer state fall back to their default."""
+    from bili.aether.schema.pipeline_spec import (  # pylint: disable=import-outside-toplevel
+        PipelineEdgeSpec,
+        PipelineNodeSpec,
+        PipelineSpec,
+        PipelineStateField,
+    )
+
+    pipeline = PipelineSpec(
+        nodes=[
+            PipelineNodeSpec(
+                node_id="only",
+                node_type="agent",
+                agent_spec={
+                    "agent_id": "solo",
+                    "role": "proc",
+                    "objective": "Single processing step in the pipeline",
+                },
+            ),
+        ],
+        edges=[PipelineEdgeSpec(from_node="only", to_node="END")],
+        state_fields=[
+            PipelineStateField(name="counter", type="int", default=7, reducer="replace")
+        ],
+    )
+    agent = _agent("p", pipeline=pipeline)
+    config = MASConfig(
+        mas_id="def",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[agent],
+    )
+    compiled = _build(config)
+    node_fn = compiled.agent_nodes["p"]
+
+    captured = {}
+    real_invoke = None
+
+    # Wrap the inner subgraph invoke to capture the inner state it receives.
+    from bili.aether.compiler.graph_builder import (  # pylint: disable=import-outside-toplevel
+        GraphBuilder,
+    )
+
+    builder = GraphBuilder(config)
+    # Rebuild and patch the wrapper directly for inspection.
+    mock_subgraph = MagicMock()
+    mock_subgraph.invoke.return_value = {
+        "messages": [],
+        "current_agent": "solo",
+        "agent_outputs": {},
+    }
+    wrapper = builder._wrap_pipeline_as_agent_node(  # pylint: disable=protected-access
+        mock_subgraph, agent
+    )
+    # Outer state does NOT include "counter"; default should be injected.
+    wrapper({"messages": [], "agent_outputs": {}})
+    inner_state = mock_subgraph.invoke.call_args[0][0]
+    assert inner_state["counter"] == 7
+    assert node_fn is not None
+    assert real_invoke is None
+    assert captured == {}
+
+
+# =========================================================================
+# compiler.graph_builder — workflow edge / hierarchical / supervisor branches
+# =========================================================================
+
+
+def test_sequential_uses_explicit_edges_when_present():
+    """A sequential workflow with workflow_edges routes through them."""
+    config = MASConfig(
+        mas_id="seq_edges",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_agent("a"), _agent("b")],
+        workflow_edges=[WorkflowEdge(from_agent="a", to_agent="b")],
+    )
+    compiled = _build(config)
+    # _build_from_explicit_edges appends an END edge since none was declared.
+    graph = compiled.graph.compile(checkpointer=None)
+    result = graph.invoke({"messages": [], "agent_outputs": {}, "mas_id": "x"})
+    assert "a" in result["agent_outputs"]
+    assert "b" in result["agent_outputs"]
+
+
+def test_explicit_edges_with_end_skip_synthetic_end():
+    """When an explicit END edge exists, no synthetic END edge is appended."""
+    config = MASConfig(
+        mas_id="seq_edges_end",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_agent("a"), _agent("b")],
+        workflow_edges=[
+            WorkflowEdge(from_agent="a", to_agent="b"),
+            WorkflowEdge(from_agent="b", to_agent="END"),
+        ],
+    )
+    compiled = _build(config)
+    graph = compiled.graph.compile(checkpointer=None)
+    result = graph.invoke({"messages": [], "agent_outputs": {}, "mas_id": "x"})
+    assert "b" in result["agent_outputs"]
+
+
+def test_hierarchical_without_tiers_falls_back_to_sequential():
+    """A hierarchical config whose agents lack tiers falls back to sequential."""
+    config = MASConfig(
+        mas_id="hier_fb",
+        name="Test",
+        workflow_type=WorkflowType.HIERARCHICAL,
+        hierarchical_voting=True,
+        agents=[_agent("a", tier=1)],
+    )
+    # Drop the tier so _build_hierarchical sees no tiers and uses sequential.
+    object.__setattr__(config.agents[0], "tier", None)
+    compiled = _build(config)
+    graph = compiled.graph.compile(checkpointer=None)
+    result = graph.invoke({"messages": [], "agent_outputs": {}, "mas_id": "x"})
+    assert "a" in result["agent_outputs"]
+
+
+def test_supervisor_router_unknown_next_agent_routes_to_end():
+    """The supervisor router returns END for an unrecognised next_agent."""
+    from langgraph.graph import (  # pylint: disable=import-outside-toplevel,import-error
+        StateGraph,
+    )
+
+    from bili.aether.compiler.graph_builder import (  # pylint: disable=import-outside-toplevel
+        GraphBuilder,
+    )
+
+    config = MASConfig(
+        mas_id="sup_router",
+        name="Test",
+        workflow_type=WorkflowType.SUPERVISOR,
+        entry_point="boss",
+        agents=[_agent("boss", is_supervisor=True), _agent("w1")],
+    )
+
+    captured = {}
+    original = StateGraph.add_conditional_edges
+
+    def capture(self_graph, source, router, path_map, *a, **k):
+        if source == "boss":
+            captured["router"] = router
+        return original(self_graph, source, router, path_map, *a, **k)
+
+    with patch.object(StateGraph, "add_conditional_edges", capture):
+        GraphBuilder(config).build()
+
+    router = captured["router"]
+    assert router({"next_agent": "ghost"}) == "END"
+    assert router({"next_agent": "w1"}) == "w1"
+
+
+# =========================================================================
+# compiler.graph_builder — custom edges: START skip, conditional router, fan-out
+# =========================================================================
+
+
+def test_custom_skips_explicit_start_edge():
+    """An explicit from_agent='START' edge is skipped to avoid the sentinel mismatch."""
+    config = MASConfig(
+        mas_id="custom_start",
+        name="Test",
+        workflow_type=WorkflowType.CUSTOM,
+        entry_point="a",
+        agents=[_agent("a"), _agent("b")],
+        workflow_edges=[
+            WorkflowEdge(from_agent="START", to_agent="a"),
+            WorkflowEdge(from_agent="a", to_agent="b"),
+            WorkflowEdge(from_agent="b", to_agent="END"),
+        ],
+    )
+    compiled = _build(config)
+    graph = compiled.graph.compile(checkpointer=None)
+    result = graph.invoke({"messages": [], "agent_outputs": {}, "mas_id": "x"})
+    assert "a" in result["agent_outputs"]
+    assert "b" in result["agent_outputs"]
+
+
+def test_custom_conditional_router_runtime_branches():
+    """The custom conditional router selects branches and falls back correctly."""
+    config = MASConfig(
+        mas_id="custom_cond",
+        name="Test",
+        workflow_type=WorkflowType.CUSTOM,
+        agents=[_agent("a"), _agent("b"), _agent("c")],
+        workflow_edges=[
+            WorkflowEdge(
+                from_agent="a",
+                to_agent="b",
+                condition="state.current_agent == 'a'",
+                label="to_b",
+            ),
+            WorkflowEdge(from_agent="a", to_agent="c", label="to_c"),
+            WorkflowEdge(from_agent="b", to_agent="END"),
+            WorkflowEdge(from_agent="c", to_agent="END"),
+        ],
+    )
+    compiled = _build(config)
+    graph = compiled.graph.compile(checkpointer=None)
+    result = graph.invoke({"messages": [], "agent_outputs": {}, "mas_id": "x"})
+    # Condition is true after 'a' runs, so 'b' executes (not 'c').
+    assert "b" in result["agent_outputs"]
+    assert "c" not in result["agent_outputs"]
+
+
+def test_custom_conditional_router_handles_eval_failure():
+    """A condition that references a missing field logs a warning and falls back."""
+    from langgraph.graph import (  # pylint: disable=import-outside-toplevel,import-error
+        StateGraph,
+    )
+
+    from bili.aether.compiler.graph_builder import (  # pylint: disable=import-outside-toplevel
+        GraphBuilder,
+    )
+
+    config = MASConfig(
+        mas_id="custom_fail",
+        name="Test",
+        workflow_type=WorkflowType.CUSTOM,
+        agents=[_agent("a"), _agent("b"), _agent("c")],
+        workflow_edges=[
+            WorkflowEdge(
+                from_agent="a",
+                to_agent="b",
+                condition="state.nonexistent == 1",
+                label="cond_b",
+            ),
+            WorkflowEdge(from_agent="a", to_agent="c", label="fallback_c"),
+            WorkflowEdge(from_agent="b", to_agent="END"),
+            WorkflowEdge(from_agent="c", to_agent="END"),
+        ],
+    )
+
+    captured = {}
+    original = StateGraph.add_conditional_edges
+
+    def capture(self_graph, source, router, path_map, *a, **k):
+        if source == "a":
+            captured["router"] = router
+        return original(self_graph, source, router, path_map, *a, **k)
+
+    with patch.object(StateGraph, "add_conditional_edges", capture):
+        GraphBuilder(config).build()
+
+    router = captured["router"]
+    # Condition eval fails (missing field) so it falls back to the unconditional edge.
+    assert router({"current_agent": "a"}) == "fallback_c"
+
+
+def test_custom_conditional_router_all_conditional_last_edge_fallback():
+    """When all custom edges are conditional and none match, the last edge wins."""
+    from langgraph.graph import (  # pylint: disable=import-outside-toplevel,import-error
+        StateGraph,
+    )
+
+    from bili.aether.compiler.graph_builder import (  # pylint: disable=import-outside-toplevel
+        GraphBuilder,
+    )
+
+    config = MASConfig(
+        mas_id="custom_all_cond",
+        name="Test",
+        workflow_type=WorkflowType.CUSTOM,
+        agents=[_agent("a"), _agent("b"), _agent("c")],
+        workflow_edges=[
+            WorkflowEdge(
+                from_agent="a",
+                to_agent="b",
+                condition="state.current_agent == 'never'",
+                label="to_b",
+            ),
+            WorkflowEdge(
+                from_agent="a",
+                to_agent="c",
+                condition="state.current_agent == 'nope'",
+                label="to_c",
+            ),
+            WorkflowEdge(from_agent="b", to_agent="END"),
+            WorkflowEdge(from_agent="c", to_agent="END"),
+        ],
+    )
+
+    captured = {}
+    original = StateGraph.add_conditional_edges
+
+    def capture(self_graph, source, router, path_map, *a, **k):
+        if source == "a":
+            captured["router"] = router
+        return original(self_graph, source, router, path_map, *a, **k)
+
+    with patch.object(StateGraph, "add_conditional_edges", capture):
+        GraphBuilder(config).build()
+
+    router = captured["router"]
+    # No condition matches and there is no unconditional edge, so the last
+    # edge's label is returned as a final fallback.
+    assert router({"current_agent": "a"}) == "to_c"
+
+
+def test_sequential_entry_not_in_agent_ids_uses_natural_order():
+    """When the entry agent is not in the list, sequential keeps natural order."""
+    from langgraph.graph import (  # pylint: disable=import-outside-toplevel,import-error
+        StateGraph,
+    )
+
+    from bili.aether.compiler.graph_builder import (  # pylint: disable=import-outside-toplevel
+        GraphBuilder,
+    )
+
+    config = MASConfig(
+        mas_id="seq_foreign_entry",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_agent("a"), _agent("b")],
+    )
+    builder = GraphBuilder(config)
+
+    # Force get_entry_agent to return an agent whose ID is not in the list,
+    # exercising the natural-order fallback branch.
+    foreign = _agent("foreign")
+    edges = []
+    original_add_edge = StateGraph.add_edge
+
+    def capture_add_edge(self_graph, src, dst, *a, **k):
+        edges.append((src, dst))
+        return original_add_edge(self_graph, src, dst, *a, **k)
+
+    with patch.object(
+        type(builder._config),  # pylint: disable=protected-access
+        "get_entry_agent",
+        lambda _self: foreign,
+    ), patch.object(StateGraph, "add_edge", capture_add_edge):
+        builder.build()
+
+    # The entry edge should target 'a' (natural list order preserved because
+    # the foreign entry ID is not present in the agent list).
+    start_targets = [dst for src, dst in edges if "start" in str(src).lower()]
+    assert "a" in start_targets
+
+
+def test_custom_fan_out_router_returns_all_targets():
+    """Multiple unconditional edges from one source fan out to all targets."""
+    from langgraph.graph import (  # pylint: disable=import-outside-toplevel,import-error
+        StateGraph,
+    )
+
+    from bili.aether.compiler.graph_builder import (  # pylint: disable=import-outside-toplevel
+        GraphBuilder,
+    )
+
+    config = MASConfig(
+        mas_id="custom_fan",
+        name="Test",
+        workflow_type=WorkflowType.CUSTOM,
+        agents=[_agent("a"), _agent("b"), _agent("c")],
+        workflow_edges=[
+            WorkflowEdge(from_agent="a", to_agent="b", label="fb"),
+            WorkflowEdge(from_agent="a", to_agent="c", label="fc"),
+            WorkflowEdge(from_agent="b", to_agent="END"),
+            WorkflowEdge(from_agent="c", to_agent="END"),
+        ],
+    )
+
+    captured = {}
+    original = StateGraph.add_conditional_edges
+
+    def capture(self_graph, source, router, path_map, *a, **k):
+        if source == "a":
+            captured["router"] = router
+        return original(self_graph, source, router, path_map, *a, **k)
+
+    with patch.object(StateGraph, "add_conditional_edges", capture):
+        GraphBuilder(config).build()
+
+    router = captured["router"]
+    targets = router({})
+    assert set(targets) == {"fb", "fc"}
+
+
+# =========================================================================
+# compiler.graph_builder — consensus checker / router voting logic
+# =========================================================================
+
+
+def _consensus_checker(config):
+    """Capture the __consensus_checker__ node function from a consensus build."""
+    from langgraph.graph import (  # pylint: disable=import-outside-toplevel,import-error
+        StateGraph,
+    )
+
+    captured = {}
+    original_add_node = StateGraph.add_node
+
+    def capture_add_node(self_graph, name, fn, *a, **k):
+        if name == "__consensus_checker__":
+            captured["fn"] = fn
+        return original_add_node(self_graph, name, fn, *a, **k)
+
+    with patch.object(StateGraph, "add_node", capture_add_node):
+        _build(config)
+    return captured["fn"]
+
+
+class TestConsensusVoting:
+    """Tests for the consensus checker's vote-extraction and threshold logic."""
+
+    def _config(self, **kwargs):
+        defaults = dict(
+            mas_id="cons_vote",
+            name="Test",
+            workflow_type=WorkflowType.CONSENSUS,
+            consensus_threshold=0.5,
+            max_consensus_rounds=3,
+        )
+        defaults.update(kwargs)
+        return MASConfig(**defaults)
+
+    def test_consensus_reached_from_message_votes(self):
+        """Votes parsed from 'vote:' message text drive a reached consensus."""
+        config = self._config(
+            agents=[_agent("a"), _agent("b")],
+        )
+        checker = _consensus_checker(config)
+        state = {
+            "current_round": 0,
+            "agent_outputs": {
+                "a": {"message": "My vote: yes, I agree"},
+                "b": {"message": "Decision: yes overall"},
+            },
+        }
+        result = checker(state)
+        assert result["votes"] == {"a": "yes", "b": "yes"}
+        assert result["consensus_reached"] is True
+        assert result["current_round"] == 1
+
+    def test_consensus_uses_parsed_vote_field(self):
+        """A configured consensus_vote_field is read from parsed JSON output."""
+        config = self._config(
+            agents=[
+                _agent(
+                    "a",
+                    output_format="json",
+                    consensus_vote_field="decision",
+                ),
+                _agent(
+                    "b",
+                    output_format="json",
+                    consensus_vote_field="decision",
+                ),
+            ],
+        )
+        checker = _consensus_checker(config)
+        state = {
+            "current_round": 0,
+            "agent_outputs": {
+                "a": {"parsed": {"decision": "approve"}, "message": ""},
+                "b": {"parsed": {"decision": "approve"}, "message": ""},
+            },
+        }
+        result = checker(state)
+        assert result["votes"] == {"a": "approve", "b": "approve"}
+        assert result["consensus_reached"] is True
+
+    def test_consensus_round_limit_forces_completion(self):
+        """With no votes, consensus is forced once the round limit is reached."""
+        config = self._config(
+            agents=[_agent("a"), _agent("b")],
+            max_consensus_rounds=1,
+        )
+        checker = _consensus_checker(config)
+        # No vote signals in the outputs.
+        state = {
+            "current_round": 0,
+            "agent_outputs": {"a": {"message": "thinking"}, "b": {"message": "hmm"}},
+        }
+        result = checker(state)
+        assert result["votes"] == {}
+        assert result["consensus_reached"] is True
+        assert result["current_round"] == 1
+
+
+def _consensus_router(config):
+    """Capture the consensus router from add_conditional_edges."""
+    from langgraph.graph import (  # pylint: disable=import-outside-toplevel,import-error
+        StateGraph,
+    )
+
+    captured = {}
+    original = StateGraph.add_conditional_edges
+
+    def capture(self_graph, source, router, path_map, *a, **k):
+        if source == "__consensus_checker__":
+            captured["router"] = router
+        return original(self_graph, source, router, path_map, *a, **k)
+
+    with patch.object(StateGraph, "add_conditional_edges", capture):
+        _build(config)
+    return captured["router"]
+
+
+class TestConsensusRouter:
+    """Tests for the consensus router continue/end decision."""
+
+    def _config(self):
+        return MASConfig(
+            mas_id="cons_router",
+            name="Test",
+            workflow_type=WorkflowType.CONSENSUS,
+            consensus_threshold=0.5,
+            max_consensus_rounds=2,
+            agents=[_agent("a"), _agent("b")],
+        )
+
+    def test_router_ends_when_consensus_reached(self):
+        """The router ends when consensus_reached is True."""
+        router = _consensus_router(self._config())
+        assert router({"consensus_reached": True, "current_round": 0}) == "end"
+
+    def test_router_ends_at_round_limit(self):
+        """The router ends when the current round meets max_consensus_rounds."""
+        router = _consensus_router(self._config())
+        assert router({"consensus_reached": False, "current_round": 2}) == "end"
+
+    def test_router_continues_below_limit(self):
+        """The router continues when no consensus and below the round limit."""
+        router = _consensus_router(self._config())
+        assert router({"consensus_reached": False, "current_round": 1}) == "continue"

--- a/bili/aether/tests/test_executor_extended.py
+++ b/bili/aether/tests/test_executor_extended.py
@@ -522,7 +522,7 @@ class TestAstreamMethod:
             return events
 
         with pytest.raises(RuntimeError, match="not initialized"):
-            asyncio.get_event_loop().run_until_complete(_run())
+            asyncio.run(_run())
 
     def test_astream_yields_events(self):
         """astream() yields StreamEvent objects for stub agents."""
@@ -536,7 +536,7 @@ class TestAstreamMethod:
                 events.append(event)
             return events
 
-        events = asyncio.get_event_loop().run_until_complete(_run())
+        events = asyncio.run(_run())
         assert len(events) > 0
         for event in events:
             assert isinstance(event, StreamEvent)

--- a/bili/aether/tests/test_executor_extended.py
+++ b/bili/aether/tests/test_executor_extended.py
@@ -19,6 +19,7 @@ Split from test_executor.py to stay within the pylint line limit.
 
 import asyncio
 from unittest.mock import MagicMock as Mock
+from unittest.mock import patch
 
 import pytest
 from langchain_core.messages import HumanMessage  # pylint: disable=import-error
@@ -658,3 +659,141 @@ class TestResumeStreaming:  # pylint: disable=too-few-public-methods
         executor = MASExecutor(config)
         with pytest.raises(RuntimeError, match="not initialized"):
             list(executor.resume_streaming("input", "thread-1"))
+
+
+# =========================================================================
+# Helper-method coverage
+# =========================================================================
+
+
+class TestExecutorHelpers:
+    """Direct tests for small executor helper methods and properties."""
+
+    def test_log_dir_property_returns_configured_dir(self, tmp_path):
+        executor = MASExecutor(_seq_config(), log_dir=str(tmp_path))
+        assert executor.log_dir == str(tmp_path)
+
+    def test_resolve_agent_for_node_exact_prefix_and_miss(self):
+        executor = MASExecutor(_seq_config(n_agents=2))
+        executor.initialize()
+        # Exact match returns the node name itself.
+        assert executor._resolve_agent_for_node("agent_0") == "agent_0"
+        # A pipeline sub-node prefixed by an agent id resolves to that agent.
+        assert executor._resolve_agent_for_node("agent_0__sub") == "agent_0"
+        # An unrelated node name resolves to None.
+        assert executor._resolve_agent_for_node("nonexistent") is None
+
+    def test_resolve_agent_for_node_returns_none_before_init(self):
+        executor = MASExecutor(_seq_config())
+        assert executor._resolve_agent_for_node("agent_0") is None
+
+    def test_get_communication_log_path_is_none(self):
+        executor = MASExecutor(_seq_config())
+        assert executor._get_communication_log_path() is None
+
+    def test_serialize_state_stringifies_unserializable_values(self):
+        # A dict with non-string keys cannot be JSON-encoded even with default=str.
+        state = {
+            "messages": [HumanMessage(content="hi")],
+            "weird": {(1, 2): "tuple-key"},
+        }
+        result = MASExecutor._serialize_state(state)
+        assert result["messages"][0]["content"] == "hi"
+        assert isinstance(result["weird"], str)
+
+    def test_create_checkpointer_with_user_id_uses_factory(self):
+        executor = MASExecutor(
+            _seq_config(
+                checkpoint_enabled=True, checkpoint_config={"type": "postgres"}
+            ),
+            user_id="u@example.com",
+        )
+        sentinel = Mock()
+        with patch(
+            "bili.aether.integration.checkpointer_factory.create_checkpointer_from_config",
+            return_value=sentinel,
+        ) as mock_factory:
+            result = executor._create_checkpointer_with_user_id()
+        assert result is sentinel
+        assert mock_factory.call_args.kwargs["user_id"] == "u@example.com"
+
+    def test_create_checkpointer_with_user_id_falls_back_on_import_error(self):
+        from langgraph.checkpoint.memory import MemorySaver
+
+        executor = MASExecutor(_seq_config(), user_id="u@example.com")
+        # Making the factory module unimportable forces the MemorySaver fallback.
+        with patch.dict(
+            "sys.modules",
+            {"bili.aether.integration.checkpointer_factory": None},
+        ):
+            result = executor._create_checkpointer_with_user_id()
+        assert isinstance(result, MemorySaver)
+
+    def test_initialize_with_user_id_creates_tenant_checkpointer(self):
+        executor = MASExecutor(
+            _seq_config(
+                checkpoint_enabled=True, checkpoint_config={"type": "postgres"}
+            ),
+            user_id="u@example.com",
+        )
+        with patch.object(
+            executor, "_create_checkpointer_with_user_id", return_value=Mock()
+        ) as mock_create:
+            executor.initialize()
+        mock_create.assert_called_once()
+
+
+# =========================================================================
+# run_streaming_tokens branch coverage
+# =========================================================================
+
+
+class TestRunStreamingTokensBranches:
+    """Drive run_streaming_tokens with a stubbed graph to cover edge branches."""
+
+    def test_token_and_node_complete_branches(self):
+        executor = MASExecutor(_seq_config())
+        executor.initialize()
+
+        chunk_text = Mock()
+        chunk_text.content = "hello"
+        chunk_empty = Mock()
+        chunk_empty.content = ""
+        chunk_list = Mock()
+        chunk_list.content = [{"text": "abc"}, {"no_text": "skip"}]
+
+        fake_stream = [
+            # Empty content is skipped.
+            ("messages", (chunk_empty, {"langgraph_node": "agent_0"})),
+            # Missing node name is skipped.
+            ("messages", (chunk_text, {"langgraph_node": ""})),
+            # Structured (list) content yields only the text blocks.
+            ("messages", (chunk_list, {"langgraph_node": "agent_0"})),
+            # Plain string content yields a token.
+            ("messages", (chunk_text, {"langgraph_node": "agent_0"})),
+            # Updates mode yields a node-complete event.
+            ("updates", {"agent_0": {"messages": []}}),
+        ]
+        executor._compiled_graph = Mock()
+        executor._compiled_graph.stream.return_value = iter(fake_stream)
+
+        events = list(executor.run_streaming_tokens({"messages": []}))
+        tokens = [d["token"] for k, d in events if k == "__token__"]
+        assert "abc" in tokens
+        assert "hello" in tokens
+        assert any(k == "__node_complete__" for k, _ in events)
+
+    def test_emits_human_interrupt_when_graph_pauses(self):
+        executor = MASExecutor(_seq_config(human_in_loop=True))
+        executor.initialize()
+
+        executor._compiled_graph = Mock()
+        executor._compiled_graph.stream.return_value = iter([])
+        graph_state = Mock()
+        graph_state.next = ["agent_1"]
+        executor._compiled_graph.get_state.return_value = graph_state
+
+        events = list(executor.run_streaming_tokens({"messages": []}, thread_id="t1"))
+        interrupts = [d for k, d in events if k == "__human_interrupt__"]
+        assert len(interrupts) == 1
+        assert interrupts[0]["next"] == ["agent_1"]

--- a/bili/aether/tests/test_runtime_cli.py
+++ b/bili/aether/tests/test_runtime_cli.py
@@ -1,0 +1,158 @@
+"""Tests for the AETHER runtime CLI (bili/aether/runtime/cli.py).
+
+Covers _ensure_bili_stub, _build_input_data, and the main() entry point
+across its default, cross-model, and checkpoint-persistence branches. All
+heavy dependencies (loader, MASExecutor) are mocked.
+"""
+
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bili.aether.runtime import cli as cli_module
+from bili.aether.runtime.cli import (
+    _build_input_data,
+    _build_parser,
+    _ensure_bili_stub,
+    main,
+)
+
+
+def _result(success=True, output="formatted output"):
+    """Build a fake run result exposing success and get_formatted_output."""
+    res = MagicMock()
+    res.success = success
+    res.get_formatted_output.return_value = output
+    return res
+
+
+def _patched_main(argv):
+    """Return a context-manager set patching argv, loader, and MASExecutor."""
+    return (
+        patch.object(sys, "argv", argv),
+        patch("bili.aether.config.loader.load_mas_from_yaml"),
+        patch("bili.aether.runtime.executor.MASExecutor"),
+    )
+
+
+class TestEnsureBiliStub:
+    """_ensure_bili_stub inserts the project root and stubs bili."""
+
+    def test_inserts_root_and_creates_stub(self):
+        """A bili module without __path__ is replaced by a package stub."""
+        expected_root = os.path.dirname(
+            os.path.dirname(
+                os.path.dirname(os.path.dirname(os.path.abspath(cli_module.__file__)))
+            )
+        )
+        with patch.object(sys, "path", ["/unrelated"]), patch.dict(
+            sys.modules, {"bili": types.ModuleType("bili")}
+        ):
+            _ensure_bili_stub()
+            assert expected_root in sys.path
+            assert sys.modules["bili"].__path__ == [os.path.join(expected_root, "bili")]
+
+
+class TestBuildInputData:
+    """_build_input_data turns CLI args into MASExecutor input state."""
+
+    def test_input_text_wraps_human_message(self):
+        """--input text is wrapped as a single HumanMessage."""
+        args = _build_parser().parse_args(["config.yaml", "--input", "hello"])
+        data = _build_input_data(args)
+        assert data["messages"][0].content == "hello"
+
+    def test_input_file_is_read(self, tmp_path):
+        """--input-file content is read from disk and wrapped."""
+        path = tmp_path / "in.txt"
+        path.write_text("from file")
+        args = _build_parser().parse_args(["config.yaml", "--input-file", str(path)])
+        data = _build_input_data(args)
+        assert data["messages"][0].content == "from file"
+
+    def test_no_input_returns_empty_dict(self):
+        """With no input text or file, an empty state dict is returned."""
+        args = _build_parser().parse_args(["config.yaml"])
+        assert _build_input_data(args) == {}
+
+
+class TestMain:
+    """main() dispatches across the run modes and exits with the right code."""
+
+    def test_default_run_success_exits_zero(self):
+        """A successful default run exits with code 0."""
+        p_argv, p_load, p_exec = _patched_main(
+            ["cli.py", "config.yaml", "--input", "hi"]
+        )
+        with p_argv, p_load, p_exec as exec_cls:
+            executor = exec_cls.return_value
+            executor.run.return_value = _result(success=True)
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 0
+        executor.run.assert_called_once()
+
+    def test_default_run_failure_exits_one(self):
+        """A failed default run exits with code 1."""
+        p_argv, p_load, p_exec = _patched_main(
+            ["cli.py", "config.yaml", "--input", "hi", "--no-save"]
+        )
+        with p_argv, p_load, p_exec as exec_cls:
+            exec_cls.return_value.run.return_value = _result(success=False)
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 1
+        # --no-save disables result saving.
+        assert exec_cls.return_value.run.call_args.kwargs["save_results"] is False
+
+    def test_cross_model_success(self):
+        """A passing cross-model test prints both results and exits 0."""
+        p_argv, p_load, p_exec = _patched_main(
+            [
+                "cli.py",
+                "config.yaml",
+                "--input",
+                "hi",
+                "--test-cross-model",
+                "--source-model",
+                "gpt-4",
+                "--target-model",
+                "claude",
+            ]
+        )
+        with p_argv, p_load, p_exec as exec_cls:
+            exec_cls.return_value.run_cross_model_test.return_value = (
+                _result(success=True),
+                _result(success=True),
+            )
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 0
+
+    def test_cross_model_missing_models_exits_one(self):
+        """Cross-model without both model names exits 1 before running."""
+        p_argv, p_load, p_exec = _patched_main(
+            ["cli.py", "config.yaml", "--input", "hi", "--test-cross-model"]
+        )
+        with p_argv, p_load, p_exec as exec_cls:
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 1
+        exec_cls.return_value.run_cross_model_test.assert_not_called()
+
+    def test_checkpoint_persistence_run(self):
+        """The checkpoint-persistence test runs both phases and exits on success."""
+        p_argv, p_load, p_exec = _patched_main(
+            ["cli.py", "config.yaml", "--input", "hi", "--test-checkpoint"]
+        )
+        with p_argv, p_load, p_exec as exec_cls:
+            exec_cls.return_value.run_with_checkpoint_persistence.return_value = (
+                _result(success=True),
+                _result(success=True),
+            )
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 0

--- a/bili/aether/ui/attack_results_page.py
+++ b/bili/aether/ui/attack_results_page.py
@@ -693,11 +693,19 @@ def _render_matrix(df: pd.DataFrame, is_cross_model: bool) -> None:
     # alone. When no result carries a Tier-3 score, pivot_score is empty and a
     # score-only axis would hide every Tier-1/Tier-2 fallback cell. The union
     # guarantees the matrix still shows "!" and "T2:" cells in that case.
-    row_labels = sorted(
-        set(pivot_score.index) | set(pivot_tier1.index) | set(pivot_tier2.index)
-    )
-    col_labels = sorted(
-        set(pivot_score.columns) | set(pivot_tier1.columns) | set(pivot_tier2.columns)
+    #
+    # Keep only string labels before sorting: a missing phase/payload can leave
+    # NaN/None in a pivot index, and sorted() raises TypeError comparing a float
+    # against a str, which would crash the whole matrix render.
+    def _string_labels(*indexes):
+        labels = set()
+        for index in indexes:
+            labels.update(v for v in index if isinstance(v, str))
+        return sorted(labels)
+
+    row_labels = _string_labels(pivot_score.index, pivot_tier1.index, pivot_tier2.index)
+    col_labels = _string_labels(
+        pivot_score.columns, pivot_tier1.columns, pivot_tier2.columns
     )
     display = pd.DataFrame(
         {col: [_cell_val(row, col) for row in row_labels] for col in col_labels},

--- a/bili/aether/ui/attack_results_page.py
+++ b/bili/aether/ui/attack_results_page.py
@@ -689,12 +689,19 @@ def _render_matrix(df: pd.DataFrame, is_cross_model: bool) -> None:
             return "T2:✓" if not t2 else "T2:✗"
         return "—"
 
+    # Build the matrix axes from the union of all three pivots, not pivot_score
+    # alone. When no result carries a Tier-3 score, pivot_score is empty and a
+    # score-only axis would hide every Tier-1/Tier-2 fallback cell. The union
+    # guarantees the matrix still shows "!" and "T2:" cells in that case.
+    row_labels = sorted(
+        set(pivot_score.index) | set(pivot_tier1.index) | set(pivot_tier2.index)
+    )
+    col_labels = sorted(
+        set(pivot_score.columns) | set(pivot_tier1.columns) | set(pivot_tier2.columns)
+    )
     display = pd.DataFrame(
-        {
-            col: [_cell_val(row, col) for row in pivot_score.index]
-            for col in pivot_score.columns
-        },
-        index=pivot_score.index,
+        {col: [_cell_val(row, col) for row in row_labels] for col in col_labels},
+        index=row_labels,
     )
 
     def _cell_style(val: str) -> str:

--- a/bili/aether/ui/tests/test_attack_graph.py
+++ b/bili/aether/ui/tests/test_attack_graph.py
@@ -1,0 +1,226 @@
+"""Tests for bili.aether.ui.components.attack_graph.
+
+The attack-graph component wraps ``convert_mas_to_graph`` and the third-party
+``streamlit_flow`` component. The pure helpers (``build_node_states`` and
+``_apply_style_overrides``) are tested directly. ``render_attack_graph`` is
+driven through ``AppTest.from_string`` so it executes inside a real Streamlit
+runtime with the flow component mocked.
+
+Streamlit UI modules cannot be imported at module level because doing so
+triggers ``st.set_page_config()`` and other runtime side-effects.
+"""
+
+# pylint: disable=import-outside-toplevel, protected-access, reimported
+# pylint: disable=duplicate-code
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from streamlit.testing.v1 import AppTest
+
+_FM = {
+    "streamlit_flow": MagicMock(),
+    "streamlit_flow.elements": MagicMock(),
+    "streamlit_flow.state": MagicMock(),
+}
+
+
+# ---------------------------------------------------------------------------
+# build_node_states
+# ---------------------------------------------------------------------------
+
+
+def _make_obs(agent_id, influenced=False, resisted=False, received_payload=False):
+    """Build an AgentObservation-like object exposing attribute access."""
+    return SimpleNamespace(
+        agent_id=agent_id,
+        influenced=influenced,
+        resisted=resisted,
+        received_payload=received_payload,
+    )
+
+
+def test_build_node_states_influenced_takes_priority():
+    """influenced wins over resisted and received in the precedence chain."""
+    with patch.dict("sys.modules", _FM):
+        from bili.aether.ui.components.attack_graph import build_node_states
+
+        obs = _make_obs("a0", influenced=True, resisted=True, received_payload=True)
+        assert build_node_states([obs]) == {"a0": "influenced"}
+
+
+def test_build_node_states_resisted_over_received():
+    """resisted wins over received when not influenced."""
+    with patch.dict("sys.modules", _FM):
+        from bili.aether.ui.components.attack_graph import build_node_states
+
+        obs = _make_obs("a0", resisted=True, received_payload=True)
+        assert build_node_states([obs]) == {"a0": "resisted"}
+
+
+def test_build_node_states_received_only():
+    """received maps to the received state."""
+    with patch.dict("sys.modules", _FM):
+        from bili.aether.ui.components.attack_graph import build_node_states
+
+        obs = _make_obs("a0", received_payload=True)
+        assert build_node_states([obs]) == {"a0": "received"}
+
+
+def test_build_node_states_clean_default():
+    """An observation with no flags set maps to clean."""
+    with patch.dict("sys.modules", _FM):
+        from bili.aether.ui.components.attack_graph import build_node_states
+
+        obs = _make_obs("a0")
+        assert build_node_states([obs]) == {"a0": "clean"}
+
+
+def test_build_node_states_accepts_dicts():
+    """build_node_states supports dict-shaped observations."""
+    with patch.dict("sys.modules", _FM):
+        from bili.aether.ui.components.attack_graph import build_node_states
+
+        observations = [
+            {
+                "agent_id": "a0",
+                "influenced": False,
+                "resisted": True,
+                "received_payload": True,
+            },
+            {
+                "agent_id": "a1",
+                "influenced": True,
+                "resisted": False,
+                "received_payload": True,
+            },
+        ]
+        assert build_node_states(observations) == {
+            "a0": "resisted",
+            "a1": "influenced",
+        }
+
+
+# ---------------------------------------------------------------------------
+# _apply_style_overrides
+# ---------------------------------------------------------------------------
+
+
+def _fake_node(node_id):
+    """Build a minimal node object with an id and a style dict."""
+    return SimpleNamespace(id=node_id, style={"background": "#fff"})
+
+
+def test_apply_style_overrides_target_border():
+    """The target node receives the red target border."""
+    with patch.dict("sys.modules", _FM):
+        from bili.aether.ui.components import attack_graph as ag
+
+        nodes = [_fake_node("a0"), _fake_node("a1")]
+        result = ag._apply_style_overrides(nodes, "a0", None)
+        assert result[0].style["border"] == ag._TARGET_BORDER
+        assert result[0].style["borderRadius"] == ag._BORDER_RADIUS
+        # Untargeted node keeps original style, no border key.
+        assert "border" not in result[1].style
+        # Original node objects are not mutated.
+        assert "border" not in nodes[0].style
+
+
+def test_apply_style_overrides_state_beats_target():
+    """A post-run state override takes priority over target selection."""
+    with patch.dict("sys.modules", _FM):
+        from bili.aether.ui.components import attack_graph as ag
+
+        nodes = [_fake_node("a0")]
+        result = ag._apply_style_overrides(nodes, "a0", {"a0": "resisted"})
+        assert result[0].style["border"] == ag._RESISTED_BORDER
+
+
+def test_apply_style_overrides_clean_state_no_border():
+    """A clean state leaves the role-based default style unchanged."""
+    with patch.dict("sys.modules", _FM):
+        from bili.aether.ui.components import attack_graph as ag
+
+        nodes = [_fake_node("a0")]
+        result = ag._apply_style_overrides(nodes, None, {"a0": "clean"})
+        assert "border" not in result[0].style
+
+
+def test_apply_style_overrides_influenced_and_received():
+    """influenced and received map to their respective borders."""
+    with patch.dict("sys.modules", _FM):
+        from bili.aether.ui.components import attack_graph as ag
+
+        nodes = [_fake_node("a0"), _fake_node("a1")]
+        result = ag._apply_style_overrides(
+            nodes, None, {"a0": "influenced", "a1": "received"}
+        )
+        assert result[0].style["border"] == ag._INFLUENCED_BORDER
+        assert result[1].style["border"] == ag._RECEIVED_BORDER
+
+
+# ---------------------------------------------------------------------------
+# render_attack_graph
+# ---------------------------------------------------------------------------
+
+
+def _render_script(target="agent_0", node_states="None", click="agent_0"):
+    """Build an AppTest script that drives render_attack_graph once."""
+    return f"""
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {{
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui.components import attack_graph as ag
+
+    returned_state = _Mock()
+    returned_state.selected_id = {click!r}
+    mock_flow = _Mock(return_value=returned_state)
+    mock_state_cls = _Mock(side_effect=lambda n, e: _Mock(selected_id=None))
+    ag.streamlit_flow = mock_flow
+    ag.StreamlitFlowState = mock_state_cls
+
+    cfg = mk(mas_id="atk")
+    clicked = ag.render_attack_graph(cfg, {target!r}, {node_states})
+    st.markdown(f"clicked:{{clicked}}")
+"""
+
+
+def test_render_attack_graph_returns_clicked_agent():
+    """Clicking an agent node returns that agent's id."""
+    at = AppTest.from_string(_render_script(click="agent_0"))
+    at.run()
+    assert not at.exception
+    assert "clicked:agent_0" in " ".join(m.value for m in at.markdown)
+
+
+def test_render_attack_graph_ignores_non_agent_click():
+    """A selected id that is not an agent returns None."""
+    at = AppTest.from_string(_render_script(click="edge_x"))
+    at.run()
+    assert not at.exception
+    assert "clicked:None" in " ".join(m.value for m in at.markdown)
+
+
+def test_render_attack_graph_shows_legend_after_run():
+    """When node_states is provided the propagation legend caption renders."""
+    at = AppTest.from_string(
+        _render_script(node_states="{'agent_0': 'influenced'}", click="None")
+    )
+    at.run()
+    assert not at.exception
+    assert any("Influenced" in c.value for c in at.caption)
+
+
+def test_render_attack_graph_no_legend_before_run():
+    """With node_states None no legend caption is shown."""
+    at = AppTest.from_string(_render_script(node_states="None", click="None"))
+    at.run()
+    assert not at.exception
+    assert not any("Influenced" in c.value for c in at.caption)

--- a/bili/aether/ui/tests/test_attack_page.py
+++ b/bili/aether/ui/tests/test_attack_page.py
@@ -1007,3 +1007,959 @@ with patch.object(ap, "_is_stub_mode", return_value=True):
     assert not at.exception
     all_err = " ".join(m.value for m in at.error)
     assert "Connection refused" in all_err
+
+
+# ---------------------------------------------------------------------------
+# _on_suite_header_change and _set_suite_payloads (lines 244-246, 251-252)
+# ---------------------------------------------------------------------------
+
+
+def test_on_suite_header_change_propagates():
+    """_on_suite_header_change pushes the header value to all child keys."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.aether.ui import attack_page as ap
+st.session_state["hdr"] = False
+st.session_state["c1"] = True
+st.session_state["c2"] = True
+ap._on_suite_header_change("hdr", ["c1", "c2"])
+st.markdown(f"c1:{st.session_state['c1']}")
+st.markdown(f"c2:{st.session_state['c2']}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "c1:False" in all_md
+    assert "c2:False" in all_md
+
+
+def test_set_suite_payloads_sets_all():
+    """_set_suite_payloads writes the value to every payload key."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.aether.ui import attack_page as ap
+ap._set_suite_payloads(["k1", "k2"], True)
+st.markdown(f"k1:{st.session_state['k1']}")
+st.markdown(f"k2:{st.session_state['k2']}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "k1:True" in all_md
+    assert "k2:True" in all_md
+
+
+# ---------------------------------------------------------------------------
+# _report_suite_result (lines 353-373)
+# ---------------------------------------------------------------------------
+
+
+def test_report_suite_result_all_skipped():
+    """_report_suite_result counts an all-skipped suite as passed."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.aether.ui import attack_page as ap
+rows = [{"skipped": "true"}, {"skipped": "true"}]
+area = st.container()
+passed = ap._report_suite_result(rows, "injection", ["p1"], area, 0)
+st.markdown(f"passed:{passed}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "passed:1" in " ".join(m.value for m in at.markdown)
+
+
+def test_report_suite_result_all_passed():
+    """_report_suite_result counts a suite where every ran row passed."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.aether.ui import attack_page as ap
+rows = [{"skipped": "false", "tier1_pass": "true"}]
+area = st.container()
+passed = ap._report_suite_result(rows, "injection", ["p1"], area, 0)
+st.markdown(f"passed:{passed}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "passed:1" in " ".join(m.value for m in at.markdown)
+
+
+def test_report_suite_result_some_failed():
+    """_report_suite_result does not increment when a ran row failed."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.aether.ui import attack_page as ap
+rows = [{"skipped": "false", "tier1_pass": "false"}]
+area = st.container()
+passed = ap._report_suite_result(rows, "injection", ["p1"], area, 0)
+st.markdown(f"passed:{passed}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "passed:0" in " ".join(m.value for m in at.markdown)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_attack_config yaml selection (lines 205-218)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_attack_config_loads_selected_yaml(tmp_path):
+    """_resolve_attack_config loads the chosen YAML into session state."""
+    (tmp_path / "demo_config.yaml").write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+import streamlit as st
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+from bili.aether.ui import attack_page as ap
+import bili.aether.config.loader as loader_mod
+fake_cfg = MagicMock()
+fake_cfg.agents = [MagicMock(agent_id="agent_0")]
+st.session_state["attack_yaml_selector"] = 1
+with patch.object(ap, "EXAMPLES_DIR", Path({str(tmp_path)!r})):
+    with patch.object(loader_mod, "load_mas_from_yaml", return_value=fake_cfg):
+        ap._resolve_attack_config()
+st.markdown(f"loaded:{{st.session_state.get('attack_config') is not None}}")
+st.markdown(f"target:{{st.session_state.get('attack_target_agent_id')}}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "loaded:True" in all_md
+    assert "target:agent_0" in all_md
+
+
+def test_resolve_attack_config_load_error(tmp_path):
+    """_resolve_attack_config surfaces an error when YAML loading fails."""
+    (tmp_path / "broken_config.yaml").write_text("bad", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+import streamlit as st
+from unittest.mock import patch
+from pathlib import Path
+from bili.aether.ui import attack_page as ap
+import bili.aether.config.loader as loader_mod
+st.session_state["attack_yaml_selector"] = 1
+with patch.object(ap, "EXAMPLES_DIR", Path({str(tmp_path)!r})):
+    with patch.object(loader_mod, "load_mas_from_yaml",
+                      side_effect=ValueError("bad yaml")):
+        ap._resolve_attack_config()
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "Failed to load" in " ".join(e.value for e in at.error)
+
+
+# ---------------------------------------------------------------------------
+# Sidebar logo branch (line 561)
+# ---------------------------------------------------------------------------
+
+
+def test_sidebar_renders_logo_when_present():
+    """_render_sidebar calls st.image when the logo file exists."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+import streamlit as st
+from bili.aether.ui import attack_page as ap
+with st.sidebar:
+    with patch.object(ap, "LOGO_PATH") as lp:
+        lp.exists.return_value = True
+        lp.__str__ = lambda self: "/fake/logo.png"
+        with patch.object(ap, "EXAMPLES_DIR") as ed:
+            ed.exists.return_value = False
+            with patch("streamlit.image") as img:
+                ap._render_sidebar()
+                st.markdown(f"image_called:{img.called}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "image_called:True" in " ".join(m.value for m in at.sidebar.markdown)
+
+
+# ---------------------------------------------------------------------------
+# _run_mid_execution (lines 953-955)
+# ---------------------------------------------------------------------------
+
+
+def test_run_mid_execution_calls_injector():
+    """_run_mid_execution delegates to AttackInjector.inject_attack."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch, MagicMock
+import streamlit as st
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+cfg = mk()
+fake_result = MagicMock(name="attack_result")
+fake_injector = MagicMock()
+fake_injector.inject_attack.return_value = fake_result
+with patch.object(ap, "AttackInjector", return_value=fake_injector):
+    result = ap._run_mid_execution(cfg, "agent_0", "prompt_injection", "payload")
+st.markdown(f"called:{fake_injector.inject_attack.called}")
+st.markdown(f"same:{result is fake_result}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "called:True" in all_md
+    assert "same:True" in all_md
+
+
+# ---------------------------------------------------------------------------
+# _load_baseline_result file reading (lines 1124-1131)
+# ---------------------------------------------------------------------------
+
+
+def test_load_baseline_result_reads_legacy_file(tmp_path):
+    """_load_baseline_result returns the first JSON file in the legacy layout."""
+    from unittest.mock import patch
+
+    mas_dir = tmp_path / "mas_a"
+    mas_dir.mkdir(parents=True)
+    (mas_dir / "p1.json").write_text(
+        '{"mas_id": "mas_a", "prompt_id": "p1"}', encoding="utf-8"
+    )
+    with patch.object(ap_mod, "BASELINE_RESULTS_DIR", tmp_path):
+        result = ap_mod._load_baseline_result("mas_a")
+    assert result is not None
+    assert result["prompt_id"] == "p1"
+
+
+def test_load_baseline_result_skips_unreadable(tmp_path):
+    """_load_baseline_result skips an unreadable file and warns."""
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import patch
+from pathlib import Path
+from bili.aether.ui import attack_page as ap
+mas_dir = Path({str(tmp_path)!r}) / "mas_a"
+mas_dir.mkdir(parents=True, exist_ok=True)
+(mas_dir / "bad.json").write_text("{{not json", encoding="utf-8")
+with patch.object(ap, "BASELINE_RESULTS_DIR", Path({str(tmp_path)!r})):
+    result = ap._load_baseline_result("mas_a")
+import streamlit as st
+st.markdown(f"result_none:{{result is None}}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "result_none:True" in " ".join(m.value for m in at.markdown)
+    assert "unreadable" in " ".join(w.value for w in at.warning)
+
+
+# ---------------------------------------------------------------------------
+# _run_tier3_evaluation (lines 1093-1104)
+# ---------------------------------------------------------------------------
+
+
+def test_run_tier3_evaluation_success():
+    """_run_tier3_evaluation reconstructs the result and calls the evaluator."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch, MagicMock
+import streamlit as st
+from bili.aether.ui import attack_page as ap
+import bili.aegis.evaluator.semantic_evaluator as se_mod
+fake_eval = MagicMock()
+fake_eval.evaluate.return_value = [MagicMock(name="verdict")]
+result_dict = {"some": "value"}
+baseline = {"baseline": "value"}
+with patch.object(ap.AttackResult, "model_validate", return_value=MagicMock()):
+    with patch.object(se_mod, "SemanticEvaluator", return_value=fake_eval):
+        verdicts = ap._run_tier3_evaluation(result_dict, baseline)
+st.markdown(f"count:{len(verdicts)}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "count:1" in " ".join(m.value for m in at.markdown)
+
+
+def test_run_tier3_evaluation_error_returns_none():
+    """_run_tier3_evaluation returns None and shows an error on failure."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+import streamlit as st
+from bili.aether.ui import attack_page as ap
+with patch.object(ap.AttackResult, "model_validate",
+                  side_effect=ValueError("bad result")):
+    verdicts = ap._run_tier3_evaluation({}, {})
+st.markdown(f"none:{verdicts is None}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "none:True" in " ".join(m.value for m in at.markdown)
+    assert "Tier 3 evaluation failed" in " ".join(e.value for e in at.error)
+
+
+# ---------------------------------------------------------------------------
+# _render_results Tier-3 verdict rendering (lines 1016-1041)
+# ---------------------------------------------------------------------------
+
+
+def test_render_results_tier3_with_verdicts():
+    """_render_results renders Tier-3 verdict scores including the error case."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from unittest.mock import patch
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+config = mk(model_name="gpt-4o")
+result_dict = {
+    "success": True,
+    "agent_observations": [],
+    "propagation_path": [],
+    "influenced_agents": [],
+    "resistant_agents": [],
+}
+class _Verdict:
+    def __init__(self, data):
+        self._data = data
+    def model_dump(self):
+        return self._data
+
+verdicts = [
+    _Verdict({"agent_id": "agent_0", "score": 3, "reasoning": "High compliance",
+              "confidence": "high"}),
+    _Verdict({"agent_id": "agent_1", "score": 1, "reasoning": "Partial",
+              "confidence": "low"}),
+    _Verdict({"agent_id": "agent_2", "score": 0, "reasoning": "",
+              "confidence": "high"}),
+    _Verdict({"agent_id": "agent_3", "score": -1, "error": "evaluator crashed"}),
+]
+with patch.object(ap, "_is_stub_mode", return_value=False):
+    with patch.object(ap, "_load_baseline_result", return_value={"baseline": 1}):
+        with patch.object(ap, "_get_evaluator_model", return_value="claude-3"):
+            with patch.object(ap, "_run_tier3_evaluation", return_value=verdicts):
+                ap._render_results(config, result_dict)
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "agent_0" in all_md
+    assert "Score 3/3" in all_md
+    all_err = " ".join(e.value for e in at.error)
+    assert "evaluator crashed" in all_err
+
+
+def test_render_results_tier3_evaluation_returns_none():
+    """_render_results stops cleanly when Tier-3 evaluation returns None."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+config = mk(model_name="gpt-4o")
+result_dict = {
+    "success": True,
+    "agent_observations": [],
+    "propagation_path": [],
+    "influenced_agents": [],
+    "resistant_agents": [],
+}
+with patch.object(ap, "_is_stub_mode", return_value=False):
+    with patch.object(ap, "_load_baseline_result", return_value={"baseline": 1}):
+        with patch.object(ap, "_get_evaluator_model", return_value="claude-3"):
+            with patch.object(ap, "_run_tier3_evaluation", return_value=None):
+                ap._render_results(config, result_dict)
+"""
+    )
+    at.run()
+    assert not at.exception
+
+
+# ---------------------------------------------------------------------------
+# _run_pre_execution_streaming (lines 859-929)
+# ---------------------------------------------------------------------------
+
+
+def test_run_pre_execution_streaming_builds_result():
+    """_run_pre_execution_streaming streams tokens and returns an AttackResult."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from unittest.mock import patch, MagicMock
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+config = mk(num_agents=2)
+
+# Patch the strategy function to return the config unchanged.
+with patch.object(
+    ap._pre_exec_strats, "inject_prompt_injection", return_value=config
+):
+    fake_executor = MagicMock()
+    msg = MagicMock()
+    msg.content = "agent output text"
+    events = [
+        ("__token__", {"node": "agent_0", "token": "hello"}),
+        ("__token__", {"node": "not_an_agent", "token": "ignored"}),
+        ("__node_complete__", {"node": "agent_0",
+                               "state_update": {"messages": [msg]}}),
+        ("__node_complete__", {"node": "agent_1", "state_update": None}),
+    ]
+    fake_executor.run_streaming_tokens.return_value = iter(events)
+    with patch.object(ap, "MASExecutor", return_value=fake_executor):
+        result = ap._run_pre_execution_streaming(
+            config, "agent_0", "prompt_injection", "payload text"
+        )
+st.markdown(f"mas_id:{result.mas_id}")
+st.markdown(f"target:{result.target_agent_id}")
+st.markdown(f"success:{result.success}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert f"mas_id:{'test_mas'}" in all_md
+    assert "target:agent_0" in all_md
+    assert "success:True" in all_md
+
+
+def test_run_pre_execution_streaming_reraises_on_error():
+    """_run_pre_execution_streaming re-raises when the stream loop fails."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from unittest.mock import patch, MagicMock
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+config = mk(num_agents=1)
+
+def _boom(*args, **kwargs):
+    raise RuntimeError("stream broke")
+
+with patch.object(
+    ap._pre_exec_strats, "inject_prompt_injection", return_value=config
+):
+    fake_executor = MagicMock()
+    fake_executor.run_streaming_tokens.side_effect = _boom
+    with patch.object(ap, "MASExecutor", return_value=fake_executor):
+        raised = False
+        try:
+            ap._run_pre_execution_streaming(
+                config, "agent_0", "prompt_injection", "payload"
+            )
+        except RuntimeError:
+            raised = True
+st.markdown(f"raised:{raised}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "raised:True" in " ".join(m.value for m in at.markdown)
+
+
+# ---------------------------------------------------------------------------
+# _run_attack success flow (lines 823-843)
+# ---------------------------------------------------------------------------
+
+
+def test_run_attack_pre_execution_success():
+    """_run_attack stores the result and node states on a successful pre-exec run."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from unittest.mock import patch, MagicMock
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+st.session_state.attack_config = mk()
+st.session_state.attack_target_agent_id = "agent_0"
+st.session_state.attack_suite = "injection"
+st.session_state.attack_phase = "pre_execution"
+
+fake_result = MagicMock()
+fake_result.model_dump.return_value = {"success": True}
+fake_result.agent_observations = []
+with patch.object(ap.st, "rerun"):
+    with patch.object(ap, "_resolve_payload", return_value="payload"):
+        with patch.object(ap, "_run_pre_execution_streaming", return_value=fake_result):
+            with patch.object(ap, "build_node_states", return_value={"agent_0": "ok"}):
+                ap._run_attack()
+st.markdown(f"stored:{'attack_result' in st.session_state}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "stored:True" in " ".join(m.value for m in at.markdown)
+
+
+def test_run_attack_mid_execution_path():
+    """_run_attack uses the mid-execution handler when phase is mid_execution."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from unittest.mock import patch, MagicMock
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+st.session_state.attack_config = mk()
+st.session_state.attack_target_agent_id = "agent_0"
+st.session_state.attack_suite = "injection"
+st.session_state.attack_phase = "mid_execution"
+
+fake_result = MagicMock()
+fake_result.model_dump.return_value = {"success": True}
+fake_result.agent_observations = []
+with patch.object(ap.st, "rerun"):
+    with patch.object(ap, "_resolve_payload", return_value="payload"):
+        with patch.object(ap, "_run_mid_execution", return_value=fake_result) as mid:
+            with patch.object(ap, "build_node_states", return_value={}):
+                ap._run_attack()
+st.markdown(f"mid_called:{mid.called}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "mid_called:True" in " ".join(m.value for m in at.markdown)
+
+
+def test_run_attack_execution_error():
+    """_run_attack shows an error when the execution handler raises."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from unittest.mock import patch
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+st.session_state.attack_config = mk()
+st.session_state.attack_target_agent_id = "agent_0"
+st.session_state.attack_suite = "injection"
+st.session_state.attack_phase = "pre_execution"
+with patch.object(ap, "_resolve_payload", return_value="payload"):
+    with patch.object(ap, "_run_pre_execution_streaming",
+                      side_effect=RuntimeError("boom")):
+        ap._run_attack()
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "Attack failed" in " ".join(e.value for e in at.error)
+
+
+# ---------------------------------------------------------------------------
+# _execute_batch_attack (lines 378-539)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_batch_attack_no_yaml_path():
+    """_execute_batch_attack errors out when no YAML path is available."""
+    at = AppTest.from_string(
+        """
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+ap._execute_batch_attack(mk(), "", stub_mode=True)
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "No YAML config path" in " ".join(e.value for e in at.error)
+
+
+def test_execute_batch_attack_no_payloads_selected():
+    """_execute_batch_attack warns when no payloads are selected."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+# Empty libraries mean no suite ends up with a selection.
+with patch.object(ap, "_load_payload_library", return_value={}):
+    ap._execute_batch_attack(mk(), "/path/to/config.yaml", stub_mode=True)
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "No payloads selected" in " ".join(w.value for w in at.warning)
+
+
+def test_execute_batch_attack_standard_suite_success():
+    """_execute_batch_attack reports a standard suite that returns normally."""
+    import sys
+    import types
+    from unittest.mock import MagicMock, patch
+
+    # Provide a stub _suite_runner whose run_suite returns normally.
+    runner_mod = types.ModuleType("bili.aegis.suites._suite_runner")
+    runner_mod.run_suite = MagicMock(return_value=None)
+    se_mod = types.ModuleType("bili.aegis.evaluator.semantic_evaluator")
+    se_mod.SemanticEvaluator = MagicMock()
+    with patch.dict(
+        sys.modules,
+        {
+            "bili.aegis.suites._suite_runner": runner_mod,
+            "bili.aegis.evaluator.semantic_evaluator": se_mod,
+        },
+    ):
+        at = AppTest.from_string(
+            """
+from unittest.mock import patch, MagicMock
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+
+payload = MagicMock()
+
+def _lib(suite):
+    return {"pld_1": payload} if suite == "injection" else {}
+
+with patch.object(ap, "_load_payload_library", side_effect=_lib):
+    ap._execute_batch_attack(mk(), "/path/to/config.yaml", stub_mode=True)
+"""
+        )
+        at.run()
+    assert not at.exception
+    assert runner_mod.run_suite.called
+    all_success = " ".join(s.value for s in at.success)
+    assert "completed" in all_success
+
+
+def test_execute_batch_attack_standard_suite_sysexit_pass():
+    """_execute_batch_attack treats sys.exit(0) from run_suite as a pass."""
+    import sys
+    import types
+    from unittest.mock import MagicMock, patch
+
+    def _exit_zero(**kwargs):
+        raise SystemExit(0)
+
+    runner_mod = types.ModuleType("bili.aegis.suites._suite_runner")
+    runner_mod.run_suite = _exit_zero
+    se_mod = types.ModuleType("bili.aegis.evaluator.semantic_evaluator")
+    se_mod.SemanticEvaluator = MagicMock()
+    with patch.dict(
+        sys.modules,
+        {
+            "bili.aegis.suites._suite_runner": runner_mod,
+            "bili.aegis.evaluator.semantic_evaluator": se_mod,
+        },
+    ):
+        at = AppTest.from_string(
+            """
+from unittest.mock import patch, MagicMock
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+payload = MagicMock()
+def _lib(suite):
+    return {"pld_1": payload} if suite == "injection" else {}
+with patch.object(ap, "_load_payload_library", side_effect=_lib):
+    ap._execute_batch_attack(mk(), "/path/to/config.yaml", stub_mode=True)
+"""
+        )
+        at.run()
+    assert not at.exception
+    assert "completed" in " ".join(s.value for s in at.success)
+
+
+def test_execute_batch_attack_standard_suite_sysexit_fail():
+    """_execute_batch_attack treats sys.exit(non-zero) from run_suite as a failure."""
+    import sys
+    import types
+    from unittest.mock import MagicMock, patch
+
+    def _exit_one(**kwargs):
+        raise SystemExit(1)
+
+    runner_mod = types.ModuleType("bili.aegis.suites._suite_runner")
+    runner_mod.run_suite = _exit_one
+    se_mod = types.ModuleType("bili.aegis.evaluator.semantic_evaluator")
+    se_mod.SemanticEvaluator = MagicMock()
+    with patch.dict(
+        sys.modules,
+        {
+            "bili.aegis.suites._suite_runner": runner_mod,
+            "bili.aegis.evaluator.semantic_evaluator": se_mod,
+        },
+    ):
+        at = AppTest.from_string(
+            """
+from unittest.mock import patch, MagicMock
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+payload = MagicMock()
+def _lib(suite):
+    return {"pld_1": payload} if suite == "injection" else {}
+with patch.object(ap, "_load_payload_library", side_effect=_lib):
+    ap._execute_batch_attack(mk(), "/path/to/config.yaml", stub_mode=True)
+"""
+        )
+        at.run()
+    assert not at.exception
+    # One suite failed -> overall warning is shown.
+    assert "failed" in " ".join(w.value for w in at.warning)
+
+
+def test_execute_batch_attack_suite_exception():
+    """_execute_batch_attack reports a suite that raises an unexpected error."""
+    import sys
+    import types
+    from unittest.mock import MagicMock, patch
+
+    def _raise(**kwargs):
+        raise RuntimeError("runner exploded")
+
+    runner_mod = types.ModuleType("bili.aegis.suites._suite_runner")
+    runner_mod.run_suite = _raise
+    se_mod = types.ModuleType("bili.aegis.evaluator.semantic_evaluator")
+    se_mod.SemanticEvaluator = MagicMock()
+    with patch.dict(
+        sys.modules,
+        {
+            "bili.aegis.suites._suite_runner": runner_mod,
+            "bili.aegis.evaluator.semantic_evaluator": se_mod,
+        },
+    ):
+        at = AppTest.from_string(
+            """
+from unittest.mock import patch, MagicMock
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+payload = MagicMock()
+def _lib(suite):
+    return {"pld_1": payload} if suite == "injection" else {}
+with patch.object(ap, "_load_payload_library", side_effect=_lib):
+    ap._execute_batch_attack(mk(), "/path/to/config.yaml", stub_mode=True)
+"""
+        )
+        at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "failed" in all_md
+
+
+def test_execute_batch_attack_persistence_suite():
+    """_execute_batch_attack runs the persistence suite via its own runner."""
+    import sys
+    import types
+    from unittest.mock import MagicMock, patch
+
+    persistence_mod = types.ModuleType(
+        "bili.aegis.suites.persistence.run_persistence_suite"
+    )
+    persistence_mod.run_persistence_suite = MagicMock(
+        return_value=([{"skipped": "false", "tier1_pass": "true"}], None)
+    )
+    eval_cfg_mod = types.ModuleType("bili.aegis.evaluator.evaluator_config")
+    eval_cfg_mod.PERSISTENCE_JUDGE_PROMPT = "judge"
+    eval_cfg_mod.PERSISTENCE_SCORE_DESCRIPTIONS = {}
+    se_mod = types.ModuleType("bili.aegis.evaluator.semantic_evaluator")
+    se_mod.SemanticEvaluator = MagicMock()
+    with patch.dict(
+        sys.modules,
+        {
+            "bili.aegis.suites.persistence.run_persistence_suite": persistence_mod,
+            "bili.aegis.evaluator.evaluator_config": eval_cfg_mod,
+            "bili.aegis.evaluator.semantic_evaluator": se_mod,
+        },
+    ):
+        at = AppTest.from_string(
+            """
+from unittest.mock import patch, MagicMock
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+payload = MagicMock()
+def _lib(suite):
+    return {"pld_1": payload} if suite == "persistence" else {}
+with patch.object(ap, "_load_payload_library", side_effect=_lib):
+    ap._execute_batch_attack(mk(), "/path/to/config.yaml", stub_mode=False)
+"""
+        )
+        at.run()
+    assert not at.exception
+    assert persistence_mod.run_persistence_suite.called
+
+
+def test_execute_batch_attack_cross_model_suite():
+    """_execute_batch_attack runs the cross-model suite via its own runner."""
+    import sys
+    import types
+    from unittest.mock import MagicMock, patch
+
+    cm_mod = types.ModuleType("bili.aegis.suites.cross_model.run_cross_model_suite")
+    cm_mod.MODEL_MATRIX = [("m1", "Model One")]
+    cm_mod.run_cross_model_suite = MagicMock(
+        return_value=([{"skipped": "false", "tier1_pass": "true"}], None)
+    )
+    se_mod = types.ModuleType("bili.aegis.evaluator.semantic_evaluator")
+    se_mod.SemanticEvaluator = MagicMock()
+    with patch.dict(
+        sys.modules,
+        {
+            "bili.aegis.suites.cross_model.run_cross_model_suite": cm_mod,
+            "bili.aegis.evaluator.semantic_evaluator": se_mod,
+        },
+    ):
+        at = AppTest.from_string(
+            """
+from unittest.mock import patch, MagicMock
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+payload = MagicMock()
+def _lib(suite):
+    return {"pld_1": payload} if suite == "cross_model" else {}
+with patch.object(ap, "_load_payload_library", side_effect=_lib):
+    ap._execute_batch_attack(mk(), "/path/to/config.yaml", stub_mode=True)
+"""
+        )
+        at.run()
+    assert not at.exception
+    assert cm_mod.run_cross_model_suite.called
+
+
+# ---------------------------------------------------------------------------
+# _render_main toggle captions (lines 724, 734)
+# ---------------------------------------------------------------------------
+
+
+def test_render_main_stub_and_t3_captions():
+    """_render_main shows 'No LLM calls' and 'T3 skipped' captions when toggled."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from unittest.mock import patch
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+cfg = mk(mas_id="toggle_test")
+st.session_state.attack_config = cfg
+st.session_state.attack_target_agent_id = "agent_0"
+st.session_state["attack_stub_mode"] = True
+st.session_state["attack_skip_t3"] = True
+with patch.object(ap, "LOGO_PATH") as lp:
+    lp.exists.return_value = False
+    with patch.object(ap, "render_attack_graph", return_value=None):
+        with patch.object(ap, "_load_payload_library", return_value={}):
+            ap._render_main()
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_captions = " ".join(c.value for c in at.caption)
+    assert "No LLM calls" in all_captions
+    assert "T3 skipped" in all_captions
+
+
+# ---------------------------------------------------------------------------
+# _render_main node click triggers rerun (lines 787-788)
+# ---------------------------------------------------------------------------
+
+
+def test_render_main_node_click_updates_target():
+    """_render_main updates the target agent when the graph returns a new node."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from unittest.mock import patch
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+cfg = mk(num_agents=2, mas_id="click_test")
+st.session_state.attack_config = cfg
+st.session_state.attack_target_agent_id = "agent_0"
+with patch.object(ap, "LOGO_PATH") as lp:
+    lp.exists.return_value = False
+    # The graph returns a different node than the current target, so the
+    # click branch updates session state and reruns.
+    with patch.object(ap, "render_attack_graph", return_value="agent_1"):
+        with patch.object(ap, "_load_payload_library", return_value={}):
+            with patch.object(ap.st, "rerun"):
+                ap._render_main()
+st.markdown(f"target:{st.session_state.get('attack_target_agent_id')}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "target:agent_1" in " ".join(m.value for m in at.markdown)
+
+
+# ---------------------------------------------------------------------------
+# Sidebar Run Attack button click (line 640)
+# ---------------------------------------------------------------------------
+
+
+def test_sidebar_run_attack_button_click():
+    """Clicking the sidebar Run Attack button invokes _run_attack."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from unittest.mock import patch, MagicMock
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+cfg = mk(mas_id="run_btn_test")
+st.session_state.attack_config = cfg
+st.session_state.attack_target_agent_id = "agent_0"
+mock_payload = MagicMock()
+mock_payload.payload = "text"
+mock_payload.notes = "notes"
+with st.sidebar:
+    with patch.object(ap, "LOGO_PATH") as lp:
+        lp.exists.return_value = False
+        with patch.object(ap, "EXAMPLES_DIR") as ed:
+            ed.exists.return_value = False
+            with patch.object(ap, "_load_payload_library",
+                              return_value={"p1": mock_payload}):
+                with patch.object(ap, "_run_attack") as run_attack:
+                    ap._render_sidebar()
+                    st.session_state["__run_attack_mock_called"] = run_attack
+"""
+    )
+    at.run()
+    assert not at.exception
+    # Locate and click the Run Attack button, then re-run to fire its callback.
+    run_buttons = [b for b in at.sidebar.button if b.label == "Run Attack"]
+    assert run_buttons
+    run_buttons[0].click().run()
+    assert not at.exception
+
+
+# ---------------------------------------------------------------------------
+# Main batch run button click (line 761)
+# ---------------------------------------------------------------------------
+
+
+def test_main_batch_run_button_click():
+    """Clicking the batch run button invokes _execute_batch_attack."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from unittest.mock import patch, MagicMock
+from bili.aether.ui import attack_page as ap
+from bili.aether.ui.tests.conftest import make_test_config as mk
+cfg = mk(mas_id="batch_btn_test")
+st.session_state.attack_config = cfg
+st.session_state.attack_yaml_path = "/path/cfg.yaml"
+st.session_state.attack_target_agent_id = "agent_0"
+payload = MagicMock()
+payload.payload = "adversarial"
+payload.severity = "high"
+def _lib(suite):
+    return {"p1": payload} if suite == "injection" else {}
+with patch.object(ap, "LOGO_PATH") as lp:
+    lp.exists.return_value = False
+    with patch.object(ap, "render_attack_graph", return_value=None):
+        with patch.object(ap, "_load_payload_library", side_effect=_lib):
+            with patch.object(ap, "_execute_batch_attack") as batch:
+                ap._render_main()
+"""
+    )
+    at.run()
+    assert not at.exception
+    run_buttons = [b for b in at.button if "Run" in b.label and "attack" in b.label]
+    assert run_buttons
+    run_buttons[0].click().run()
+    assert not at.exception

--- a/bili/aether/ui/tests/test_attack_results_page.py
+++ b/bili/aether/ui/tests/test_attack_results_page.py
@@ -937,3 +937,506 @@ def test_tier2_tier3_disagree_score_one_not_influenced():
 def test_tier2_tier3_disagree_score_three_influenced():
     """No disagreement when T3=3 and influenced (both agree)."""
     assert arp_mod._tier2_tier3_disagree(["a0"], 3) is False
+
+
+# ---------------------------------------------------------------------------
+# _load_suite_results disk-reading (lines 94-117)
+# ---------------------------------------------------------------------------
+
+
+def _write_suite_file(path, payload_id, mas_id, success):
+    """Write a minimal attack-suite result JSON file at *path*."""
+    import json
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "payload_id": payload_id,
+                "injection_type": "injection",
+                "severity": "high",
+                "mas_id": mas_id,
+                "injection_phase": "pre",
+                "attack_suite": "injection",
+                "execution": {
+                    "success": success,
+                    "duration_ms": 10,
+                    "agent_count": 1,
+                },
+                "run_metadata": {
+                    "stub_mode": True,
+                    "timestamp": "t",
+                    "tier3_score": 1,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_load_suite_results_versioned_and_legacy(tmp_path):
+    """_load_suite_results derives run_id from versioned and legacy layouts."""
+    from unittest.mock import patch
+
+    results_root = tmp_path / "injection" / "results"
+    # Versioned: {mas_id}/run_002/{payload}.json
+    _write_suite_file(
+        results_root / "mas_a" / "run_002" / "p1.json", "p1", "mas_a", True
+    )
+    # Legacy flat: {mas_id}/{payload}.json
+    _write_suite_file(results_root / "mas_b" / "p2.json", "p2", "mas_b", False)
+    with patch.object(arp_mod, "_SUITES_DIR", tmp_path):
+        results = arp_mod._load_suite_results.__wrapped__("injection")
+    by_payload = {r["payload_id"]: r for r in results}
+    assert by_payload["p1"]["run_id"] == "run_002"
+    assert by_payload["p2"]["run_id"] == "run_000 (legacy)"
+
+
+def test_load_suite_results_missing_dir(tmp_path):
+    """_load_suite_results returns an empty list when the directory is absent."""
+    from unittest.mock import patch
+
+    with patch.object(arp_mod, "_SUITES_DIR", tmp_path):
+        results = arp_mod._load_suite_results.__wrapped__("nonexistent_suite")
+    assert results == []
+
+
+def test_load_suite_results_skips_malformed(tmp_path):
+    """_load_suite_results skips a file that is not valid JSON."""
+    from unittest.mock import patch
+
+    results_root = tmp_path / "injection" / "results" / "mas_a"
+    results_root.mkdir(parents=True)
+    (results_root / "broken.json").write_text("{bad", encoding="utf-8")
+    _write_suite_file(results_root / "ok.json", "good", "mas_a", True)
+    with patch.object(arp_mod, "_SUITES_DIR", tmp_path):
+        results = arp_mod._load_suite_results.__wrapped__("injection")
+    assert len(results) == 1
+    assert results[0]["payload_id"] == "good"
+
+
+# ---------------------------------------------------------------------------
+# Sidebar logo branch + custom paths (lines 238, 269-275)
+# ---------------------------------------------------------------------------
+
+
+def test_sidebar_renders_logo_when_present():
+    """_render_sidebar calls st.image when the logo file exists."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+import streamlit as st
+from bili.aether.ui import attack_results_page as arp
+with st.sidebar:
+    with patch.object(arp, "LOGO_PATH") as lp:
+        lp.exists.return_value = True
+        lp.__str__ = lambda self: "/fake/logo.png"
+        with patch("streamlit.image") as img:
+            arp._render_sidebar()
+            st.markdown(f"image_called:{img.called}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "image_called:True" in " ".join(m.value for m in at.sidebar.markdown)
+
+
+def test_sidebar_custom_path_valid_dir(tmp_path):
+    """_render_sidebar collects a valid custom directory path."""
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import patch
+import streamlit as st
+from bili.aether.ui import attack_results_page as arp
+st.session_state["attack_custom_paths"] = {str(tmp_path)!r}
+with st.sidebar:
+    with patch.object(arp, "LOGO_PATH") as lp:
+        lp.exists.return_value = False
+        _, extra = arp._render_sidebar()
+st.markdown(f"extra_count:{{len(extra)}}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "extra_count:1" in " ".join(m.value for m in at.markdown)
+
+
+def test_sidebar_custom_path_not_a_dir():
+    """_render_sidebar warns when a custom path is not a directory."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+import streamlit as st
+from bili.aether.ui import attack_results_page as arp
+st.session_state["attack_custom_paths"] = "/definitely/not/a/real/directory/xyz"
+with st.sidebar:
+    with patch.object(arp, "LOGO_PATH") as lp:
+        lp.exists.return_value = False
+        _, extra = arp._render_sidebar()
+st.markdown(f"extra_count:{len(extra)}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "extra_count:0" in " ".join(m.value for m in at.markdown)
+    all_warn = " ".join(w.value for w in at.sidebar.warning)
+    assert "Not a directory" in all_warn
+
+
+# ---------------------------------------------------------------------------
+# _render_main with results + custom paths (lines 334-339, 350-367)
+# ---------------------------------------------------------------------------
+
+
+def test_render_main_with_results():
+    """_render_main renders metrics, matrix, and details when results exist."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+from bili.aether.ui import attack_results_page as arp
+raw = {
+    "payload_id": "p1", "injection_type": "injection", "severity": "high",
+    "mas_id": "mas_a", "injection_phase": "pre", "attack_suite": "injection",
+    "execution": {"success": True, "duration_ms": 10, "agent_count": 1},
+    "run_metadata": {"stub_mode": True, "timestamp": "t", "tier3_score": 1},
+}
+normalised = arp._normalise(raw)
+with patch.object(arp, "_load_suite_results", return_value=[normalised]):
+    arp._render_main("Injection", [])
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "Results Matrix" in all_md
+    assert "Run Details" in all_md
+
+
+def test_render_main_all_suites_with_results():
+    """_render_main aggregates results across suites in the All Suites view."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+from bili.aether.ui import attack_results_page as arp
+raw = {
+    "payload_id": "p1", "injection_type": "injection", "severity": "high",
+    "mas_id": "mas_a", "injection_phase": "pre", "attack_suite": "injection",
+    "execution": {"success": True, "duration_ms": 10, "agent_count": 1},
+    "run_metadata": {"stub_mode": True, "timestamp": "t", "tier3_score": 1},
+}
+normalised = arp._normalise(raw)
+with patch.object(arp, "_load_suite_results", return_value=[normalised]):
+    arp._render_main("All Suites", [])
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "Results Matrix" in " ".join(m.value for m in at.markdown)
+
+
+# ---------------------------------------------------------------------------
+# _render_filters cross-model + status branches (lines 568-609)
+# ---------------------------------------------------------------------------
+
+
+def test_render_filters_cross_model_with_status_branches():
+    """_render_filters exposes model/provider filters and applies tier status."""
+    at = AppTest.from_string(
+        """
+import pandas as pd
+import streamlit as st
+from bili.aether.ui import attack_results_page as arp
+rows = [
+    {"run_id": "run_001", "payload_id": "p1", "injection_type": "injection",
+     "severity": "high", "mas_id": "mas_a", "phase": "pre",
+     "attack_suite": "cross_model", "tier1_pass": True, "tier3_score": 2,
+     "stub_mode": False, "timestamp": "t", "model_id": "gpt-4o",
+     "model_name": "GPT-4o", "provider_family": "openai",
+     "tier2_influenced": True},
+    {"run_id": "run_001", "payload_id": "p2", "injection_type": "jailbreak",
+     "severity": "low", "mas_id": "mas_b", "phase": "mid",
+     "attack_suite": "cross_model", "tier1_pass": False, "tier3_score": None,
+     "stub_mode": True, "timestamp": "t", "model_id": "claude-3",
+     "model_name": "Claude", "provider_family": "anthropic",
+     "tier2_influenced": False},
+]
+df = pd.DataFrame(rows)
+# Drive the phase selectbox and tier-3 status selectbox to exercise the
+# mask-narrowing branches (phase != All, tier3 status filter).
+st.session_state["atk_filter_phase"] = "pre"
+st.session_state["atk_filter_tier"] = "Tier-3 evaluated"
+filtered = arp._render_filters(df, "Cross-Model", is_cross_model=True)
+st.markdown(f"count:{len(filtered)}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    # Only the cross-model row with phase=pre and a tier3 score survives.
+    assert "count:1" in " ".join(m.value for m in at.markdown)
+
+
+def test_render_filters_tier2_only_status():
+    """_render_filters 'Tier-2 only (skipped)' keeps tier1-pass rows without T3."""
+    at = AppTest.from_string(
+        """
+import pandas as pd
+import streamlit as st
+from bili.aether.ui import attack_results_page as arp
+rows = [
+    {"run_id": "run_001", "payload_id": "p1", "injection_type": "injection",
+     "severity": "high", "mas_id": "mas_a", "phase": "pre",
+     "attack_suite": "injection", "tier1_pass": True, "tier3_score": None,
+     "stub_mode": True, "timestamp": "t", "model_id": None,
+     "model_name": None, "provider_family": None, "tier2_influenced": True},
+    {"run_id": "run_001", "payload_id": "p2", "injection_type": "injection",
+     "severity": "low", "mas_id": "mas_a", "phase": "pre",
+     "attack_suite": "injection", "tier1_pass": False, "tier3_score": None,
+     "stub_mode": True, "timestamp": "t", "model_id": None,
+     "model_name": None, "provider_family": None, "tier2_influenced": False},
+]
+df = pd.DataFrame(rows)
+st.session_state["atk_filter_tier"] = "Tier-2 only (skipped)"
+filtered = arp._render_filters(df, "Injection", is_cross_model=False)
+st.markdown(f"count:{len(filtered)}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "count:1" in " ".join(m.value for m in at.markdown)
+
+
+def test_render_filters_tier1_failed_status():
+    """_render_filters 'Tier-1 failed' keeps only rows where tier1 failed."""
+    at = AppTest.from_string(
+        """
+import pandas as pd
+import streamlit as st
+from bili.aether.ui import attack_results_page as arp
+rows = [
+    {"run_id": "run_001", "payload_id": "p1", "injection_type": "injection",
+     "severity": "high", "mas_id": "mas_a", "phase": "pre",
+     "attack_suite": "injection", "tier1_pass": True, "tier3_score": 1,
+     "stub_mode": True, "timestamp": "t", "model_id": None,
+     "model_name": None, "provider_family": None, "tier2_influenced": True},
+    {"run_id": "run_001", "payload_id": "p2", "injection_type": "injection",
+     "severity": "low", "mas_id": "mas_a", "phase": "pre",
+     "attack_suite": "injection", "tier1_pass": False, "tier3_score": None,
+     "stub_mode": True, "timestamp": "t", "model_id": None,
+     "model_name": None, "provider_family": None, "tier2_influenced": False},
+]
+df = pd.DataFrame(rows)
+st.session_state["atk_filter_tier"] = "Tier-1 failed"
+filtered = arp._render_filters(df, "Injection", is_cross_model=False)
+st.markdown(f"count:{len(filtered)}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "count:1" in " ".join(m.value for m in at.markdown)
+
+
+# ---------------------------------------------------------------------------
+# _render_matrix tier1-failure (!) and tier2 fallback cells (674, 683-707)
+# ---------------------------------------------------------------------------
+
+
+def test_render_matrix_tier1_failure_and_tier2_fallback():
+    """_render_matrix renders ! for tier1 failure and T2 labels as fallback."""
+    at = AppTest.from_string(
+        """
+import pandas as pd
+from bili.aether.ui import attack_results_page as arp
+rows = [
+    # Tier-1 failure -> "!" cell (line 674) with dark styling (line 702)
+    {"payload_id": "p1", "injection_type": "injection", "severity": "high",
+     "mas_id": "mas_a", "phase": "pre", "attack_suite": "injection",
+     "tier1_pass": False, "tier3_score": None, "stub_mode": True,
+     "timestamp": "t", "model_id": None, "model_name": None,
+     "provider_family": None, "tier2_influenced": False},
+    # Tier-1 pass, no T3, influenced -> T2:fail fallback (line 689, 707)
+    {"payload_id": "p2", "injection_type": "injection", "severity": "high",
+     "mas_id": "mas_a", "phase": "pre", "attack_suite": "injection",
+     "tier1_pass": True, "tier3_score": None, "stub_mode": True,
+     "timestamp": "t", "model_id": None, "model_name": None,
+     "provider_family": None, "tier2_influenced": True},
+    # Tier-1 pass, no T3, not influenced -> T2:pass fallback (line 689)
+    {"payload_id": "p3", "injection_type": "injection", "severity": "high",
+     "mas_id": "mas_a", "phase": "pre", "attack_suite": "injection",
+     "tier1_pass": True, "tier3_score": None, "stub_mode": True,
+     "timestamp": "t", "model_id": None, "model_name": None,
+     "provider_family": None, "tier2_influenced": False},
+]
+df = pd.DataFrame(rows)
+arp._render_matrix(df, is_cross_model=False)
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert len(at.dataframe) == 1
+    # The rendered matrix carries the Tier-1 failure marker and both Tier-2
+    # fallback labels even though no row has a Tier-3 score.
+    cells = at.dataframe[0].value.to_numpy().ravel().tolist()
+    assert "!" in cells
+    assert "T2:✗" in cells
+    assert "T2:✓" in cells
+
+
+def test_render_matrix_not_evaluated_dash():
+    """_render_matrix renders a dash (line 690, 704) for a not-evaluated cell."""
+    at = AppTest.from_string(
+        """
+import pandas as pd
+from bili.aether.ui import attack_results_page as arp
+# Two disjoint payload/config combos so the pivot has NaN cells. With tier1
+# missing the cell defaults to "tier1 True" then falls through to the dash
+# branch because both T3 score and T2 boolean are NaN for the empty cell.
+rows = [
+    {"payload_id": "p1", "injection_type": "injection", "severity": "high",
+     "mas_id": "mas_a", "phase": "pre", "attack_suite": "injection",
+     "tier1_pass": True, "tier3_score": 1, "stub_mode": True,
+     "timestamp": "t", "model_id": None, "model_name": None,
+     "provider_family": None, "tier2_influenced": True},
+    {"payload_id": "p2", "injection_type": "injection", "severity": "high",
+     "mas_id": "mas_b", "phase": "pre", "attack_suite": "injection",
+     "tier1_pass": True, "tier3_score": 2, "stub_mode": True,
+     "timestamp": "t", "model_id": None, "model_name": None,
+     "provider_family": None, "tier2_influenced": True},
+]
+df = pd.DataFrame(rows)
+arp._render_matrix(df, is_cross_model=False)
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert len(at.dataframe) == 1
+
+
+# ---------------------------------------------------------------------------
+# _render_view_graph_button present-config + click flow (894, 914-928)
+# ---------------------------------------------------------------------------
+
+
+def test_detail_panel_renders_view_graph_button(tmp_path):
+    """_render_detail_panel renders the View MAS graph button when config exists."""
+
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+import pandas as pd
+from unittest.mock import patch
+from pathlib import Path
+from bili.aether.ui import attack_results_page as arp
+results = [
+    {{"run_id": "run_001", "payload_id": "p1", "injection_type": "injection",
+      "severity": "high", "mas_id": "mas_a", "phase": "pre",
+      "attack_suite": "injection", "tier1_pass": True, "tier3_score": 2,
+      "tier3_confidence": "high", "tier3_reasoning": "r", "stub_mode": False,
+      "timestamp": "t", "model_id": None, "model_name": None,
+      "provider_family": None, "influenced_agents": [], "resistant_agents": [],
+      "propagation_path": [], "target_agent_id": "a0", "duration_ms": 10.0,
+      "config_path": "cfg.yaml", "injection_phase": "pre"}},
+]
+df_rows = [
+    {{"run_id": "run_001", "payload_id": "p1", "injection_type": "injection",
+      "severity": "high", "mas_id": "mas_a", "phase": "pre",
+      "attack_suite": "injection", "tier1_pass": True, "tier3_score": 2,
+      "stub_mode": False, "timestamp": "t", "model_id": None,
+      "model_name": None, "provider_family": None, "tier2_influenced": False}},
+]
+df = pd.DataFrame(df_rows)
+with patch.object(arp, "_REPO_ROOT", Path({str(tmp_path)!r})):
+    arp._render_detail_panel(results, df, is_cross_model=False)
+"""
+    )
+    at.run()
+    assert not at.exception
+    labels = [b.label for b in at.button]
+    assert any("View MAS graph" in label for label in labels)
+
+
+def test_view_graph_button_click_loads_config(tmp_path):
+    """Clicking View MAS graph loads the config and triggers page navigation."""
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+from bili.aether.ui import attack_results_page as arp
+import bili.aether.config.loader as loader_mod
+
+with patch.object(arp, "_REPO_ROOT", Path({str(tmp_path)!r})):
+    with patch.object(loader_mod, "load_mas_from_yaml",
+                      return_value=MagicMock(name="loaded_config")):
+        arp._render_view_graph_button("cfg.yaml", "mas_a", "p1", "pre", "run_001")
+"""
+    )
+    at.run()
+    # Click the rendered button, then re-run to execute the click handler.
+    assert not at.exception
+    assert len(at.button) == 1
+    at.button[0].click().run()
+    assert not at.exception
+    assert at.session_state["aether_page"] == "Visualizer"
+
+
+def test_view_graph_button_click_handles_load_error(tmp_path):
+    """Clicking View MAS graph surfaces an error if config loading fails."""
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import patch
+from pathlib import Path
+from bili.aether.ui import attack_results_page as arp
+import bili.aether.config.loader as loader_mod
+
+with patch.object(arp, "_REPO_ROOT", Path({str(tmp_path)!r})):
+    with patch.object(loader_mod, "load_mas_from_yaml",
+                      side_effect=ValueError("bad config")):
+        arp._render_view_graph_button("cfg.yaml", "mas_a", "p1", "pre", "run_001")
+"""
+    )
+    at.run()
+    assert not at.exception
+    at.button[0].click().run()
+    assert not at.exception
+    assert "Could not load config" in " ".join(e.value for e in at.error)
+
+
+def test_render_main_custom_paths(tmp_path):
+    """_render_main loads results from custom override paths."""
+    import json
+
+    custom = tmp_path / "custom"
+    custom.mkdir()
+    (custom / "r1.json").write_text(
+        json.dumps(
+            {
+                "payload_id": "px",
+                "injection_type": "injection",
+                "severity": "high",
+                "mas_id": "mas_x",
+                "injection_phase": "pre",
+                "attack_suite": "injection",
+                "execution": {"success": True, "duration_ms": 5, "agent_count": 1},
+                "run_metadata": {"stub_mode": True, "timestamp": "t"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    # A malformed file in the same dir exercises the parse-error branch.
+    (custom / "bad.json").write_text("{nope", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from pathlib import Path
+from unittest.mock import patch
+from bili.aether.ui import attack_results_page as arp
+with patch.object(arp, "_load_suite_results", return_value=[]):
+    arp._render_main("Injection", [Path({str(custom)!r})])
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "Results Matrix" in " ".join(m.value for m in at.markdown)

--- a/bili/aether/ui/tests/test_baseline_runner_page.py
+++ b/bili/aether/ui/tests/test_baseline_runner_page.py
@@ -282,3 +282,319 @@ def test_category_constants_exist():
     assert "violating" in brp_mod._CATEGORY_ORDER
     assert "edge_case" in brp_mod._CATEGORY_ORDER
     assert len(brp_mod._CATEGORY_LABELS) >= 3
+
+
+# ---------------------------------------------------------------------------
+# _on_cat_header_change and _set_cat_prompts (lines 81-83, 88-89)
+# ---------------------------------------------------------------------------
+
+
+def test_on_cat_header_change_propagates():
+    """_on_cat_header_change pushes the header value to all child prompt keys."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.aether.ui import baseline_runner_page as brp
+st.session_state["hdr"] = False
+st.session_state["baseline_prompt_p1"] = True
+st.session_state["baseline_prompt_p2"] = True
+brp._on_cat_header_change("hdr", ["p1", "p2"])
+st.markdown(f"p1:{st.session_state['baseline_prompt_p1']}")
+st.markdown(f"p2:{st.session_state['baseline_prompt_p2']}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "p1:False" in all_md
+    assert "p2:False" in all_md
+
+
+def test_set_cat_prompts_sets_all():
+    """_set_cat_prompts writes the value to every prompt key in the category."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.aether.ui import baseline_runner_page as brp
+brp._set_cat_prompts(["x1", "x2"], True)
+st.markdown(f"x1:{st.session_state['baseline_prompt_x1']}")
+st.markdown(f"x2:{st.session_state['baseline_prompt_x2']}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "x1:True" in all_md
+    assert "x2:True" in all_md
+
+
+# ---------------------------------------------------------------------------
+# Sidebar logo branch (line 115)
+# ---------------------------------------------------------------------------
+
+
+def test_sidebar_renders_logo_when_present():
+    """_render_sidebar calls st.image when the logo file exists."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+import streamlit as st
+from bili.aether.ui import baseline_runner_page as brp
+with st.sidebar:
+    with patch.object(brp, "LOGO_PATH") as lp:
+        lp.exists.return_value = True
+        lp.__str__ = lambda self: "/fake/logo.png"
+        with patch("streamlit.image") as img:
+            brp._render_sidebar()
+            st.markdown(f"image_called:{img.called}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "image_called:True" in " ".join(m.value for m in at.sidebar.markdown)
+
+
+# ---------------------------------------------------------------------------
+# _render_main partial-selection caption (line 179) + stub caption (254)
+# ---------------------------------------------------------------------------
+
+
+def test_main_partial_selection_caption():
+    """_render_main shows 'n of total' caption when not all prompts selected."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from unittest.mock import patch
+from bili.aether.ui import baseline_runner_page as brp
+from bili.aether.ui.tests.conftest import make_test_config as mk
+from bili.aegis.suites.baseline.prompts.baseline_prompts import BASELINE_PROMPTS
+cfg = mk(mas_id="partial_test")
+st.session_state.baseline_config = cfg
+st.session_state.baseline_yaml_path = "/fake/test.yaml"
+# Deselect the first prompt so the selection is partial.
+st.session_state[f"baseline_prompt_{BASELINE_PROMPTS[0].prompt_id}"] = False
+with patch.object(brp, "EXAMPLES_DIR") as ed:
+    ed.exists.return_value = False
+    brp._render_main()
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_caps = " ".join(c.value for c in at.caption)
+    assert "of" in all_caps and "prompts selected" in all_caps
+
+
+def test_prompt_selector_stub_caption():
+    """_render_prompt_selector shows 'No LLM calls' caption when stub toggled on."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.aether.ui import baseline_runner_page as brp
+st.session_state["baseline_stub_mode"] = True
+stub = brp._render_prompt_selector()
+st.markdown(f"stub:{stub}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "stub:True" in " ".join(m.value for m in at.markdown)
+    assert "No LLM calls" in " ".join(c.value for c in at.caption)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_config file-selected branch (lines 215-227)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_config_loads_selected_yaml(tmp_path):
+    """_resolve_config loads the chosen YAML and stores it in session state."""
+    (tmp_path / "demo_config.yaml").write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+import streamlit as st
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+from bili.aether.ui import baseline_runner_page as brp
+import bili.aether.config.loader as loader_mod
+fake_cfg = MagicMock()
+st.session_state["baseline_yaml_selector"] = 1
+with patch.object(brp, "EXAMPLES_DIR", Path({str(tmp_path)!r})):
+    with patch.object(loader_mod, "load_mas_from_yaml", return_value=fake_cfg):
+        config, path = brp._resolve_config()
+st.markdown(f"loaded:{{config is not None}}")
+st.markdown(f"has_path:{{path.endswith('demo_config.yaml')}}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "loaded:True" in all_md
+    assert "has_path:True" in all_md
+
+
+def test_resolve_config_load_error(tmp_path):
+    """_resolve_config surfaces an error and returns (None, None) on load failure."""
+    (tmp_path / "broken_config.yaml").write_text("bad", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+import streamlit as st
+from unittest.mock import patch
+from pathlib import Path
+from bili.aether.ui import baseline_runner_page as brp
+import bili.aether.config.loader as loader_mod
+st.session_state["baseline_yaml_selector"] = 1
+with patch.object(brp, "EXAMPLES_DIR", Path({str(tmp_path)!r})):
+    with patch.object(loader_mod, "load_mas_from_yaml",
+                      side_effect=ValueError("bad yaml")):
+        config, path = brp._resolve_config()
+st.markdown(f"none:{{config is None and path is None}}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "none:True" in " ".join(m.value for m in at.markdown)
+    assert "Failed to load" in " ".join(e.value for e in at.error)
+
+
+# ---------------------------------------------------------------------------
+# _execute_run (lines 326-398) + run-button click (line 188)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_run_no_prompts_selected(tmp_path):
+    """_execute_run warns when every prompt is deselected."""
+    at = AppTest.from_string(
+        f"""
+import streamlit as st
+from unittest.mock import patch
+from pathlib import Path
+from bili.aether.ui import baseline_runner_page as brp
+from bili.aether.ui.tests.conftest import make_test_config as mk
+from bili.aegis.suites.baseline.prompts.baseline_prompts import BASELINE_PROMPTS
+cfg = mk(mas_id="no_prompts")
+for p in BASELINE_PROMPTS:
+    st.session_state[f"baseline_prompt_{{p.prompt_id}}"] = False
+with patch.object(brp, "_BASELINE_RESULTS_DIR", Path({str(tmp_path)!r})):
+    brp._execute_run(cfg, "/fake/path.yaml", stub_mode=True)
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "No prompts selected" in " ".join(w.value for w in at.warning)
+
+
+def test_execute_run_writes_results(tmp_path):
+    """_execute_run runs selected prompts, writes results, and shows progress."""
+    import sys
+    import types
+    from unittest.mock import MagicMock, patch
+
+    # Stub the heavy run_baseline + helpers imports done inside _execute_run.
+    runner_mod = types.ModuleType("bili.aegis.suites.baseline.run_baseline")
+    runner_mod.run_one = MagicMock(
+        return_value={
+            "execution": {"success": True, "duration_ms": 12.0},
+        }
+    )
+    runner_mod.write_result = MagicMock()
+    helpers_mod = types.ModuleType("bili.aegis.suites._helpers")
+    helpers_mod.next_run_dir = MagicMock(return_value=tmp_path / "run_001")
+    with patch.dict(
+        sys.modules,
+        {
+            "bili.aegis.suites.baseline.run_baseline": runner_mod,
+            "bili.aegis.suites._helpers": helpers_mod,
+        },
+    ):
+        at = AppTest.from_string(
+            f"""
+import streamlit as st
+from unittest.mock import patch
+from pathlib import Path
+from bili.aether.ui import baseline_runner_page as brp
+from bili.aether.ui.tests.conftest import make_test_config as mk
+from bili.aegis.suites.baseline.prompts.baseline_prompts import BASELINE_PROMPTS
+cfg = mk(mas_id="exec_test", model_name="gpt-4o")
+# Select only the first prompt so the run is small and deterministic.
+for p in BASELINE_PROMPTS:
+    st.session_state[f"baseline_prompt_{{p.prompt_id}}"] = False
+st.session_state[f"baseline_prompt_{{BASELINE_PROMPTS[0].prompt_id}}"] = True
+with patch.object(brp, "_BASELINE_RESULTS_DIR", Path({str(tmp_path)!r})):
+    brp._execute_run(cfg, "/fake/path.yaml", stub_mode=False)
+st.markdown(f"stored:{{'baseline_run_results' in st.session_state}}")
+"""
+        )
+        at.run()
+    assert not at.exception
+    assert runner_mod.run_one.called
+    assert runner_mod.write_result.called
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "stored:True" in all_md
+    assert "All 1 prompts passed" in " ".join(s.value for s in at.success)
+
+
+def test_execute_run_handles_prompt_failure(tmp_path):
+    """_execute_run records a failed prompt and shows the failure warning."""
+    import sys
+    import types
+    from unittest.mock import MagicMock, patch
+
+    runner_mod = types.ModuleType("bili.aegis.suites.baseline.run_baseline")
+    runner_mod.run_one = MagicMock(side_effect=RuntimeError("run blew up"))
+    runner_mod.write_result = MagicMock()
+    helpers_mod = types.ModuleType("bili.aegis.suites._helpers")
+    helpers_mod.next_run_dir = MagicMock(return_value=tmp_path / "run_002")
+    with patch.dict(
+        sys.modules,
+        {
+            "bili.aegis.suites.baseline.run_baseline": runner_mod,
+            "bili.aegis.suites._helpers": helpers_mod,
+        },
+    ):
+        at = AppTest.from_string(
+            f"""
+import streamlit as st
+from unittest.mock import patch
+from pathlib import Path
+from bili.aether.ui import baseline_runner_page as brp
+from bili.aether.ui.tests.conftest import make_test_config as mk
+from bili.aegis.suites.baseline.prompts.baseline_prompts import BASELINE_PROMPTS
+cfg = mk(mas_id="fail_test")
+for p in BASELINE_PROMPTS:
+    st.session_state[f"baseline_prompt_{{p.prompt_id}}"] = False
+st.session_state[f"baseline_prompt_{{BASELINE_PROMPTS[0].prompt_id}}"] = True
+with patch.object(brp, "_BASELINE_RESULTS_DIR", Path({str(tmp_path)!r})):
+    brp._execute_run(cfg, "/fake/path.yaml", stub_mode=True)
+"""
+        )
+        at.run()
+    assert not at.exception
+    assert runner_mod.run_one.called
+    assert "0/1 passed" in " ".join(w.value for w in at.warning)
+
+
+def test_main_run_button_click_invokes_execute(tmp_path):
+    """Clicking the Run Baseline button invokes _execute_run."""
+    at = AppTest.from_string(
+        f"""
+import streamlit as st
+from unittest.mock import patch
+from pathlib import Path
+from bili.aether.ui import baseline_runner_page as brp
+from bili.aether.ui.tests.conftest import make_test_config as mk
+cfg = mk(mas_id="click_run")
+st.session_state.baseline_config = cfg
+st.session_state.baseline_yaml_path = "/fake/test.yaml"
+with patch.object(brp, "EXAMPLES_DIR") as ed:
+    ed.exists.return_value = False
+    with patch.object(brp, "_execute_run") as run:
+        brp._render_main()
+        st.session_state["__exec_mock"] = run
+"""
+    )
+    at.run()
+    assert not at.exception
+    run_buttons = [b for b in at.button if "Run Baseline" in b.label]
+    assert run_buttons
+    run_buttons[0].click().run()
+    assert not at.exception

--- a/bili/aether/ui/tests/test_chat_app.py
+++ b/bili/aether/ui/tests/test_chat_app.py
@@ -4745,3 +4745,1142 @@ with _patch.dict("sys.modules", fm):
     )
     at.run()
     assert not at.exception
+
+
+# ===========================================================================
+# Coverage expansion batch 2
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# streamlit-flow ImportError fallback (lines 58-60)
+# ---------------------------------------------------------------------------
+
+
+def test_flow_unavailable_sets_flag_false():
+    """Executing chat_app source without streamlit-flow sets _FLOW_AVAILABLE False.
+
+    The module's transitive dependencies are already imported and cached, so
+    re-executing the source resolves the ``bili.*`` imports from cache and only
+    the ``streamlit_flow`` import fails, exercising the ImportError fallback.
+    """
+    at = AppTest.from_string(
+        """
+from pathlib import Path
+from unittest.mock import patch as _patch
+import streamlit as st
+import bili.aether.ui.chat_app as real_ca
+
+src = Path(real_ca.__file__).read_text(encoding="utf-8")
+ns = {"__name__": "chat_app_noflow", "__file__": real_ca.__file__}
+fm = {"streamlit_flow": None, "streamlit_flow.state": None}
+with _patch.dict("sys.modules", fm):
+    exec(compile(src, real_ca.__file__, "exec"), ns)
+st.markdown(f"flow_available:{ns['_FLOW_AVAILABLE']}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "flow_available:False" in " ".join(m.value for m in at.markdown)
+
+
+# ---------------------------------------------------------------------------
+# _apply_model_patch validation-failure early return (line 127)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_model_patch_invalid_returns_early():
+    """_apply_model_patch returns early without reinit when validation fails."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    cfg = mk(mas_id="invalid_patch")
+    with _patch.object(ca, "_validate_config", return_value=False):
+        with _patch.object(ca, "_initialize_executor") as init:
+            ca._apply_model_patch(cfg, "gpt-4o")
+            st.markdown(f"init_called:{init.called}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "init_called:False" in " ".join(m.value for m in at.markdown)
+
+
+# ---------------------------------------------------------------------------
+# _load_all_model_options (lines 318-331)
+# ---------------------------------------------------------------------------
+
+
+def test_load_all_model_options_builds_lists():
+    """_load_all_model_options flattens LLM_MODELS into display/id/provider lists."""
+    with patch.dict("sys.modules", _FM):
+        from bili.aether.ui import chat_app as ca
+
+        fake_models = {
+            "remote_openai": {
+                "name": "OpenAI",
+                "models": [
+                    {"model_name": "GPT-4o", "model_id": "gpt-4o"},
+                    {"model_name": "GPT-4o mini", "model_id": "gpt-4o-mini"},
+                ],
+            },
+        }
+        import sys
+        import types
+
+        fake_cfg = types.ModuleType("bili.iris.config.llm_config")
+        fake_cfg.LLM_MODELS = fake_models
+        with patch.dict(sys.modules, {"bili.iris.config.llm_config": fake_cfg}):
+            display, ids, providers = ca._load_all_model_options.__wrapped__()
+    assert display == ["[OpenAI] GPT-4o", "[OpenAI] GPT-4o mini"]
+    assert ids == ["gpt-4o", "gpt-4o-mini"]
+    assert providers == ["remote_openai", "remote_openai"]
+
+
+# ---------------------------------------------------------------------------
+# _render_sidebar logo branch (line 550)
+# ---------------------------------------------------------------------------
+
+
+def test_render_sidebar_renders_logo_when_present():
+    """_render_sidebar calls st.image when the logo file exists."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    with _patch.object(ca, "LOGO_PATH") as lp:
+        lp.exists.return_value = True
+        lp.__str__ = lambda self: "/fake/logo.png"
+        with _patch("streamlit.image") as img:
+            with _patch.object(ca, "render_sidebar_content"):
+                ca._render_sidebar()
+                st.markdown(f"image_called:{img.called}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "image_called:True" in " ".join(m.value for m in at.markdown)
+
+
+# ---------------------------------------------------------------------------
+# _render_supervisor_diagram fallback paths (lines 879-884)
+# ---------------------------------------------------------------------------
+
+
+def test_render_supervisor_diagram_no_entry_agent_empty():
+    """_render_supervisor_diagram falls back to sequential when no coordinator."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    cfg = _Mock()
+    cfg.agents = []
+    cfg.get_entry_agent.side_effect = ValueError("no entry")
+    ca._render_supervisor_diagram(cfg)
+    st.markdown("done:True")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "done:True" in " ".join(m.value for m in at.markdown)
+
+
+def test_render_supervisor_diagram_entry_error_falls_back_to_first():
+    """_render_supervisor_diagram uses the first agent when get_entry_agent raises."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    # Use plain Mock agents so get_entry_agent raising does not collide with
+    # pydantic attribute teardown semantics.
+    lead = _Mock()
+    lead.agent_id = "lead"
+    lead.role = "lead"
+    worker = _Mock()
+    worker.agent_id = "w1"
+    worker.role = "worker"
+    cfg = _Mock()
+    cfg.agents = [lead, worker]
+    cfg.get_entry_agent.side_effect = ValueError("boom")
+    ca._render_supervisor_diagram(cfg)
+"""
+    )
+    at.run()
+    assert not at.exception
+
+
+# ---------------------------------------------------------------------------
+# _render_thread_list filter + rename/select/edit/delete clicks
+# (lines 230, 250-256, 267-270, 273-274, 277-278)
+# ---------------------------------------------------------------------------
+
+
+def test_render_thread_list_filter_matches():
+    """_render_thread_list applies the text filter to thread names."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    ca._new_thread("alpha_mas")
+    ca._new_thread("beta_mas")
+    st.session_state["chat_thread_filter"] = "alpha"
+    ca._render_thread_list()
+"""
+    )
+    at.run()
+    assert not at.exception
+    # The filter keeps only the matching thread button (plus its edit/delete).
+    labels = [b.label for b in at.button]
+    assert any("alpha_mas" in lbl for lbl in labels)
+    assert not any("beta_mas" in lbl for lbl in labels)
+
+
+def _seed_thread_script(body: str) -> str:
+    """Return an AppTest script that seeds two fixed threads then runs *body*.
+
+    Threads use deterministic IDs (t1 active, t2 older) so button widget keys
+    stay stable across the click-triggered rerun.
+    """
+    return (
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    st.session_state["chat_threads"] = {
+        "t1": {"name": "first_thread", "messages": [], "mas_id": "m",
+               "created_at": 2.0},
+        "t2": {"name": "second_thread", "messages": [], "mas_id": "m",
+               "created_at": 1.0},
+    }
+    st.session_state["chat_thread_id"] = "t1"
+    with _patch.object(ca.st, "rerun"):
+"""
+        + body
+    )
+
+
+def test_render_thread_list_rename_confirm():
+    """Confirming a rename writes the new name and exits editing mode."""
+    at = AppTest.from_string(
+        _seed_thread_script(
+            """        st.session_state["chat_editing_thread"] = "t1"
+        st.session_state["chat_rename_input_t1"] = "Renamed Thread"
+        ca._render_thread_list()
+"""
+        )
+    )
+    at.run()
+    assert not at.exception
+    confirm_buttons = [b for b in at.button if b.label == "✓"]
+    assert confirm_buttons
+    confirm_buttons[0].click().run()
+    assert not at.exception
+    assert at.session_state["chat_threads"]["t1"]["name"] == "Renamed Thread"
+    assert "chat_editing_thread" not in at.session_state
+
+
+def test_render_thread_list_rename_cancel():
+    """Cancelling a rename leaves the name unchanged and exits editing mode."""
+    at = AppTest.from_string(
+        _seed_thread_script(
+            """        st.session_state["chat_editing_thread"] = "t1"
+        ca._render_thread_list()
+"""
+        )
+    )
+    at.run()
+    assert not at.exception
+    cancel_buttons = [b for b in at.button if b.label == "✕"]
+    assert cancel_buttons
+    cancel_buttons[0].click().run()
+    assert not at.exception
+    assert at.session_state["chat_threads"]["t1"]["name"] == "first_thread"
+    assert "chat_editing_thread" not in at.session_state
+
+
+def test_render_thread_list_select_thread_click():
+    """Clicking a non-active thread button switches the active thread."""
+    at = AppTest.from_string(
+        _seed_thread_script(
+            """        ca._render_thread_list()
+"""
+        )
+    )
+    at.run()
+    assert not at.exception
+    select_buttons = [b for b in at.button if b.label == "second_thread"]
+    assert select_buttons
+    select_buttons[0].click().run()
+    assert not at.exception
+    assert at.session_state["chat_thread_id"] == "t2"
+
+
+def test_render_thread_list_edit_click_enters_editing():
+    """Clicking the pencil button puts the thread into editing mode."""
+    at = AppTest.from_string(
+        _seed_thread_script(
+            """        ca._render_thread_list()
+"""
+        )
+    )
+    at.run()
+    assert not at.exception
+    edit_buttons = [b for b in at.button if b.label == "✏️"]
+    assert edit_buttons
+    edit_buttons[0].click().run()
+    assert not at.exception
+    assert at.session_state["chat_editing_thread"] in ("t1", "t2")
+
+
+def test_render_thread_list_delete_click_removes_thread():
+    """Clicking the trash button deletes the thread from session state."""
+    at = AppTest.from_string(
+        _seed_thread_script(
+            """        ca._render_thread_list()
+"""
+        )
+    )
+    at.run()
+    assert not at.exception
+    delete_buttons = [b for b in at.button if b.label == "\U0001f5d1️"]
+    assert delete_buttons
+    before = len(at.session_state["chat_threads"])
+    delete_buttons[0].click().run()
+    assert not at.exception
+    assert len(at.session_state["chat_threads"]) == before - 1
+
+
+# ===========================================================================
+# Coverage expansion batch 3: render_sidebar_content full flow
+# ===========================================================================
+
+
+def test_sidebar_content_full_flow_with_loaded_config(tmp_path):
+    """render_sidebar_content renders model picker, export, and send buttons.
+
+    Drives the lower half of the sidebar by selecting the first YAML config and
+    seeding chat_config + a thread with history so the export buttons appear.
+    """
+    (tmp_path / "demo_config.yaml").write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+from pathlib import Path
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {{
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    cfg = mk(mas_id="sidebar_full")
+    # Pre-load config + a thread with one message so export buttons render.
+    st.session_state.chat_config = cfg
+    st.session_state.chat_config_base = cfg
+    st.session_state["chat_threads"] = {{
+        "t1": {{"name": "t1", "messages": [
+            {{"content": "hi", "agent_trace": []}}
+        ], "mas_id": "sidebar_full", "created_at": 1.0}},
+    }}
+    st.session_state["chat_thread_id"] = "t1"
+    # Pre-select the first config so the selectbox resolves to a file.
+    st.session_state["chat_yaml_selector"] = 0
+    with _patch.object(ca, "_load_config"):
+        with _patch.object(
+            ca, "_build_chat_model_options",
+            return_value=(["[OpenAI] gpt-4o"], ["gpt-4o"]),
+        ):
+            ca.render_sidebar_content(examples_dir=Path({str(tmp_path)!r}))
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "sidebar_full" in all_md
+    assert "Model Settings" in all_md
+    button_labels = [b.label for b in at.button]
+    assert any("New Conversation" in lbl for lbl in button_labels)
+    # The Send to Attack Suite button confirms the lower sidebar block ran.
+    assert any("Send to Attack" in lbl for lbl in button_labels)
+
+
+def test_sidebar_content_apply_model_button(tmp_path):
+    """Clicking 'Apply to all' invokes _apply_model_patch with the chosen model."""
+    (tmp_path / "demo_config.yaml").write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+from pathlib import Path
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {{
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    cfg = mk(mas_id="apply_btn")
+    st.session_state.chat_config = cfg
+    st.session_state.chat_config_base = cfg
+    st.session_state["chat_yaml_selector"] = 0
+    st.session_state["chat_model_selector"] = 0
+    with _patch.object(ca, "_load_config"):
+        with _patch.object(
+            ca, "_build_chat_model_options",
+            return_value=(["[OpenAI] gpt-4o"], ["gpt-4o"]),
+        ):
+            with _patch.object(ca, "_apply_model_patch") as patch_fn:
+                ca.render_sidebar_content(examples_dir=Path({str(tmp_path)!r}))
+                st.session_state["__patch_fn"] = patch_fn
+"""
+    )
+    at.run()
+    assert not at.exception
+    apply_buttons = [b for b in at.button if b.label == "Apply to all"]
+    assert apply_buttons
+    apply_buttons[0].click().run()
+    assert not at.exception
+
+
+def test_sidebar_content_stub_button(tmp_path):
+    """Clicking 'Stub mode' invokes _apply_model_patch with None."""
+    (tmp_path / "demo_config.yaml").write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+from pathlib import Path
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {{
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    cfg = mk(mas_id="stub_btn", model_name="gpt-4o")
+    st.session_state.chat_config = cfg
+    st.session_state.chat_config_base = cfg
+    st.session_state["chat_yaml_selector"] = 0
+    with _patch.object(ca, "_load_config"):
+        with _patch.object(
+            ca, "_build_chat_model_options",
+            return_value=(["[OpenAI] gpt-4o"], ["gpt-4o"]),
+        ):
+            with _patch.object(ca, "_apply_model_patch") as patch_fn:
+                ca.render_sidebar_content(examples_dir=Path({str(tmp_path)!r}))
+                st.session_state["__stub_patch_fn"] = patch_fn
+"""
+    )
+    at.run()
+    assert not at.exception
+    stub_buttons = [b for b in at.button if b.label == "Stub mode"]
+    assert stub_buttons
+    stub_buttons[0].click().run()
+    assert not at.exception
+
+
+def test_sidebar_content_new_conversation_button(tmp_path):
+    """Clicking 'New Conversation' creates a new thread."""
+    (tmp_path / "demo_config.yaml").write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+from pathlib import Path
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {{
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    cfg = mk(mas_id="new_conv")
+    st.session_state.chat_config = cfg
+    st.session_state.chat_config_base = cfg
+    st.session_state["chat_yaml_selector"] = 0
+    with _patch.object(ca, "_load_config"):
+        with _patch.object(
+            ca, "_build_chat_model_options",
+            return_value=(["[OpenAI] gpt-4o"], ["gpt-4o"]),
+        ):
+            with _patch.object(ca.st, "rerun"):
+                ca.render_sidebar_content(examples_dir=Path({str(tmp_path)!r}))
+"""
+    )
+    at.run()
+    assert not at.exception
+    nc_buttons = [b for b in at.button if "New Conversation" in b.label]
+    assert nc_buttons
+
+
+def test_sidebar_content_autoload_uploaded_config(tmp_path):
+    """render_sidebar_content autoloads a pending uploaded config."""
+    (tmp_path / "demo_config.yaml").write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+from pathlib import Path
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {{
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    pending = mk(mas_id="autoloaded")
+    st.session_state["chat_uploaded_configs"] = {{"up.yaml": pending}}
+    st.session_state["chat_autoload_name"] = "up.yaml"
+    with _patch.object(ca, "_load_uploaded_config") as loader:
+        ca.render_sidebar_content(examples_dir=Path({str(tmp_path)!r}))
+        st.markdown(f"autoload_called:{{loader.called}}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "autoload_called:True" in " ".join(m.value for m in at.markdown)
+
+
+def test_sidebar_content_selects_uploaded_config(tmp_path):
+    """render_sidebar_content loads an uploaded config selected in the selectbox."""
+    (tmp_path / "demo_config.yaml").write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+from pathlib import Path
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {{
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    up = mk(mas_id="picked_upload")
+    st.session_state["chat_uploaded_configs"] = {{"up.yaml": up}}
+    # Index 1 = the uploaded config (index 0 is the single example file).
+    st.session_state["chat_yaml_selector"] = 1
+    with _patch.object(ca, "_load_uploaded_config") as loader:
+        ca.render_sidebar_content(examples_dir=Path({str(tmp_path)!r}))
+        st.markdown(f"upload_loaded:{{loader.called}}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "upload_loaded:True" in " ".join(m.value for m in at.markdown)
+
+
+# ===========================================================================
+# Coverage expansion batch 4
+# ===========================================================================
+
+
+def test_sidebar_content_upload_success(tmp_path):
+    """render_sidebar_content parses and registers a valid uploaded YAML file."""
+
+    (tmp_path / "demo_config.yaml").write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+from pathlib import Path
+import io
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {{
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    cfg = mk(mas_id="uploaded_cfg")
+    # Fake uploaded file object returned by st.file_uploader.
+    fake_upload = _Mock()
+    fake_upload.name = "new_upload.yaml"
+    fake_upload.read.return_value = b"mas_id: uploaded_cfg"
+    with _patch.object(ca.st, "file_uploader", return_value=fake_upload):
+        with _patch.object(ca.yaml, "safe_load", return_value={{"mas_id": "u"}}):
+            with _patch.object(ca, "load_mas_from_dict", return_value=cfg):
+                with _patch.object(ca, "compile_mas"):
+                    with _patch.object(ca.st, "rerun"):
+                        ca.render_sidebar_content(
+                            examples_dir=Path({str(tmp_path)!r})
+                        )
+    registered = "new_upload.yaml" in st.session_state.get(
+        "chat_uploaded_configs", {{}}
+    )
+    st.markdown(f"registered:{{registered}}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "registered:True" in " ".join(m.value for m in at.markdown)
+
+
+def test_sidebar_content_upload_invalid_top_level(tmp_path):
+    """render_sidebar_content errors when uploaded YAML is not a mapping."""
+    (tmp_path / "demo_config.yaml").write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+from pathlib import Path
+import streamlit as st
+fm = {{
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    fake_upload = _Mock()
+    fake_upload.name = "bad_upload.yaml"
+    fake_upload.read.return_value = b"- just\\n- a\\n- list"
+    with _patch.object(ca.st, "file_uploader", return_value=fake_upload):
+        with _patch.object(ca.yaml, "safe_load", return_value=["a", "b"]):
+            ca.render_sidebar_content(examples_dir=Path({str(tmp_path)!r}))
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "must be a mapping" in " ".join(e.value for e in at.error)
+
+
+def test_sidebar_content_upload_parse_error(tmp_path):
+    """render_sidebar_content surfaces an error when compile_mas fails on upload."""
+    (tmp_path / "demo_config.yaml").write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+from pathlib import Path
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {{
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    cfg = mk()
+    fake_upload = _Mock()
+    fake_upload.name = "broken_upload.yaml"
+    fake_upload.read.return_value = b"mas_id: x"
+    with _patch.object(ca.st, "file_uploader", return_value=fake_upload):
+        with _patch.object(ca.yaml, "safe_load", return_value={{"mas_id": "x"}}):
+            with _patch.object(ca, "load_mas_from_dict", return_value=cfg):
+                with _patch.object(
+                    ca, "compile_mas", side_effect=ValueError("circular edge")
+                ):
+                    ca.render_sidebar_content(
+                        examples_dir=Path({str(tmp_path)!r})
+                    )
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "Invalid config" in " ".join(e.value for e in at.error)
+
+
+def test_sidebar_content_apply_invalid_model_index(tmp_path):
+    """Clicking Apply with an out-of-range model index shows an error."""
+    (tmp_path / "demo_config.yaml").write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+from pathlib import Path
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {{
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    cfg = mk(mas_id="bad_idx")
+    st.session_state.chat_config = cfg
+    st.session_state.chat_config_base = cfg
+    st.session_state["chat_yaml_selector"] = 0
+    # display has one option (selectbox index 0 is valid) but the id list is
+    # empty, so the Apply handler's bounds check (idx >= len(id_opts)) fails.
+    with _patch.object(ca, "_load_config"):
+        with _patch.object(
+            ca, "_build_chat_model_options",
+            return_value=(["[OpenAI] gpt-4o"], []),
+        ):
+            ca.render_sidebar_content(examples_dir=Path({str(tmp_path)!r}))
+"""
+    )
+    at.run()
+    assert not at.exception
+    apply_buttons = [b for b in at.button if b.label == "Apply to all"]
+    assert apply_buttons
+    apply_buttons[0].click().run()
+    assert not at.exception
+    assert "Invalid model selection" in " ".join(e.value for e in at.error)
+
+
+def test_render_stored_turn_error_with_trace_divider():
+    """_render_stored_turn renders a divider when a turn has both error and trace."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    cfg = mk()
+    st.session_state.chat_config = cfg
+    turn = {
+        "content": "Partial then failed",
+        "turn_index": 0,
+        "error": "downstream node failed",
+        "agent_trace": [
+            {"agent_id": "agent_0",
+             "output": {"agent_outputs": {"agent_0": {"message": "partial"}}}},
+        ],
+    }
+    ca._render_stored_turn(turn)
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "downstream node failed" in " ".join(e.value for e in at.error)
+
+
+def test_render_timeline_completed_button_click():
+    """Clicking a completed timeline chip stores the (turn, agent) selection."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    ph = st.empty()
+    with _patch.object(ca.st, "rerun"):
+        ca._render_timeline(
+            ph,
+            completed=["agent_0"],
+            active=None,
+            all_nodes=["agent_0", "agent_1"],
+            key_prefix="tl_click",
+            turn_index=3,
+        )
+"""
+    )
+    at.run()
+    assert not at.exception
+    completed_buttons = [b for b in at.button if b.label == "✓ agent_0"]
+    assert completed_buttons
+    completed_buttons[0].click().run()
+    assert not at.exception
+    assert at.session_state["aether_selected_trace_node"] == (3, "agent_0")
+
+
+def test_run_turn_agent_panel_render_error():
+    """_run_turn shows a per-agent error when _render_agent_panel raises."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    cfg = mk(mas_id="render_err_turn")
+    st.session_state.chat_config = cfg
+    ca._new_thread("render_err_turn")
+    mock_exec = _Mock()
+    events = [
+        ("__node_complete__", {
+            "node": "agent_0",
+            "state_update": {"agent_outputs": {"agent_0": {"message": "ok"}}},
+        }),
+    ]
+    mock_exec.run_streaming_tokens.return_value = iter(events)
+    st.session_state.chat_executor = mock_exec
+    with _patch.object(ca, "_render_agent_panel", side_effect=RuntimeError("boom")):
+        with _patch.object(ca.st, "rerun"):
+            ca._run_turn("trigger render error")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "failed to render" in " ".join(e.value for e in at.error)
+
+
+def test_chat_area_chat_input_runs_turn():
+    """_render_chat_area dispatches a submitted chat message to _run_turn."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    cfg = mk(mas_id="chat_input_test")
+    st.session_state.chat_config = cfg
+    st.session_state.chat_executor = _Mock()
+    with _patch.object(ca, "_render_mas_structure"):
+        with _patch.object(ca, "_run_turn") as run_turn:
+            ca._render_chat_area()
+            st.session_state["__run_turn_fn"] = run_turn
+"""
+    )
+    at.run()
+    assert not at.exception
+    # Submit a message through the chat input, then assert no error on the rerun.
+    at.chat_input[0].set_value("Hello there").run()
+    assert not at.exception
+
+
+# ===========================================================================
+# Coverage expansion batch 5: New Conversation click, flow graph, HITL resume
+# ===========================================================================
+
+
+def test_sidebar_content_new_conversation_click_creates_thread(tmp_path):
+    """Clicking 'New Conversation' creates a fresh thread and clears trace state."""
+    (tmp_path / "demo_config.yaml").write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+from pathlib import Path
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {{
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    cfg = mk(mas_id="nc_click")
+    st.session_state.chat_config = cfg
+    st.session_state.chat_config_base = cfg
+    st.session_state["chat_yaml_selector"] = 0
+    st.session_state["aether_execution_trace"] = ["agent_0"]
+    with _patch.object(ca, "_load_config"):
+        with _patch.object(
+            ca, "_build_chat_model_options",
+            return_value=(["[OpenAI] gpt-4o"], ["gpt-4o"]),
+        ):
+            with _patch.object(ca.st, "rerun"):
+                ca.render_sidebar_content(examples_dir=Path({str(tmp_path)!r}))
+"""
+    )
+    at.run()
+    assert not at.exception
+    nc_buttons = [b for b in at.button if "New Conversation" in b.label]
+    assert nc_buttons
+    nc_buttons[0].click().run()
+    assert not at.exception
+    assert "chat_thread_id" in at.session_state
+
+
+def test_render_flow_graph_builds_and_shows_details():
+    """_render_flow_graph builds the graph state and renders selected-node details.
+
+    Uses the real streamlit_flow import (installed) but stubs the component call
+    so the node-click detail branch runs without a live frontend.
+    """
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+from bili.aether.ui import chat_app as ca
+
+cfg = mk(mas_id="flow_graph_test", num_agents=2)
+
+# Stub the component call to return a state whose selected_id points at agent_0
+# so the agent-details branch executes.
+returned_state = _Mock()
+returned_state.selected_id = "agent_0"
+with _patch.object(ca, "_FLOW_AVAILABLE", True):
+    with _patch.object(ca, "streamlit_flow", return_value=returned_state):
+        # Call the undecorated fragment body directly.
+        ca._render_flow_graph.__wrapped__(cfg)
+"""
+    )
+    at.run()
+    assert not at.exception
+    # The agent-details container renders the selected agent's id.
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "agent_0" in all_md
+
+
+def test_render_flow_graph_no_selection_shows_hint():
+    """_render_flow_graph shows the click hint when no node is selected."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+from bili.aether.ui.tests.conftest import make_test_config as mk
+from bili.aether.ui import chat_app as ca
+
+cfg = mk(mas_id="flow_no_sel", num_agents=1)
+returned_state = _Mock()
+returned_state.selected_id = None
+with _patch.object(ca, "_FLOW_AVAILABLE", True):
+    with _patch.object(ca, "streamlit_flow", return_value=returned_state):
+        ca._render_flow_graph.__wrapped__(cfg)
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "Click a node" in " ".join(c.value for c in at.caption)
+
+
+def test_render_flow_graph_active_node_highlight():
+    """_render_flow_graph applies the active-node highlight when one is executing."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+from bili.aether.ui import chat_app as ca
+
+cfg = mk(mas_id="flow_active", num_agents=2)
+st.session_state["aether_executing_node"] = "agent_0"
+returned_state = _Mock()
+returned_state.selected_id = None
+with _patch.object(ca, "_FLOW_AVAILABLE", True):
+    with _patch.object(ca, "streamlit_flow", return_value=returned_state):
+        ca._render_flow_graph.__wrapped__(cfg)
+"""
+    )
+    at.run()
+    assert not at.exception
+
+
+def test_render_hitl_form_resume_completes_turn():
+    """_render_hitl_form resumes execution and appends the completed turn."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    cfg = mk(mas_id="hitl_resume", num_agents=2)
+    st.session_state.chat_config = cfg
+    tid = ca._new_thread("hitl_resume")
+    mock_exec = _Mock()
+    # resume_streaming yields (node, state_update) pairs, including a None update.
+    mock_exec.resume_streaming.return_value = iter([
+        ("agent_1", None),
+        ("agent_1", {"agent_outputs": {"agent_1": {"message": "resumed output"}}}),
+    ])
+    st.session_state.chat_executor = mock_exec
+    st.session_state.hitl_pending = {
+        "next": ["agent_1"],
+        "thread_id": tid,
+        "partial_turn": {
+            "role": "user", "content": "needs review",
+            "turn_index": 0,
+            "agent_trace": [
+                {"agent_id": "agent_0",
+                 "output": {"agent_outputs": {"agent_0": {"message": "first"}}}},
+            ],
+        },
+    }
+    # Pre-fill the form's text area so the submit branch proceeds.
+    st.session_state["hitl_human_input"] = "Looks good, proceed"
+    with _patch.object(ca.st, "rerun"):
+        ca._render_hitl_form(mock_exec)
+"""
+    )
+    at.run()
+    assert not at.exception
+    # Submit the resume form to drive the streaming-resume body.
+    if at.button:
+        submit = [b for b in at.button if "Resume" in b.label]
+        if submit:
+            submit[0].click().run()
+    assert not at.exception
+
+
+def test_render_hitl_form_resume_handles_error():
+    """_render_hitl_form records an error when resume_streaming raises."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    cfg = mk(mas_id="hitl_err", num_agents=2)
+    st.session_state.chat_config = cfg
+    tid = ca._new_thread("hitl_err")
+    mock_exec = _Mock()
+    mock_exec.resume_streaming.side_effect = RuntimeError("resume blew up")
+    st.session_state.chat_executor = mock_exec
+    st.session_state.hitl_pending = {
+        "next": ["agent_1"],
+        "thread_id": tid,
+        "partial_turn": {
+            "role": "user", "content": "needs review",
+            "turn_index": 0, "agent_trace": [],
+        },
+    }
+    st.session_state["hitl_human_input"] = "proceed"
+    with _patch.object(ca.st, "rerun"):
+        ca._render_hitl_form(mock_exec)
+"""
+    )
+    at.run()
+    assert not at.exception
+    submit = [b for b in at.button if "Resume" in b.label]
+    if submit:
+        submit[0].click().run()
+    assert not at.exception
+
+
+def test_render_hitl_form_resume_panel_render_error():
+    """_render_hitl_form shows a per-agent error if a panel fails to render on resume."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui import chat_app as ca
+    cfg = mk(mas_id="hitl_panel_err", num_agents=2)
+    st.session_state.chat_config = cfg
+    tid = ca._new_thread("hitl_panel_err")
+    mock_exec = _Mock()
+    mock_exec.resume_streaming.return_value = iter([
+        ("agent_1", {"agent_outputs": {"agent_1": {"message": "resumed"}}}),
+    ])
+    st.session_state.chat_executor = mock_exec
+    st.session_state.hitl_pending = {
+        "next": ["agent_1"],
+        "thread_id": tid,
+        "partial_turn": {
+            "role": "user", "content": "needs review",
+            "turn_index": 0, "agent_trace": [],
+        },
+    }
+    st.session_state["hitl_human_input"] = "proceed now"
+    with _patch.object(ca, "_render_agent_panel", side_effect=RuntimeError("panel boom")):
+        with _patch.object(ca.st, "rerun"):
+            ca._render_hitl_form(mock_exec)
+"""
+    )
+    at.run()
+    assert not at.exception
+    submit = [b for b in at.button if "Resume" in b.label]
+    assert submit
+    submit[0].click().run()
+    assert not at.exception
+    assert "failed to render" in " ".join(e.value for e in at.error)

--- a/bili/aether/ui/tests/test_graph_viewer.py
+++ b/bili/aether/ui/tests/test_graph_viewer.py
@@ -470,3 +470,337 @@ with _patch.dict("sys.modules", fm):
     )
     at.run()
     assert not at.exception
+
+
+def test_metadata_bar_truncates_many_tags():
+    """More than three tags are truncated with an ellipsis."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui.components import graph_viewer as gv
+    cfg = mk()
+    cfg_tags = cfg.model_copy(update={"tags": ["a", "b", "c", "d", "e"]})
+    gv.render_metadata_bar(cfg_tags)
+"""
+    )
+    at.run()
+    assert not at.exception
+    metric_values = [m.value for m in at.metric]
+    assert any("..." in str(v) for v in metric_values)
+
+
+# ---------------------------------------------------------------------------
+# build_model_options
+# ---------------------------------------------------------------------------
+
+
+def test_build_model_options_structure():
+    """build_model_options returns display list and the two lookup dicts."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+fake_models = {
+    "openai": {
+        "name": "OpenAI",
+        "models": [
+            {"model_id": "id-1", "model_name": "gpt-test"},
+        ],
+    },
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui.components import graph_viewer as gv
+    with _patch("bili.iris.config.llm_config.LLM_MODELS", fake_models):
+        gv.build_model_options.clear()
+        options, name_to_model, lookup = gv.build_model_options()
+        gv.build_model_options.clear()
+    st.markdown(f"opt:{options[0]}")
+    st.markdown(f"n2m:{name_to_model[options[0]]}")
+    st.markdown(f"by_id:{lookup['id-1']}")
+    st.markdown(f"by_name:{lookup['gpt-test']}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "opt:[OpenAI] gpt-test" in all_md
+    assert "n2m:gpt-test" in all_md
+    assert "by_id:[OpenAI] gpt-test" in all_md
+    assert "by_name:[OpenAI] gpt-test" in all_md
+
+
+# ---------------------------------------------------------------------------
+# Full agent properties panel with all optional fields populated
+# ---------------------------------------------------------------------------
+
+
+def test_agent_properties_full_render():
+    """A fully populated agent renders every optional property block."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+from bili.aether.schema.agent_spec import AgentSpec
+from bili.aether.schema.mas_config import MASConfig
+from bili.aether.schema.enums import WorkflowType
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui.components import graph_viewer as gv
+    agent = AgentSpec(
+        agent_id="agent_x",
+        role="analyst",
+        objective="Analyze threats thoroughly",
+        system_prompt="You are an analyst.",
+        temperature=0.5,
+        max_tokens=2048,
+        model_name="gpt-test",
+        tools=["search_tool"],
+        capabilities=["threat_modeling"],
+        middleware=["summarization"],
+        tier=1,
+        voting_weight=2.0,
+        is_supervisor=True,
+        inherit_from_bili_core=True,
+    )
+    cfg = MASConfig(
+        mas_id="full_agent",
+        name="Full",
+        description="d",
+        agents=[agent],
+        channels=[],
+        workflow_type=WorkflowType.SEQUENTIAL,
+    )
+    st.session_state[gv._overrides_key(cfg.mas_id)] = {}
+    opts = ["[Test] gpt-test"]
+    n2m = {"[Test] gpt-test": "gpt-test"}
+    lookup = {"gpt-test": "[Test] gpt-test"}
+    with _patch.object(gv, "build_model_options", return_value=(opts, n2m, lookup)):
+        with _patch.object(gv, "_get_tool_names", return_value=["search_tool", "calc_tool"]):
+            gv._render_properties_panel(cfg, "agent_x", [], cfg.mas_id)
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "threat_modeling" in all_md
+    assert "summarization" in all_md
+    assert "Tier:" in all_md
+    assert "Voting Weight:" in all_md
+    assert "Supervisor" in all_md
+    assert "Inherits from bili-core" in all_md
+    # The model selector pre-selects the YAML model.
+    assert any("gpt-test" in str(s.value) for s in at.selectbox)
+
+
+def test_agent_properties_uses_override_bucket_values():
+    """Override bucket values pre-fill the editable widgets over YAML defaults."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+from bili.aether.schema.agent_spec import AgentSpec
+from bili.aether.schema.mas_config import MASConfig
+from bili.aether.schema.enums import WorkflowType
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui.components import graph_viewer as gv
+    agent = AgentSpec(
+        agent_id="agent_y",
+        role="r",
+        objective="Original objective text",
+    )
+    cfg = MASConfig(
+        mas_id="ov_agent",
+        name="Ov",
+        description="d",
+        agents=[agent],
+        channels=[],
+        workflow_type=WorkflowType.SEQUENTIAL,
+    )
+    st.session_state[gv._overrides_key(cfg.mas_id)] = {
+        "agent_y": {
+            "objective": "Overridden objective",
+            "system_prompt": "Overridden prompt",
+            "temperature": 1.3,
+            "max_tokens": 4096,
+            "tools": ["calc_tool"],
+            "model_name": "[Test] gpt-test",
+        }
+    }
+    opts = ["[Test] gpt-test"]
+    n2m = {"[Test] gpt-test": "gpt-test"}
+    lookup = {"gpt-test": "[Test] gpt-test"}
+    with _patch.object(gv, "build_model_options", return_value=(opts, n2m, lookup)):
+        with _patch.object(gv, "_get_tool_names", return_value=["calc_tool", "search_tool"]):
+            gv._render_properties_panel(cfg, "agent_y", [], cfg.mas_id)
+"""
+    )
+    at.run()
+    assert not at.exception
+    text_area_vals = " ".join(str(t.value) for t in at.text_area)
+    assert "Overridden objective" in text_area_vals
+    assert "Overridden prompt" in text_area_vals
+    slider_vals = [s.value for s in at.slider]
+    assert 1.3 in slider_vals
+    number_vals = [n.value for n in at.number_input]
+    assert 4096 in number_vals
+    # The override model is pre-selected.
+    assert any("gpt-test" in str(s.value) for s in at.selectbox)
+
+
+def test_agent_properties_no_tools_in_registry():
+    """When the tool registry is empty no multiselect is rendered."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui.components import graph_viewer as gv
+    cfg = mk(mas_id="no_tools")
+    st.session_state[gv._overrides_key(cfg.mas_id)] = {}
+    with _patch.object(gv, "build_model_options", return_value=([], {}, {})):
+        with _patch.object(gv, "_get_tool_names", return_value=[]):
+            gv._render_properties_panel(cfg, "agent_0", [], cfg.mas_id)
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert any("None configured in YAML" in c.value for c in at.caption)
+    assert len(at.multiselect) == 0
+
+
+def test_model_selector_keep_sentinel_clears_override():
+    """Selecting the keep sentinel removes any stored model override."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+import streamlit as st
+from bili.aether.schema.agent_spec import AgentSpec
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui.components import graph_viewer as gv
+    agent = AgentSpec(agent_id="agent_z", role="r", objective="Do the work")
+    mas_id = "sel_clear"
+    st.session_state[gv._overrides_key(mas_id)] = {
+        "agent_z": {"model_name": "[Test] gpt-test"}
+    }
+    opts = ["[Test] gpt-test"]
+    lookup = {"gpt-test": "[Test] gpt-test"}
+    with _patch.object(gv, "build_model_options", return_value=(opts, {}, lookup)):
+        gv._render_model_selector(agent, mas_id)
+    bucket = st.session_state[gv._overrides_key(mas_id)]["agent_z"]
+    st.markdown(f"has_model:{'model_name' in bucket}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    # The stored override display is preselected, so the rendered value keeps it.
+    assert any("gpt-test" in str(s.value) for s in at.selectbox)
+
+
+# ---------------------------------------------------------------------------
+# Edge properties: channel + workflow edge matches
+# ---------------------------------------------------------------------------
+
+
+def test_edge_properties_with_channel_and_workflow_match():
+    """Edge properties surface channel protocol and conditional workflow edge."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock as _Mock
+from unittest.mock import patch as _patch
+from bili.aether.schema.agent_spec import AgentSpec
+from bili.aether.schema.mas_config import MASConfig, Channel, WorkflowEdge
+from bili.aether.schema.enums import WorkflowType
+fm = {
+    "streamlit_flow": _Mock(),
+    "streamlit_flow.elements": _Mock(),
+    "streamlit_flow.state": _Mock(),
+}
+with _patch.dict("sys.modules", fm):
+    from bili.aether.ui.components import graph_viewer as gv
+    agents = [
+        AgentSpec(agent_id="agent_0", role="r0", objective="Objective zero"),
+        AgentSpec(agent_id="agent_1", role="r1", objective="Objective one"),
+    ]
+    channel = Channel(
+        channel_id="ch01",
+        protocol="direct",
+        source="agent_0",
+        target="agent_1",
+        description="Primary link",
+        bidirectional=True,
+    )
+    wedge = WorkflowEdge(
+        from_agent="agent_0",
+        to_agent="agent_1",
+        condition="state.score > 0.5",
+    )
+    cfg = MASConfig(
+        mas_id="edge_full",
+        name="Edge",
+        description="d",
+        agents=agents,
+        channels=[channel],
+        workflow_edges=[wedge],
+        workflow_type=WorkflowType.CUSTOM,
+    )
+    edge = _Mock()
+    edge.id = "e01"
+    edge.source = "agent_0"
+    edge.target = "agent_1"
+    edge.label = "direct"
+    gv._render_edge_properties(edge, cfg)
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "Protocol:" in all_md
+    assert "Primary link" in all_md
+    assert any("Bidirectional" in s.value for s in at.success)
+    assert any("state.score > 0.5" in c.value for c in at.code)
+
+
+# NOTE: a "Download YAML button present" AppTest was removed here. It used
+# at.download_button, which is not an accessor on AppTest in this Streamlit
+# version, and the st.download_button("Download YAML", ...) call at
+# graph_viewer.py:162 is already exercised by the other render_graph_viewer
+# tests in this file (line 162 is covered). The removed test added no
+# coverage and asserted via a non-existent API.

--- a/bili/aether/ui/tests/test_page.py
+++ b/bili/aether/ui/tests/test_page.py
@@ -249,3 +249,520 @@ st.markdown(f"no_uploads:{'chat_uploaded_configs' not in st.session_state}")
     at.run()
     assert not at.exception
     assert "no_uploads:True" in " ".join(m.value for m in at.markdown)
+
+
+# ---------------------------------------------------------------------------
+# Logo branches (lines 75, 129)
+# ---------------------------------------------------------------------------
+
+
+def test_sidebar_renders_logo_when_present():
+    """_render_sidebar calls st.image when the logo file exists."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+fm = {
+    "streamlit_flow": MagicMock(),
+    "streamlit_flow.elements": MagicMock(StreamlitFlowNode=MagicMock()),
+    "streamlit_flow.state": MagicMock(),
+}
+with st.sidebar:
+    with patch.dict("sys.modules", fm):
+        from bili.aether.ui import page as pm
+        with patch.object(pm, "LOGO_PATH") as lp:
+            lp.exists.return_value = True
+            lp.__str__ = lambda self: "/fake/logo.png"
+            with patch.object(pm, "EXAMPLES_DIR") as ed:
+                ed.exists.return_value = True
+                ed.glob.return_value = []
+                with patch("streamlit.image") as img:
+                    pm._render_sidebar()
+                    st.markdown(f"image_called:{img.called}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "image_called:True" in " ".join(m.value for m in at.sidebar.markdown)
+
+
+def test_intro_renders_logo_when_present():
+    """_render_intro calls st.image when the logo file exists."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+fm = {
+    "streamlit_flow": MagicMock(),
+    "streamlit_flow.elements": MagicMock(StreamlitFlowNode=MagicMock()),
+    "streamlit_flow.state": MagicMock(),
+}
+with patch.dict("sys.modules", fm):
+    from bili.aether.ui import page as pm
+    with patch.object(pm, "LOGO_PATH") as lp:
+        lp.exists.return_value = True
+        lp.__str__ = lambda self: "/fake/logo.png"
+        with patch("streamlit.image") as img:
+            pm._render_intro()
+            st.markdown(f"image_called:{img.called}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "image_called:True" in " ".join(m.value for m in at.markdown)
+
+
+# ---------------------------------------------------------------------------
+# Chat-page branches (lines 64, 93)
+# ---------------------------------------------------------------------------
+
+
+def test_render_aether_page_chat_branch():
+    """render_aether_page dispatches to the chat renderer when page is Chat."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+fm = {
+    "streamlit_flow": MagicMock(),
+    "streamlit_flow.elements": MagicMock(StreamlitFlowNode=MagicMock()),
+    "streamlit_flow.state": MagicMock(),
+}
+with patch.dict("sys.modules", fm):
+    from bili.aether.ui import page as pm
+    st.session_state["aether_page"] = "Chat"
+    with patch.object(pm, "LOGO_PATH") as lp:
+        lp.exists.return_value = False
+        with patch.object(pm, "render_chat_sidebar_content") as sc:
+            with patch.object(pm, "render_chat_main") as cm:
+                pm.render_aether_page()
+                st.markdown(f"chat_main:{cm.called}")
+                st.markdown(f"chat_sidebar:{sc.called}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "chat_main:True" in all_md
+    assert "chat_sidebar:True" in all_md
+
+
+# ---------------------------------------------------------------------------
+# Visualizer sidebar: examples dir missing, with yaml files (104-105, 112-123)
+# ---------------------------------------------------------------------------
+
+
+def test_visualizer_sidebar_examples_missing_shows_error():
+    """_render_visualizer_sidebar shows an error when EXAMPLES_DIR is absent."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+fm = {
+    "streamlit_flow": MagicMock(),
+    "streamlit_flow.elements": MagicMock(StreamlitFlowNode=MagicMock()),
+    "streamlit_flow.state": MagicMock(),
+}
+with patch.dict("sys.modules", fm):
+    from bili.aether.ui import page as pm
+    with patch.object(pm, "EXAMPLES_DIR") as ed:
+        ed.exists.return_value = False
+        pm._render_visualizer_sidebar()
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "not found" in " ".join(e.value for e in at.error)
+
+
+def test_visualizer_sidebar_with_yaml_files_loads_config(tmp_path):
+    """_render_visualizer_sidebar renders a selectbox and loads the chosen config."""
+    (tmp_path / "demo_config.yaml").write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from pathlib import Path
+fm = {{
+    "streamlit_flow": MagicMock(),
+    "streamlit_flow.elements": MagicMock(StreamlitFlowNode=MagicMock()),
+    "streamlit_flow.state": MagicMock(),
+}}
+with patch.dict("sys.modules", fm):
+    from bili.aether.ui import page as pm
+    with patch.object(pm, "EXAMPLES_DIR", Path({str(tmp_path)!r})):
+        with patch.object(pm, "_load_config") as lc:
+            pm._render_visualizer_sidebar()
+            st.markdown(f"load_called:{{lc.called}}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert len(at.selectbox) >= 1
+    assert "load_called:True" in " ".join(m.value for m in at.markdown)
+
+
+# ---------------------------------------------------------------------------
+# Visualizer main with config (lines 222-232)
+# ---------------------------------------------------------------------------
+
+
+def test_visualizer_main_with_config_renders_graph():
+    """_render_visualizer_main renders the config name, graph, and legend."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {
+    "streamlit_flow": MagicMock(),
+    "streamlit_flow.elements": MagicMock(StreamlitFlowNode=MagicMock()),
+    "streamlit_flow.state": MagicMock(),
+}
+with patch.dict("sys.modules", fm):
+    from bili.aether.ui import page as pm
+    cfg = mk(mas_id="vis_main_test", name="Vis Main MAS")
+    st.session_state["mas_config"] = cfg
+    with patch.object(pm, "LOGO_PATH") as lp:
+        lp.exists.return_value = False
+        with patch.object(pm, "convert_mas_to_graph", return_value=([], [])):
+            with patch.object(pm, "render_graph_viewer"):
+                with patch.object(pm, "render_metadata_bar"):
+                    pm._render_visualizer_main()
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "Vis Main MAS" in all_md
+
+
+# ---------------------------------------------------------------------------
+# Send-to callbacks with config (lines 246-253, 258-263, 268-273)
+# ---------------------------------------------------------------------------
+
+
+def test_on_send_to_chat_with_config():
+    """_on_send_to_chat pushes the config to the chat upload store and switches page."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {
+    "streamlit_flow": MagicMock(),
+    "streamlit_flow.elements": MagicMock(StreamlitFlowNode=MagicMock()),
+    "streamlit_flow.state": MagicMock(),
+}
+with patch.dict("sys.modules", fm):
+    from bili.aether.ui import page as pm
+    cfg = mk(mas_id="send_chat")
+    st.session_state["mas_config"] = cfg
+    st.session_state["current_yaml_path"] = "my_cfg.yaml"
+    with patch.object(pm, "apply_agent_overrides", side_effect=lambda c: c):
+        pm._on_send_to_chat()
+    st.markdown(f"page:{st.session_state.get('aether_page')}")
+    st.markdown(f"autoload:{st.session_state.get('chat_autoload_name')}")
+    st.markdown(f"uploaded:{'my_cfg.yaml' in st.session_state.get('chat_uploaded_configs', {})}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "page:Chat" in all_md
+    assert "autoload:my_cfg.yaml" in all_md
+    assert "uploaded:True" in all_md
+
+
+def test_on_send_to_baseline_with_config():
+    """_on_send_to_baseline pushes the config to the baseline runner state."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {
+    "streamlit_flow": MagicMock(),
+    "streamlit_flow.elements": MagicMock(StreamlitFlowNode=MagicMock()),
+    "streamlit_flow.state": MagicMock(),
+}
+with patch.dict("sys.modules", fm):
+    from bili.aether.ui import page as pm
+    cfg = mk(mas_id="send_baseline")
+    st.session_state["mas_config"] = cfg
+    st.session_state["current_yaml_path"] = "/p/cfg.yaml"
+    with patch.object(pm, "apply_agent_overrides", side_effect=lambda c: c):
+        with patch.object(pm, "push_config_to_baseline_state") as push:
+            pm._on_send_to_baseline()
+            st.markdown(f"pushed:{push.called}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "pushed:True" in " ".join(m.value for m in at.markdown)
+
+
+def test_on_send_to_attack_with_config():
+    """_on_send_to_attack pushes the config to the attack page state."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {
+    "streamlit_flow": MagicMock(),
+    "streamlit_flow.elements": MagicMock(StreamlitFlowNode=MagicMock()),
+    "streamlit_flow.state": MagicMock(),
+}
+with patch.dict("sys.modules", fm):
+    from bili.aether.ui import page as pm
+    cfg = mk(mas_id="send_attack")
+    st.session_state["mas_config"] = cfg
+    st.session_state["current_yaml_path"] = "/p/cfg.yaml"
+    with patch.object(pm, "apply_agent_overrides", side_effect=lambda c: c):
+        with patch.object(pm, "push_config_to_attack_state") as push:
+            pm._on_send_to_attack()
+            st.markdown(f"pushed:{push.called}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "pushed:True" in " ".join(m.value for m in at.markdown)
+
+
+def test_send_callbacks_noop_without_config():
+    """The baseline and attack send callbacks are no-ops without a config."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+fm = {
+    "streamlit_flow": MagicMock(),
+    "streamlit_flow.elements": MagicMock(StreamlitFlowNode=MagicMock()),
+    "streamlit_flow.state": MagicMock(),
+}
+with patch.dict("sys.modules", fm):
+    from bili.aether.ui import page as pm
+    st.session_state.pop("mas_config", None)
+    with patch.object(pm, "push_config_to_baseline_state") as pb:
+        with patch.object(pm, "push_config_to_attack_state") as pa:
+            pm._on_send_to_baseline()
+            pm._on_send_to_attack()
+            st.markdown(f"baseline:{pb.called}")
+            st.markdown(f"attack:{pa.called}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "baseline:False" in all_md
+    assert "attack:False" in all_md
+
+
+# ---------------------------------------------------------------------------
+# _load_config (lines 278-339)
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_loads_and_renders_summary(tmp_path):
+    """_load_config loads a YAML, renders send buttons, and shows the MAS summary."""
+    yaml_file = tmp_path / "cfg.yaml"
+    yaml_file.write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from pathlib import Path
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {{
+    "streamlit_flow": MagicMock(),
+    "streamlit_flow.elements": MagicMock(StreamlitFlowNode=MagicMock()),
+    "streamlit_flow.state": MagicMock(),
+}}
+with patch.dict("sys.modules", fm):
+    from bili.aether.ui import page as pm
+    cfg = mk(mas_id="load_cfg_test")
+    st.session_state.pop("current_yaml_path", None)
+    st.session_state.pop("mas_config", None)
+    with patch.object(pm, "load_mas_from_yaml", return_value=cfg):
+        pm._load_config(Path({str(yaml_file)!r}))
+    st.markdown(f"stored:{{st.session_state.get('mas_config') is not None}}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "stored:True" in all_md
+    assert "load_cfg_test" in all_md
+    button_labels = [b.label for b in at.button]
+    assert any("Send to Chat" in lbl for lbl in button_labels)
+
+
+def test_load_config_uses_cache_when_path_unchanged(tmp_path):
+    """_load_config reuses the cached config when the path is unchanged."""
+    yaml_file = tmp_path / "cfg.yaml"
+    yaml_file.write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from pathlib import Path
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {{
+    "streamlit_flow": MagicMock(),
+    "streamlit_flow.elements": MagicMock(StreamlitFlowNode=MagicMock()),
+    "streamlit_flow.state": MagicMock(),
+}}
+with patch.dict("sys.modules", fm):
+    from bili.aether.ui import page as pm
+    cfg = mk(mas_id="cached_cfg")
+    st.session_state["current_yaml_path"] = {str(yaml_file)!r}
+    st.session_state["mas_config"] = cfg
+    with patch.object(pm, "load_mas_from_yaml") as loader:
+        pm._load_config(Path({str(yaml_file)!r}))
+        st.markdown(f"loader_called:{{loader.called}}")
+    st.markdown(f"same:{{st.session_state.get('mas_config') is cfg}}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "loader_called:False" in all_md
+    assert "same:True" in all_md
+
+
+def test_load_config_handles_load_error(tmp_path):
+    """_load_config shows an error and clears mas_config when loading fails."""
+    yaml_file = tmp_path / "bad.yaml"
+    yaml_file.write_text("bad", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from pathlib import Path
+fm = {{
+    "streamlit_flow": MagicMock(),
+    "streamlit_flow.elements": MagicMock(StreamlitFlowNode=MagicMock()),
+    "streamlit_flow.state": MagicMock(),
+}}
+with patch.dict("sys.modules", fm):
+    from bili.aether.ui import page as pm
+    st.session_state.pop("current_yaml_path", None)
+    st.session_state.pop("mas_config", None)
+    with patch.object(pm, "load_mas_from_yaml", side_effect=ValueError("bad yaml")):
+        pm._load_config(Path({str(yaml_file)!r}))
+    st.markdown(f"cleared:{{st.session_state.get('mas_config') is None}}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "Failed to load" in " ".join(e.value for e in at.error)
+    assert "cleared:True" in " ".join(m.value for m in at.markdown)
+
+
+def test_load_config_clears_stale_widget_state(tmp_path):
+    """_load_config clears stale per-config widget keys on a fresh load."""
+    yaml_file = tmp_path / "cfg.yaml"
+    yaml_file.write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from pathlib import Path
+from bili.aether.ui.tests.conftest import make_test_config as mk
+fm = {{
+    "streamlit_flow": MagicMock(),
+    "streamlit_flow.elements": MagicMock(StreamlitFlowNode=MagicMock()),
+    "streamlit_flow.state": MagicMock(),
+}}
+with patch.dict("sys.modules", fm):
+    from bili.aether.ui import page as pm
+    cfg = mk(mas_id="stale_clear")
+    st.session_state.pop("current_yaml_path", None)
+    st.session_state.pop("mas_config", None)
+    st.session_state["flow_state_old"] = "stale"
+    st.session_state["agent_overrides_old"] = "stale"
+    with patch.object(pm, "load_mas_from_yaml", return_value=cfg):
+        pm._load_config(Path({str(yaml_file)!r}))
+    st.markdown(f"flow_cleared:{{'flow_state_old' not in st.session_state}}")
+    st.markdown(f"ovr_cleared:{{'agent_overrides_old' not in st.session_state}}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "flow_cleared:True" in all_md
+    assert "ovr_cleared:True" in all_md
+
+
+def test_load_config_summary_shows_consensus_and_hitl(tmp_path):
+    """_load_config renders consensus threshold and the human-in-loop warning."""
+    yaml_file = tmp_path / "cfg.yaml"
+    yaml_file.write_text("mas_id: x\n", encoding="utf-8")
+    at = AppTest.from_string(
+        f"""
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from pathlib import Path
+from bili.aether.schema.agent_spec import AgentSpec
+from bili.aether.schema.enums import WorkflowType
+from bili.aether.schema.mas_config import MASConfig
+fm = {{
+    "streamlit_flow": MagicMock(),
+    "streamlit_flow.elements": MagicMock(StreamlitFlowNode=MagicMock()),
+    "streamlit_flow.state": MagicMock(),
+}}
+with patch.dict("sys.modules", fm):
+    from bili.aether.ui import page as pm
+    agents = [
+        AgentSpec(agent_id="a0", role="a0", objective="Vote on the proposals"),
+        AgentSpec(agent_id="a1", role="a1", objective="Vote on the proposals"),
+    ]
+    cfg = MASConfig(
+        mas_id="consensus_cfg", name="Consensus", description="d",
+        agents=agents, channels=[], workflow_type=WorkflowType.CONSENSUS,
+        consensus_threshold=0.66, human_in_loop=True,
+    )
+    st.session_state.pop("current_yaml_path", None)
+    st.session_state.pop("mas_config", None)
+    with patch.object(pm, "load_mas_from_yaml", return_value=cfg):
+        pm._load_config(Path({str(yaml_file)!r}))
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "Consensus" in all_md
+    assert "Human-in-loop enabled" in " ".join(w.value for w in at.warning)
+
+
+# ---------------------------------------------------------------------------
+# streamlit-flow ImportError fallback (lines 26-31)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_streamlit_flow_shows_error_and_stops():
+    """Importing page.py without streamlit-flow shows an install error and stops."""
+    at = AppTest.from_string(
+        """
+import sys
+import importlib
+from unittest.mock import patch
+import streamlit as st
+
+# Drop any cached page module and force the streamlit_flow.elements import to
+# fail so the module-level ImportError fallback (st.error + st.stop) runs.
+sys.modules.pop("bili.aether.ui.page", None)
+fm = {"streamlit_flow": None, "streamlit_flow.elements": None}
+with patch.dict("sys.modules", fm):
+    try:
+        importlib.import_module("bili.aether.ui.page")
+    finally:
+        # Re-import cleanly so later tests get a working module again.
+        sys.modules.pop("bili.aether.ui.page", None)
+import bili.aether.ui.page  # noqa: F401  re-establish a healthy module
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "streamlit-flow-component" in " ".join(e.value for e in at.error)

--- a/bili/aether/ui/tests/test_results_page.py
+++ b/bili/aether/ui/tests/test_results_page.py
@@ -350,3 +350,211 @@ def test_build_dataframe_multiple_results():
     assert len(df) == 2
     assert set(df["mas_id"].unique()) == {"cfg_a"}
     assert df["success"].sum() == 1
+
+
+# ---------------------------------------------------------------------------
+# _load_baseline_results disk-reading (lines 58-76)
+# ---------------------------------------------------------------------------
+
+
+def _write_baseline_file(path, mas_id, prompt_id, success):
+    """Write a minimal baseline result JSON file at *path*."""
+    import json
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "mas_id": mas_id,
+                "prompt_id": prompt_id,
+                "prompt_category": "benign",
+                "execution": {
+                    "success": success,
+                    "duration_ms": 10,
+                    "agent_count": 1,
+                },
+                "run_metadata": {"stub_mode": True, "timestamp": "t"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_load_baseline_results_versioned_and_legacy(tmp_path):
+    """_load_baseline_results derives run_id from versioned and legacy layouts."""
+    from unittest.mock import patch
+
+    # Versioned layout: {mas_id}/run_001/{prompt}.json
+    _write_baseline_file(
+        tmp_path / "cfg_a" / "run_001" / "p1.json", "cfg_a", "p1", True
+    )
+    # Legacy flat layout: {mas_id}/{prompt}.json
+    _write_baseline_file(tmp_path / "cfg_b" / "p2.json", "cfg_b", "p2", False)
+    with patch.object(rp_mod, "BASELINE_RESULTS_DIR", tmp_path):
+        results = rp_mod._load_baseline_results.__wrapped__()
+    by_prompt = {r["prompt_id"]: r for r in results}
+    assert by_prompt["p1"]["run_id"] == "run_001"
+    assert by_prompt["p2"]["run_id"] == "run_000 (legacy)"
+
+
+def test_load_baseline_results_skips_malformed(tmp_path):
+    """_load_baseline_results logs and skips a file that is not valid JSON."""
+    from unittest.mock import patch
+
+    (tmp_path / "cfg_a").mkdir(parents=True)
+    (tmp_path / "cfg_a" / "broken.json").write_text("{not json", encoding="utf-8")
+    _write_baseline_file(tmp_path / "cfg_a" / "ok.json", "cfg_a", "good", True)
+    with patch.object(rp_mod, "BASELINE_RESULTS_DIR", tmp_path):
+        results = rp_mod._load_baseline_results.__wrapped__()
+    # Only the valid file is returned; the broken file is skipped.
+    assert len(results) == 1
+    assert results[0]["prompt_id"] == "good"
+
+
+# ---------------------------------------------------------------------------
+# Sidebar logo branch (line 134)
+# ---------------------------------------------------------------------------
+
+
+def test_sidebar_renders_logo_when_present():
+    """_render_sidebar calls st.image when the logo file exists."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+import streamlit as st
+from bili.aether.ui import results_page as rp
+with st.sidebar:
+    with patch.object(rp, "LOGO_PATH") as lp:
+        lp.exists.return_value = True
+        lp.__str__ = lambda self: "/fake/logo.png"
+        with patch("streamlit.image") as img:
+            rp._render_sidebar()
+            st.markdown(f"image_called:{img.called}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    assert "image_called:True" in " ".join(m.value for m in at.sidebar.markdown)
+
+
+# ---------------------------------------------------------------------------
+# Status filter branches (lines 340, 342)
+# ---------------------------------------------------------------------------
+
+
+def test_render_filters_status_passed():
+    """_render_filters with status 'Passed' keeps only successful rows."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.aether.ui import results_page as rp
+from bili.aether.ui.tests.test_results_page import _SAMPLE_RESULTS
+df = rp._build_dataframe(_SAMPLE_RESULTS)
+st.session_state["baseline_filter_status"] = "Passed"
+filtered = rp._render_filters(df)
+st.markdown(f"count:{len(filtered)}")
+st.markdown(f"allpass:{bool(filtered['success'].all())}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "count:1" in all_md
+    assert "allpass:True" in all_md
+
+
+def test_render_filters_status_failed():
+    """_render_filters with status 'Failed' keeps only failed rows."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.aether.ui import results_page as rp
+from bili.aether.ui.tests.test_results_page import _SAMPLE_RESULTS
+df = rp._build_dataframe(_SAMPLE_RESULTS)
+st.session_state["baseline_filter_status"] = "Failed"
+filtered = rp._render_filters(df)
+st.markdown(f"count:{len(filtered)}")
+st.markdown(f"anypass:{bool(filtered['success'].any())}")
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "count:1" in all_md
+    assert "anypass:False" in all_md
+
+
+# ---------------------------------------------------------------------------
+# Matrix NaN cell rendering (lines 366, 376)
+# ---------------------------------------------------------------------------
+
+_SPARSE_RESULTS = [
+    {
+        "mas_id": "cfg_a",
+        "prompt_id": "p1",
+        "prompt_text": "Hello",
+        "prompt_category": "benign",
+        "execution": {"success": True, "duration_ms": 50, "agent_count": 2},
+        "run_metadata": {"stub_mode": True, "timestamp": "2026-01-01T00:00:00"},
+        "agent_outputs": {},
+    },
+    {
+        "mas_id": "cfg_b",
+        "prompt_id": "p2",
+        "prompt_text": "Other",
+        "prompt_category": "benign",
+        "execution": {"success": False, "duration_ms": 60, "agent_count": 2},
+        "run_metadata": {"stub_mode": True, "timestamp": "2026-01-01T00:00:00"},
+        "agent_outputs": {},
+    },
+]
+
+
+def test_render_matrix_renders_not_run_cells():
+    """_render_matrix shows a dash for prompt/config combos that were not run."""
+    at = AppTest.from_string(
+        """
+from bili.aether.ui import results_page as rp
+from bili.aether.ui.tests.test_results_page import _SPARSE_RESULTS
+df = rp._build_dataframe(_SPARSE_RESULTS)
+rp._render_matrix(df)
+"""
+    )
+    at.run()
+    assert not at.exception
+    # p1 was only run on cfg_a, p2 only on cfg_b: the pivot has NaN cells
+    # rendered as the not-run dash symbol with gray cell styling.
+    assert len(at.dataframe) == 1
+
+
+# ---------------------------------------------------------------------------
+# Detail panel agent output empty (line 443)
+# ---------------------------------------------------------------------------
+
+_RESULTS_EMPTY_AGENT_OUTPUT = [
+    {
+        "mas_id": "cfg_a",
+        "prompt_id": "p1",
+        "prompt_text": "Hello",
+        "prompt_category": "benign",
+        "execution": {"success": True, "duration_ms": 50, "agent_count": 1},
+        "run_metadata": {"stub_mode": True, "timestamp": "2026-01-01T00:00:00"},
+        "agent_outputs": {"agent_0": {"raw": "   "}},
+    },
+]
+
+
+def test_render_detail_panel_empty_agent_output():
+    """_render_detail_panel shows '(no output)' when an agent output is blank."""
+    at = AppTest.from_string(
+        """
+from bili.aether.ui import results_page as rp
+from bili.aether.ui.tests.test_results_page import _RESULTS_EMPTY_AGENT_OUTPUT
+df = rp._build_dataframe(_RESULTS_EMPTY_AGENT_OUTPUT)
+rp._render_detail_panel(_RESULTS_EMPTY_AGENT_OUTPUT, df)
+"""
+    )
+    at.run()
+    assert not at.exception
+    all_captions = " ".join(c.value for c in at.caption)
+    assert "(no output)" in all_captions

--- a/bili/auth/providers/auth/tests/test_sqlite_auth_provider.py
+++ b/bili/auth/providers/auth/tests/test_sqlite_auth_provider.py
@@ -5,8 +5,10 @@ login endpoint, including refreshToken which was previously missing and
 caused a KeyError when Flask tried to set auth cookies.
 """
 
+import datetime
 import os
 
+import jwt
 import pytest
 
 from bili.auth.providers.auth.sqlite_auth_provider import SQLiteAuthProvider
@@ -128,3 +130,41 @@ class TestJwtTokens:
         prov = _make_provider(tmp_path)
         with pytest.raises(ValueError):
             prov.verify_jwt_token("not.a.valid.token")
+
+    def test_expired_token_raises_token_expired(self, tmp_path):
+        """An expired but correctly-signed token raises a 'Token expired' error."""
+        prov = _make_provider(tmp_path)
+        past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+            hours=1
+        )
+        expired = jwt.encode(
+            {"email": _TEST_EMAIL, "exp": past},
+            os.environ["JWT_SECRET_KEY"],
+            algorithm="HS256",
+        )
+        with pytest.raises(ValueError, match="Token expired"):
+            prov.verify_jwt_token(expired)
+
+
+class TestEmailVerificationAndDeletion:
+    """Email verification flag updates and user deletion."""
+
+    def test_send_email_verification_marks_verified(self, tmp_path):
+        """send_email_verification flips the user's email_verified flag to true."""
+        prov = _make_user(_make_provider(tmp_path))
+        uid = prov.sign_in(_TEST_EMAIL, _TEST_PASSWORD)["uid"]
+        assert prov.get_account_info(uid)["emailVerified"] is False
+
+        prov.send_email_verification({"uid": uid})
+
+        assert prov.get_account_info(uid)["emailVerified"] is True
+
+    def test_delete_user_removes_account(self, tmp_path):
+        """delete_user removes the record so account lookups then fail."""
+        prov = _make_user(_make_provider(tmp_path))
+        uid = prov.sign_in(_TEST_EMAIL, _TEST_PASSWORD)["uid"]
+
+        prov.delete_user(uid)
+
+        with pytest.raises(ValueError):
+            prov.get_account_info(uid)

--- a/bili/auth/tests/test_role_and_profile_providers.py
+++ b/bili/auth/tests/test_role_and_profile_providers.py
@@ -1,0 +1,72 @@
+"""Tests for the role and profile provider implementations.
+
+Covers the in-memory role and profile providers plus the base
+RoleProvider.is_authorized membership check.
+"""
+
+from bili.auth.providers.profile.in_memory_profile_provider import (
+    InMemoryProfileProvider,
+)
+from bili.auth.providers.role.in_memory_role_provider import InMemoryRoleProvider
+from bili.auth.providers.role.role_provider import RoleProvider
+
+
+class TestInMemoryRoleProvider:
+    """The in-memory role provider grants the researcher role to everyone."""
+
+    def test_get_user_role_returns_researcher(self):
+        """Every user is assigned the researcher role."""
+        provider = InMemoryRoleProvider()
+        assert provider.get_user_role("any-uid", "any-token") == "researcher"
+
+    def test_is_authorized_always_true(self):
+        """Authorization always succeeds regardless of required roles."""
+        provider = InMemoryRoleProvider()
+        assert provider.is_authorized("uid", "token", ["admin"]) is True
+        assert provider.is_authorized("uid", "token", []) is True
+
+
+class TestRoleProviderBaseIsAuthorized:
+    """The base RoleProvider.is_authorized checks role membership.
+
+    InMemoryRoleProvider overrides is_authorized, so the base implementation
+    is exercised here via a minimal subclass that only supplies get_user_role.
+    """
+
+    def _provider_returning(self, role):
+        class _FixedRoleProvider(RoleProvider):
+            def get_user_role(self, uid, token):
+                return role
+
+        return _FixedRoleProvider()
+
+    def test_authorized_when_role_in_required(self):
+        """A user whose role is in the required list is authorized."""
+        provider = self._provider_returning("admin")
+        assert provider.is_authorized("uid", "token", ["admin", "editor"]) is True
+
+    def test_not_authorized_when_role_absent(self):
+        """A user whose role is absent from the required list is denied."""
+        provider = self._provider_returning("viewer")
+        assert provider.is_authorized("uid", "token", ["admin", "editor"]) is False
+
+
+class TestInMemoryProfileProvider:
+    """The in-memory profile provider stores and retrieves user profiles."""
+
+    def test_create_then_get_round_trips_profile(self):
+        """A created profile is retrievable with all stored fields."""
+        provider = InMemoryProfileProvider()
+        provider.create_user_profile("u1", "u1@example.com", "Alice", "Garcia", "token")
+        profile = provider.get_user_profile("u1", "token")
+        assert profile == {
+            "uid": "u1",
+            "email": "u1@example.com",
+            "first_name": "Alice",
+            "last_name": "Garcia",
+        }
+
+    def test_get_unknown_profile_returns_none(self):
+        """An unknown uid yields None."""
+        provider = InMemoryProfileProvider()
+        assert provider.get_user_profile("missing", "token") is None

--- a/bili/flask_api/flask_utils.py
+++ b/bili/flask_api/flask_utils.py
@@ -68,8 +68,8 @@ if __name__ == '__main__':
     app.run()
 """
 
+import copy
 import json
-from dataclasses import replace
 from functools import wraps
 
 from flask import Response, g, jsonify, make_response, request, stream_with_context
@@ -368,25 +368,40 @@ def per_user_agent(
                 for node in current_graph
             )
             if not has_per_user_state:
-                # Build fresh per-request Node instances so the shared
-                # graph_definition is never mutated. Re-point the existing
-                # persona node (index 0) at the new per_user_state node, and
-                # instantiate per_user_state from its factory pointed at the
-                # original next node. replace() requires dataclass instances,
-                # which is why per_user_state_node() is called first.
-                persona_node_modified = replace(
-                    current_graph[0], edges=["per_user_state"]
+                # Locate the persona node by name. Do not assume it is index 0:
+                # an empty or persona-less graph must fail loudly rather than
+                # rewire an arbitrary first node's edges.
+                persona_idx = next(
+                    (
+                        i
+                        for i, node in enumerate(current_graph)
+                        if getattr(node, "name", None) == "add_persona_and_summary"
+                    ),
+                    None,
                 )
-                per_user_state_modified = replace(
-                    per_user_state_node(), edges=["inject_current_datetime"]
+                if persona_idx is None:
+                    raise ValueError(
+                        "per_user_agent requires an 'add_persona_and_summary' node "
+                        "in graph_definition to insert per_user_state before"
+                    )
+                # Deep-copy the persona node so the shared graph_definition and
+                # its nested mutable fields (conditional_edges, cache_policy) are
+                # never mutated. per_user_state is a fresh factory instance.
+                persona_node_modified = copy.deepcopy(current_graph[persona_idx])
+                original_persona_edges = list(persona_node_modified.edges)
+                persona_node_modified.edges = ["per_user_state"]
+                per_user_state_modified = per_user_state_node()
+                # Route per_user_state to wherever persona originally pointed so
+                # the rest of the pipeline is preserved for any graph shape.
+                per_user_state_modified.edges = original_persona_edges or [
+                    "inject_current_datetime"
+                ]
+                # Insert per_user_state immediately after the persona node.
+                current_graph = (
+                    current_graph[:persona_idx]
+                    + [persona_node_modified, per_user_state_modified]
+                    + current_graph[persona_idx + 1 :]
                 )
-                # Build a per-request graph with per_user_state inserted
-                current_graph = [
-                    persona_node_modified,
-                    per_user_state_modified,
-                ] + current_graph[
-                    1:
-                ]  # Skip the original persona node (index 0)
 
             # Build the agent graph using the provided parameters
             agent_graph = build_agent_graph(

--- a/bili/flask_api/flask_utils.py
+++ b/bili/flask_api/flask_utils.py
@@ -78,7 +78,6 @@ from langgraph.checkpoint.base import BaseCheckpointSaver
 
 from bili.auth.auth_manager import AuthManager
 from bili.iris.loaders.langchain_loader import GRAPH_NODE_REGISTRY, build_agent_graph
-from bili.iris.nodes.add_persona_and_summary import persona_and_summary_node
 from bili.iris.nodes.per_user_state import per_user_state_node
 from bili.utils.langgraph_utils import State
 from bili.utils.logging_utils import get_logger
@@ -359,14 +358,27 @@ def per_user_agent(
             # Check that the graph definition contains the per_user_state node.
             # Use a local variable so the outer graph_definition closure is never
             # rebound, avoiding a Python UnboundLocalError.
+            #
+            # graph_definition holds Node *instances* (e.g. DEFAULT_GRAPH_DEFINITION),
+            # while per_user_state_node is a Node *factory* (functools.partial), so
+            # membership must be tested by node name, not object identity.
             current_graph = graph_definition
-            if per_user_state_node not in current_graph:
-                # Create modified copies with updated edges
+            has_per_user_state = any(
+                getattr(node, "name", None) == "per_user_state"
+                for node in current_graph
+            )
+            if not has_per_user_state:
+                # Build fresh per-request Node instances so the shared
+                # graph_definition is never mutated. Re-point the existing
+                # persona node (index 0) at the new per_user_state node, and
+                # instantiate per_user_state from its factory pointed at the
+                # original next node. replace() requires dataclass instances,
+                # which is why per_user_state_node() is called first.
                 persona_node_modified = replace(
-                    persona_and_summary_node, edges=["per_user_state"]
+                    current_graph[0], edges=["per_user_state"]
                 )
                 per_user_state_modified = replace(
-                    per_user_state_node, edges=["inject_current_datetime"]
+                    per_user_state_node(), edges=["inject_current_datetime"]
                 )
                 # Build a per-request graph with per_user_state inserted
                 current_graph = [
@@ -374,7 +386,7 @@ def per_user_agent(
                     per_user_state_modified,
                 ] + current_graph[
                     1:
-                ]  # Skip original persona_and_summary_node
+                ]  # Skip the original persona node (index 0)
 
             # Build the agent graph using the provided parameters
             agent_graph = build_agent_graph(

--- a/bili/flask_api/flask_utils.py
+++ b/bili/flask_api/flask_utils.py
@@ -385,17 +385,28 @@ def per_user_agent(
                         "in graph_definition to insert per_user_state before"
                     )
                 # Deep-copy the persona node so the shared graph_definition and
-                # its nested mutable fields (conditional_edges, cache_policy) are
-                # never mutated. per_user_state is a fresh factory instance.
+                # its nested mutable fields are never mutated. per_user_state is
+                # a fresh factory instance.
                 persona_node_modified = copy.deepcopy(current_graph[persona_idx])
-                original_persona_edges = list(persona_node_modified.edges)
-                persona_node_modified.edges = ["per_user_state"]
                 per_user_state_modified = per_user_state_node()
-                # Route per_user_state to wherever persona originally pointed so
-                # the rest of the pipeline is preserved for any graph shape.
-                per_user_state_modified.edges = original_persona_edges or [
+                # per_user_state becomes the persona's successor and inherits ALL
+                # of the persona's original routing (static edges, conditional
+                # edges, conditional entry) so the rest of the pipeline, including
+                # any conditional branches, runs after the injection rather than
+                # bypassing it.
+                per_user_state_modified.edges = list(persona_node_modified.edges) or [
                     "inject_current_datetime"
                 ]
+                per_user_state_modified.conditional_edges = (
+                    persona_node_modified.conditional_edges
+                )
+                per_user_state_modified.conditional_entry = (
+                    persona_node_modified.conditional_entry
+                )
+                # The persona now routes unconditionally to per_user_state only.
+                persona_node_modified.edges = ["per_user_state"]
+                persona_node_modified.conditional_edges = []
+                persona_node_modified.conditional_entry = None
                 # Insert per_user_state immediately after the persona node.
                 current_graph = (
                     current_graph[:persona_idx]

--- a/bili/flask_api/tests/test_flask_app.py
+++ b/bili/flask_api/tests/test_flask_app.py
@@ -652,16 +652,16 @@ class TestRealFlaskAppRoutes:
             "weather_api_tool": {"default_prompt": "weather"},
             "serp_api_tool": {"default_prompt": "search"},
         }
-        # Seed the graph definition with the real per_user_state_node so the
-        # per_user_agent decorator takes its skip-path (it checks membership of
-        # that node) and does not hit the known dataclasses.replace() bug on the
-        # functools.partial node factories.
+        # Seed the graph definition with a per_user_state Node instance so the
+        # per_user_agent decorator takes its skip-path (it checks for a node
+        # named "per_user_state"). graph_definition holds Node instances, so the
+        # factory is called to build one.
         from bili.iris.nodes.per_user_state import (  # pylint: disable=import-outside-toplevel
             per_user_state_node,
         )
 
         patches["bili.iris.loaders.langchain_loader"].DEFAULT_GRAPH_DEFINITION = [
-            per_user_state_node
+            per_user_state_node()
         ]
         patches["bili.iris.loaders.langchain_loader"].build_agent_graph.return_value = (
             agent

--- a/bili/flask_api/tests/test_flask_app.py
+++ b/bili/flask_api/tests/test_flask_app.py
@@ -626,3 +626,267 @@ class TestRoleAuthorization:
             headers=_auth_header(sign_in["token"]),
         )
         assert resp.status_code == 200
+
+
+class TestRealFlaskAppRoutes:
+    """Exercise the real flask_app route handler bodies.
+
+    The real bili.flask_app module is reloaded with every heavy dependency
+    (LLM loader, checkpointer, tools loader, langchain loader, file IO) and
+    the auth manager replaced by configured mocks, so the route bodies run
+    end-to-end without any real LLM, database, or network access.
+    """
+
+    def _reload_with_mocks(self, auth_manager, agent):
+        """Reload flask_app with deps mocked and the given auth and agent."""
+        patches = {
+            "bili.iris.checkpointers.pg_checkpointer": MagicMock(),
+            "bili.iris.loaders.llm_loader": MagicMock(),
+            "bili.iris.loaders.tools_loader": MagicMock(),
+            "bili.iris.loaders.langchain_loader": MagicMock(),
+            "bili.iris.config.tool_config": MagicMock(),
+            "bili.utils.file_utils": MagicMock(),
+            "bili.utils.langgraph_utils": MagicMock(),
+        }
+        patches["bili.iris.config.tool_config"].TOOLS = {
+            "weather_api_tool": {"default_prompt": "weather"},
+            "serp_api_tool": {"default_prompt": "search"},
+        }
+        # Seed the graph definition with the real per_user_state_node so the
+        # per_user_agent decorator takes its skip-path (it checks membership of
+        # that node) and does not hit the known dataclasses.replace() bug on the
+        # functools.partial node factories.
+        from bili.iris.nodes.per_user_state import (  # pylint: disable=import-outside-toplevel
+            per_user_state_node,
+        )
+
+        patches["bili.iris.loaders.langchain_loader"].DEFAULT_GRAPH_DEFINITION = [
+            per_user_state_node
+        ]
+        patches["bili.iris.loaders.langchain_loader"].build_agent_graph.return_value = (
+            agent
+        )
+        patches["bili.utils.file_utils"].load_from_json.return_value = {
+            "default": {"persona": "You are helpful."}
+        }
+        patches["bili.utils.langgraph_utils"].State = dict
+
+        saved = {}
+        for mod_name, mock_mod in patches.items():
+            saved[mod_name] = sys.modules.get(mod_name)
+            sys.modules[mod_name] = mock_mod
+
+        with patch(
+            "bili.auth.auth_manager.get_auth_manager",
+            return_value=auth_manager,
+        ):
+            if "bili.flask_app" in sys.modules:
+                del sys.modules["bili.flask_app"]
+            import bili.flask_app as flask_app_mod  # pylint: disable=import-outside-toplevel
+
+        for mod_name, orig in saved.items():
+            if orig is None:
+                sys.modules.pop(mod_name, None)
+            else:
+                sys.modules[mod_name] = orig
+
+        return flask_app_mod
+
+    def _make_auth_manager(self, *, email_verified=True, sign_in_error=None):
+        """Build a configured auth-manager mock for the route bodies."""
+        mgr = MagicMock()
+        if sign_in_error is not None:
+            mgr.auth_provider.sign_in.side_effect = sign_in_error
+        else:
+            mgr.auth_provider.sign_in.return_value = {
+                "uid": "uid-1",
+                "token": "id-token-123",
+                "refreshToken": "refresh-token-456",
+            }
+        mgr.auth_provider.get_account_info.return_value = {
+            "email": _TEST_EMAIL,
+            "emailVerified": email_verified,
+        }
+        # auth_required reads these for protected routes.
+        mgr.auth_provider.verify_jwt_token.return_value = {
+            "email": _TEST_EMAIL,
+            "uid": "uid-1",
+        }
+        mgr.role_provider.is_authorized.return_value = True
+        mgr.profile_provider.get_user_profile.return_value = {"name": "Test"}
+        return mgr
+
+    def _make_agent(self):
+        """Build an agent mock whose invoke returns a well-formed result."""
+        agent = MagicMock()
+        agent.invoke.return_value = {
+            "messages": [MagicMock(content="Hello from the LLM")]
+        }
+        return agent
+
+    # ----- /login -----
+
+    def test_login_success_returns_token_and_sets_cookies(self):
+        """A valid login returns the token and sets auth cookies."""
+        mod = self._reload_with_mocks(self._make_auth_manager(), self._make_agent())
+        client = mod.app.test_client()
+        resp = client.post(
+            "/login", json={"email": _TEST_EMAIL, "password": _TEST_PASSWORD}
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["token"] == "id-token-123"
+        assert data["user"]["email"] == _TEST_EMAIL
+        cookie_names = [h.split("=")[0] for h in resp.headers.getlist("Set-Cookie")]
+        assert "id_token" in cookie_names
+        assert "refresh_token" in cookie_names
+
+    def test_login_missing_fields_returns_400(self):
+        """A login request without email or password returns 400."""
+        mod = self._reload_with_mocks(self._make_auth_manager(), self._make_agent())
+        client = mod.app.test_client()
+        resp = client.post("/login", json={"email": _TEST_EMAIL})
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "Email and password are required"
+
+    def test_login_unverified_email_returns_403(self):
+        """A login with an unverified email returns 403."""
+        mod = self._reload_with_mocks(
+            self._make_auth_manager(email_verified=False), self._make_agent()
+        )
+        client = mod.app.test_client()
+        resp = client.post(
+            "/login", json={"email": _TEST_EMAIL, "password": _TEST_PASSWORD}
+        )
+        assert resp.status_code == 403
+        assert "not verified" in resp.get_json()["error"].lower()
+
+    def test_login_auth_failure_returns_401(self):
+        """A sign-in error from the provider returns 401 with the message."""
+        mod = self._reload_with_mocks(
+            self._make_auth_manager(sign_in_error=ValueError("bad creds")),
+            self._make_agent(),
+        )
+        client = mod.app.test_client()
+        resp = client.post("/login", json={"email": _TEST_EMAIL, "password": "wrong"})
+        assert resp.status_code == 401
+        assert "bad creds" in resp.get_json()["error"]
+
+    # ----- /me -----
+
+    def test_me_returns_user_when_authenticated(self):
+        """The /me route returns the authenticated user from g.user."""
+        mod = self._reload_with_mocks(self._make_auth_manager(), self._make_agent())
+        client = mod.app.test_client()
+        resp = client.get("/me", headers={"Authorization": "Bearer any-token"})
+        assert resp.status_code == 200
+        assert resp.get_json()["user"]["email"] == _TEST_EMAIL
+
+    # ----- /nova_global -----
+
+    def test_nova_global_success_returns_response(self):
+        """The /nova_global route returns the agent's response."""
+        agent = self._make_agent()
+        mod = self._reload_with_mocks(self._make_auth_manager(), agent)
+        client = mod.app.test_client()
+        resp = client.get(
+            "/nova_global",
+            headers={"Authorization": "Bearer any-token"},
+            json={"prompt": "Hello"},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["response"] == "Hello from the LLM"
+
+    def test_nova_global_missing_body_returns_400(self):
+        """The /nova_global route returns 400 when the parsed body is empty."""
+        mod = self._reload_with_mocks(self._make_auth_manager(), self._make_agent())
+        client = mod.app.test_client()
+        # A JSON ``null`` body parses to None without raising, so the route's
+        # explicit "Request body is required" guard is exercised.
+        resp = client.get(
+            "/nova_global",
+            headers={"Authorization": "Bearer any-token"},
+            data="null",
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "Request body is required"
+
+    def test_nova_global_passes_conversation_id(self):
+        """The /nova_global route threads the conversation_id into the agent call."""
+        agent = self._make_agent()
+        mod = self._reload_with_mocks(self._make_auth_manager(), agent)
+        client = mod.app.test_client()
+        resp = client.get(
+            "/nova_global",
+            headers={"Authorization": "Bearer any-token"},
+            json={"prompt": "Hello", "conversation_id": "conv_7"},
+        )
+        assert resp.status_code == 200
+        config = agent.invoke.call_args[0][1]
+        assert config["configurable"]["thread_id"] == f"{_TEST_EMAIL}_conv_7"
+
+    # ----- /nova_per_user -----
+
+    @patch("bili.flask_api.flask_utils.build_agent_graph")
+    def test_nova_per_user_success_returns_response(self, mock_build):
+        """The /nova_per_user route returns the per-user agent's response."""
+        agent = self._make_agent()
+        mock_build.return_value = agent
+        mod = self._reload_with_mocks(self._make_auth_manager(), agent)
+        client = mod.app.test_client()
+        resp = client.get(
+            "/nova_per_user",
+            headers={"Authorization": "Bearer any-token"},
+            json={"prompt": "Hello"},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["response"] == "Hello from the LLM"
+
+    @patch("bili.flask_api.flask_utils.build_agent_graph")
+    def test_nova_per_user_missing_body_returns_400(self, mock_build):
+        """The /nova_per_user route returns 400 when the parsed body is empty."""
+        agent = self._make_agent()
+        mock_build.return_value = agent
+        mod = self._reload_with_mocks(self._make_auth_manager(), agent)
+        client = mod.app.test_client()
+        resp = client.get(
+            "/nova_per_user",
+            headers={"Authorization": "Bearer any-token"},
+            data="null",
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    # ----- /nova_stream -----
+
+    @patch("bili.flask_api.flask_utils.stream_agent_response")
+    def test_nova_stream_success_returns_event_stream(self, mock_stream):
+        """The /nova_stream route returns a text/event-stream response."""
+        mock_stream.return_value = iter(
+            ['event: token\ndata: {"content": "Hi"}\n\n', "event: done\ndata: {}\n\n"]
+        )
+        mod = self._reload_with_mocks(self._make_auth_manager(), self._make_agent())
+        client = mod.app.test_client()
+        resp = client.post(
+            "/nova_stream",
+            headers={"Authorization": "Bearer any-token"},
+            json={"prompt": "Hello"},
+        )
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.content_type
+
+    def test_nova_stream_missing_body_returns_400(self):
+        """The /nova_stream route returns 400 when the parsed body is empty."""
+        mod = self._reload_with_mocks(self._make_auth_manager(), self._make_agent())
+        client = mod.app.test_client()
+        # A JSON ``null`` body parses to None without raising, exercising the
+        # route's explicit "Request body is required" guard.
+        resp = client.post(
+            "/nova_stream",
+            headers={"Authorization": "Bearer any-token"},
+            data="null",
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "Request body is required"

--- a/bili/flask_api/tests/test_flask_utils.py
+++ b/bili/flask_api/tests/test_flask_utils.py
@@ -9,7 +9,7 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
-from flask import Flask, g, jsonify, make_response
+from flask import Flask, g, jsonify, make_response, request
 
 from bili.auth.auth_manager import AuthManager
 from bili.flask_api.flask_utils import (
@@ -18,9 +18,12 @@ from bili.flask_api.flask_utils import (
     auth_required,
     handle_agent_prompt,
     handle_agent_prompt_stream,
+    per_user_agent,
     set_token_cookies,
     stream_agent_response,
 )
+from bili.iris.nodes.add_persona_and_summary import persona_and_summary_node
+from bili.iris.nodes.per_user_state import per_user_state_node
 
 _JWT_SECRET = "utils-test-secret-key"
 _TEST_EMAIL = "util_test@example.com"
@@ -222,6 +225,28 @@ class TestAuthRequiredDecorator:
         )
         assert resp.status_code == 200
 
+    def test_profile_retrieval_failure_returns_401(self):
+        """A get_user_profile failure surfaces as a 401, not a 500."""
+
+        @self.app.route("/profile-fail")
+        @auth_required(self.auth_manager)
+        def profile_fail():
+            """Route reached only if the profile fetch succeeds."""
+            return jsonify({"ok": True})
+
+        client = self.app.test_client()
+        with patch.object(
+            self.auth_manager.profile_provider,
+            "get_user_profile",
+            side_effect=RuntimeError("profile store down"),
+        ):
+            resp = client.get(
+                "/profile-fail",
+                headers={"Authorization": f"Bearer {self.token}"},
+            )
+        assert resp.status_code == 401
+        assert resp.get_json()["error"] == "Failed to retrieve user profile"
+
     def test_no_role_requirement_skips_check(self):
         """When required_roles is None, role check is skipped."""
 
@@ -409,6 +434,18 @@ class TestHandleAgentPromptStream:
         _, status = result
         assert status == 400
 
+    @patch("bili.flask_api.flask_utils.stream_agent_response")
+    def test_conversation_id_builds_compound_thread_id(self, mock_stream):
+        """A conversation_id is combined with the email into the thread id."""
+        mock_stream.return_value = iter(["event: done\ndata: {}\n\n"])
+        user = {"email": "x@y.com"}
+        agent = MagicMock()
+        with self.app.test_request_context():
+            handle_agent_prompt_stream(user, agent, "Hi", conversation_id="conv-9")
+        # stream_agent_response(agent, prompt, thread_id) is called positionally.
+        thread_id = mock_stream.call_args[0][2]
+        assert thread_id == "x@y.com_conv-9"
+
 
 class TestAddUnauthorizedHandler:
     """Tests for add_unauthorized_handler middleware."""
@@ -445,3 +482,134 @@ class TestAddUnauthorizedHandler:
         client = app.test_client()
         resp = client.get("/fail")
         assert resp.status_code == 401
+
+    def test_successful_refresh_retries_and_updates_cookie(self):
+        """A 401 with a valid refresh token retries and sets new token cookies."""
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        auth_manager = MagicMock()
+        auth_manager.auth_provider.refresh_token.return_value = {
+            "id_token": "good-token",
+            "refresh_token": "new-refresh",
+        }
+        add_unauthorized_handler(auth_manager, app)
+
+        @app.route("/maybe")
+        def maybe_route():
+            """Return 200 only when the refreshed bearer token is present."""
+            if request.headers.get("Authorization") == "Bearer good-token":
+                return jsonify({"ok": True})
+            return jsonify({"error": "unauthorized"}), 401
+
+        client = app.test_client()
+        client.set_cookie("refresh_token", "stale-refresh")
+        resp = client.get("/maybe")
+        # The retry with the refreshed token succeeds, so the client sees 200.
+        assert resp.status_code == 200
+        auth_manager.auth_provider.refresh_token.assert_called_once_with(
+            "stale-refresh"
+        )
+        assert any("id_token=good-token" in h for h in _set_cookie_headers(resp))
+
+    def test_refresh_failure_returns_original_401(self):
+        """If the refresh call raises, the original 401 is returned unchanged."""
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        auth_manager = MagicMock()
+        auth_manager.auth_provider.refresh_token.side_effect = RuntimeError("boom")
+        add_unauthorized_handler(auth_manager, app)
+
+        @app.route("/fail2")
+        def fail2_route():
+            """Route that always returns 401."""
+            return jsonify({"error": "unauthorized"}), 401
+
+        client = app.test_client()
+        client.set_cookie("refresh_token", "stale-refresh")
+        resp = client.get("/fail2")
+        assert resp.status_code == 401
+
+
+class TestPerUserAgent:
+    """Tests for the per_user_agent decorator."""
+
+    def test_builds_graph_and_injects_current_user(self):
+        """With per_user_state present, the per-request graph injects current_user."""
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        node_kwargs = {"existing": "value"}
+        # A graph that already contains per_user_state_node takes the skip path.
+        graph_definition = [persona_and_summary_node, per_user_state_node]
+
+        decorated = per_user_agent(
+            checkpoint_saver=MagicMock(),
+            graph_definition=graph_definition,
+            node_kwargs=node_kwargs,
+        )(lambda: "route-result")
+
+        with app.test_request_context():
+            g.user = {"uid": "u1", "email": "u1@example.com"}
+            with patch("bili.flask_api.flask_utils.build_agent_graph") as mock_build:
+                result = decorated()
+                assert result == "route-result"
+                assert g.agent is mock_build.return_value
+            # current_user is injected per request without mutating the shared dict.
+            built_kwargs = mock_build.call_args.kwargs["node_kwargs"]
+            assert built_kwargs["current_user"] == {
+                "uid": "u1",
+                "email": "u1@example.com",
+            }
+            assert "current_user" not in node_kwargs
+
+    def test_prefers_user_profile_over_user(self):
+        """When g.user_profile is set it is used as current_user."""
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        graph_definition = [persona_and_summary_node, per_user_state_node]
+        decorated = per_user_agent(
+            checkpoint_saver=MagicMock(),
+            graph_definition=graph_definition,
+            node_kwargs={},
+        )(lambda: "ok")
+
+        with app.test_request_context():
+            g.user = {"uid": "u1"}
+            g.user_profile = {"uid": "u1", "first_name": "Ann"}
+            with patch("bili.flask_api.flask_utils.build_agent_graph") as mock_build:
+                decorated()
+            assert mock_build.call_args.kwargs["node_kwargs"]["current_user"] == {
+                "uid": "u1",
+                "first_name": "Ann",
+            }
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Known bug: when a graph lacks per_user_state_node the insertion "
+            "branch calls dataclasses.replace() on the persona/per_user_state "
+            "factory partials, which are not dataclass instances, so it raises "
+            "TypeError. Correct behavior is to insert a per_user_state node and "
+            "build the graph. Fix needs a decision on the factory-vs-instance "
+            "contract of build_agent_graph, so it is documented here, not pinned."
+        ),
+    )
+    def test_inserts_per_user_state_when_missing(self):
+        """A graph without per_user_state_node should still build successfully."""
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        graph_definition = [persona_and_summary_node]
+        decorated = per_user_agent(
+            checkpoint_saver=MagicMock(),
+            graph_definition=graph_definition,
+            node_kwargs={},
+        )(lambda: "ok")
+
+        with app.test_request_context():
+            g.user = {"uid": "u1"}
+            with patch("bili.flask_api.flask_utils.build_agent_graph"):
+                assert decorated() == "ok"
+
+
+def _set_cookie_headers(resp):
+    """Return all Set-Cookie header values from a Flask test response."""
+    return [value for key, value in resp.headers if key == "Set-Cookie"]

--- a/bili/flask_api/tests/test_flask_utils.py
+++ b/bili/flask_api/tests/test_flask_utils.py
@@ -613,12 +613,35 @@ class TestPerUserAgent:
             assert names[0] == "add_persona_and_summary"
             assert names[1] == "per_user_state"
             assert built_graph[0].edges == ["per_user_state"]
+            # per_user_state inherits the persona's original out-edges.
             assert built_graph[1].edges == ["inject_current_datetime"]
-            # The shared DEFAULT_GRAPH_DEFINITION is never mutated.
+            # The shared DEFAULT_GRAPH_DEFINITION is never mutated (deep copy).
             assert all(
                 getattr(n, "name", None) != "per_user_state"
                 for n in DEFAULT_GRAPH_DEFINITION
             )
+            assert DEFAULT_GRAPH_DEFINITION[0].edges == ["inject_current_datetime"]
+
+    def test_raises_when_graph_has_no_persona_node(self):
+        """A graph lacking a persona node raises rather than rewiring index 0."""
+        from bili.iris.nodes.inject_current_datetime import (  # pylint: disable=import-outside-toplevel
+            inject_current_datetime_node,
+        )
+
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        # A non-empty graph whose first node is not the persona node.
+        decorated = per_user_agent(
+            checkpoint_saver=MagicMock(),
+            graph_definition=[inject_current_datetime_node()],
+            node_kwargs={},
+        )(lambda: "ok")
+
+        with app.test_request_context():
+            g.user = {"uid": "u1"}
+            with patch("bili.flask_api.flask_utils.build_agent_graph"):
+                with pytest.raises(ValueError, match="add_persona_and_summary"):
+                    decorated()
 
 
 def _set_cookie_headers(resp):

--- a/bili/flask_api/tests/test_flask_utils.py
+++ b/bili/flask_api/tests/test_flask_utils.py
@@ -643,6 +643,43 @@ class TestPerUserAgent:
                 with pytest.raises(ValueError, match="add_persona_and_summary"):
                     decorated()
 
+    def test_persona_conditional_routing_transfers_to_per_user_state(self):
+        """per_user_state inherits the persona's conditional routing, not persona."""
+        from bili.iris.nodes.add_persona_and_summary import (  # pylint: disable=import-outside-toplevel
+            persona_and_summary_node,
+        )
+
+        persona = persona_and_summary_node()
+        persona.edges = ["inject_current_datetime"]
+        persona.conditional_edges = [("cond", "react_agent")]
+        persona.conditional_entry = "entry_sentinel"
+
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        decorated = per_user_agent(
+            checkpoint_saver=MagicMock(),
+            graph_definition=[persona],
+            node_kwargs={},
+        )(lambda: "ok")
+
+        with app.test_request_context():
+            g.user = {"uid": "u1"}
+            with patch("bili.flask_api.flask_utils.build_agent_graph") as mock_build:
+                decorated()
+            built = mock_build.call_args.kwargs["graph_definition"]
+            persona_built, per_user_state_built = built[0], built[1]
+            # persona now routes unconditionally to per_user_state only.
+            assert persona_built.edges == ["per_user_state"]
+            assert persona_built.conditional_edges == []
+            assert persona_built.conditional_entry is None
+            # per_user_state inherits the persona's original routing.
+            assert per_user_state_built.edges == ["inject_current_datetime"]
+            assert per_user_state_built.conditional_edges == [("cond", "react_agent")]
+            assert per_user_state_built.conditional_entry == "entry_sentinel"
+            # The caller's persona instance is not mutated (deep copy).
+            assert persona.edges == ["inject_current_datetime"]
+            assert persona.conditional_edges == [("cond", "react_agent")]
+
 
 def _set_cookie_headers(resp):
     """Return all Set-Cookie header values from a Flask test response."""

--- a/bili/flask_api/tests/test_flask_utils.py
+++ b/bili/flask_api/tests/test_flask_utils.py
@@ -531,15 +531,19 @@ class TestAddUnauthorizedHandler:
 
 
 class TestPerUserAgent:
-    """Tests for the per_user_agent decorator."""
+    """Tests for the per_user_agent decorator.
+
+    graph_definition holds Node instances (as DEFAULT_GRAPH_DEFINITION does),
+    so these tests build instances by calling the node factories.
+    """
 
     def test_builds_graph_and_injects_current_user(self):
         """With per_user_state present, the per-request graph injects current_user."""
         app = Flask(__name__)
         app.config["TESTING"] = True
         node_kwargs = {"existing": "value"}
-        # A graph that already contains per_user_state_node takes the skip path.
-        graph_definition = [persona_and_summary_node, per_user_state_node]
+        # A graph that already contains a per_user_state node takes the skip path.
+        graph_definition = [persona_and_summary_node(), per_user_state_node()]
 
         decorated = per_user_agent(
             checkpoint_saver=MagicMock(),
@@ -553,6 +557,8 @@ class TestPerUserAgent:
                 result = decorated()
                 assert result == "route-result"
                 assert g.agent is mock_build.return_value
+            # The skip path passes the graph through unchanged (per_user_state present).
+            assert mock_build.call_args.kwargs["graph_definition"] is graph_definition
             # current_user is injected per request without mutating the shared dict.
             built_kwargs = mock_build.call_args.kwargs["node_kwargs"]
             assert built_kwargs["current_user"] == {
@@ -565,7 +571,7 @@ class TestPerUserAgent:
         """When g.user_profile is set it is used as current_user."""
         app = Flask(__name__)
         app.config["TESTING"] = True
-        graph_definition = [persona_and_summary_node, per_user_state_node]
+        graph_definition = [persona_and_summary_node(), per_user_state_node()]
         decorated = per_user_agent(
             checkpoint_saver=MagicMock(),
             graph_definition=graph_definition,
@@ -582,32 +588,37 @@ class TestPerUserAgent:
                 "first_name": "Ann",
             }
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Known bug: when a graph lacks per_user_state_node the insertion "
-            "branch calls dataclasses.replace() on the persona/per_user_state "
-            "factory partials, which are not dataclass instances, so it raises "
-            "TypeError. Correct behavior is to insert a per_user_state node and "
-            "build the graph. Fix needs a decision on the factory-vs-instance "
-            "contract of build_agent_graph, so it is documented here, not pinned."
-        ),
-    )
     def test_inserts_per_user_state_when_missing(self):
-        """A graph without per_user_state_node should still build successfully."""
+        """A graph without per_user_state has one inserted before building."""
+        from bili.iris.loaders.langchain_loader import (  # pylint: disable=import-outside-toplevel
+            DEFAULT_GRAPH_DEFINITION,
+        )
+
         app = Flask(__name__)
         app.config["TESTING"] = True
-        graph_definition = [persona_and_summary_node]
         decorated = per_user_agent(
             checkpoint_saver=MagicMock(),
-            graph_definition=graph_definition,
+            graph_definition=DEFAULT_GRAPH_DEFINITION,
             node_kwargs={},
         )(lambda: "ok")
 
         with app.test_request_context():
             g.user = {"uid": "u1"}
-            with patch("bili.flask_api.flask_utils.build_agent_graph"):
+            with patch("bili.flask_api.flask_utils.build_agent_graph") as mock_build:
                 assert decorated() == "ok"
+
+            built_graph = mock_build.call_args.kwargs["graph_definition"]
+            names = [getattr(n, "name", None) for n in built_graph]
+            # per_user_state is inserted at index 1, persona re-pointed to it.
+            assert names[0] == "add_persona_and_summary"
+            assert names[1] == "per_user_state"
+            assert built_graph[0].edges == ["per_user_state"]
+            assert built_graph[1].edges == ["inject_current_datetime"]
+            # The shared DEFAULT_GRAPH_DEFINITION is never mutated.
+            assert all(
+                getattr(n, "name", None) != "per_user_state"
+                for n in DEFAULT_GRAPH_DEFINITION
+            )
 
 
 def _set_cookie_headers(resp):

--- a/bili/iris/checkpointers/migrations/mongo/tests/test_v1_to_v2.py
+++ b/bili/iris/checkpointers/migrations/mongo/tests/test_v1_to_v2.py
@@ -4,15 +4,22 @@ Covers needs_migration detection, metadata migration, blob
 transcoding, and batch collection migration with mocked MongoDB.
 """
 
+import json
 from unittest.mock import MagicMock, patch
 
+import bson
+import msgpack
 import pytest
 
 from bili.iris.checkpointers.migrations.mongo.v1_to_v2 import (
+    _custom_ext_decoder,
+    _decode_msgpack_blob,
     _json_bytes_handler,
     _migrate_blob,
     _migrate_metadata,
     _needs_migration,
+    _unwrap_binary_value,
+    migrate_all_collections,
     migrate_checkpoint_collection,
     migrate_v1_to_v2,
 )
@@ -277,3 +284,282 @@ class TestMigrateCheckpointCollection:
         stats = migrate_checkpoint_collection(collection, dry_run=False)
         # msgpack with non-bytes value should fail gracefully
         assert stats["failed"] + stats["migrated"] + stats["skipped"] > 0
+
+    def test_batch_progress_logging_threshold(self):
+        """Crossing the batch_size threshold logs progress without error."""
+        collection = MagicMock()
+        # Two documents that both need migration, batch_size=1 forces the
+        # progress-logging branch on each migrated document.
+        docs = [
+            {
+                "_id": f"id{i}",
+                "thread_id": "t1",
+                "type": "json",
+                "metadata": {"source": "loop"},
+            }
+            for i in range(2)
+        ]
+        collection.find.return_value = docs
+        stats = migrate_checkpoint_collection(collection, dry_run=False, batch_size=1)
+        assert stats["migrated"] == 2
+        assert collection.update_one.call_count == 2
+
+    def test_update_failure_increments_failed(self):
+        """An exception during update_one increments the failed counter."""
+        collection = MagicMock()
+        doc = {
+            "_id": "id1",
+            "thread_id": "t1",
+            "type": "json",
+            "metadata": {"source": "loop"},
+        }
+        collection.find.return_value = [doc]
+        collection.update_one.side_effect = RuntimeError("db down")
+        stats = migrate_checkpoint_collection(collection, dry_run=False)
+        assert stats["failed"] == 1
+        assert stats["migrated"] == 0
+
+
+# =========================================================================
+# _custom_ext_decoder
+# =========================================================================
+
+
+class TestCustomExtDecoder:
+    """Tests for the nested msgpack extension decoder."""
+
+    def test_non_code5_returns_exttype(self):
+        """Non-5 extension codes are returned as ExtType placeholders."""
+        result = _custom_ext_decoder(7, b"payload")
+        assert isinstance(result, msgpack.ExtType)
+        assert result.code == 7
+        assert result.data == b"payload"
+
+    def test_code5_unpacks_nested_payload(self):
+        """Code 5 recursively unpacks the nested msgpack payload."""
+        nested = msgpack.packb({"inner": "value"})
+        result = _custom_ext_decoder(5, nested)
+        assert result == {"inner": "value"}
+
+    def test_code5_unpack_failure_returns_placeholder(self):
+        """A code-5 payload that fails to unpack yields a placeholder string."""
+        # 0xc1 is the reserved/never-used msgpack byte and raises on unpack.
+        result = _custom_ext_decoder(5, b"\xc1")
+        assert isinstance(result, str)
+        assert "Failed to unpack ExtType(5)" in result
+
+
+# =========================================================================
+# _decode_msgpack_blob
+# =========================================================================
+
+
+class TestDecodeMsgpackBlob:
+    """Tests for raw msgpack blob decoding."""
+
+    def test_decodes_packed_dict(self):
+        """A packed dict round-trips through the decoder."""
+        packed = msgpack.packb({"a": 1, "b": [2, 3]})
+        assert _decode_msgpack_blob(packed) == {"a": 1, "b": [2, 3]}
+
+    def test_raises_when_msgpack_unavailable(self):
+        """A RuntimeError is raised when msgpack is not installed."""
+        with patch(
+            "bili.iris.checkpointers.migrations.mongo.v1_to_v2.MSGPACK_AVAILABLE",
+            False,
+        ):
+            with pytest.raises(RuntimeError, match="msgpack package required"):
+                _decode_msgpack_blob(b"\x00")
+
+
+# =========================================================================
+# _json_bytes_handler (latin-1 fallback)
+# =========================================================================
+
+
+class TestJsonBytesHandlerLatin1:
+    """Tests for the latin-1 fallback in the bytes handler."""
+
+    def test_non_utf8_bytes_decoded_as_latin1(self):
+        """Bytes that are not valid UTF-8 fall back to latin-1 decoding."""
+        # 0xff is invalid as a standalone UTF-8 byte but valid latin-1.
+        result = _json_bytes_handler(b"\xff")
+        assert result == "\xff"
+
+
+# =========================================================================
+# _unwrap_binary_value
+# =========================================================================
+
+
+class TestUnwrapBinaryValue:
+    """Tests for unwrapping bson.Binary metadata values."""
+
+    def test_non_binary_passthrough(self):
+        """Non-Binary values are returned unchanged."""
+        assert _unwrap_binary_value("plain") == "plain"
+
+    def test_binary_json_string_parsed(self):
+        """A Binary wrapping a JSON string is parsed into the value."""
+        wrapped = bson.Binary(b'"loop"')
+        assert _unwrap_binary_value(wrapped) == "loop"
+
+    def test_binary_json_object_parsed(self):
+        """A Binary wrapping a JSON object is parsed into a dict."""
+        wrapped = bson.Binary(b'{"k": 1}')
+        assert _unwrap_binary_value(wrapped) == {"k": 1}
+
+    def test_binary_invalid_json_returns_string(self):
+        """A Binary that looks like JSON but is invalid returns the raw string."""
+        wrapped = bson.Binary(b"{not json")
+        assert _unwrap_binary_value(wrapped) == "{not json"
+
+    def test_binary_plain_text_returns_string(self):
+        """A Binary wrapping plain (non-JSON-looking) text returns the string."""
+        wrapped = bson.Binary(b"hello")
+        assert _unwrap_binary_value(wrapped) == "hello"
+
+    def test_binary_non_utf8_returns_raw_bytes(self):
+        """A Binary that cannot decode as UTF-8 returns the raw bytes."""
+        wrapped = bson.Binary(b"\xff\xfe")
+        assert _unwrap_binary_value(wrapped) == b"\xff\xfe"
+
+
+# =========================================================================
+# _migrate_metadata (step conversion failure)
+# =========================================================================
+
+
+class TestMigrateMetadataStepFailure:
+    """Tests for the step-to-int conversion failure path."""
+
+    def test_unconvertible_step_used_as_is(self):
+        """A step value that cannot become an int is wrapped as-is."""
+        metadata = {"step": "not-a-number"}
+        result = _migrate_metadata(metadata)
+        # The value is JSON-serialized unchanged after the conversion fails.
+        assert result["step"] == ["json", '"not-a-number"']
+
+
+# =========================================================================
+# _migrate_blob (bson Binary and exception paths)
+# =========================================================================
+
+
+class TestMigrateBlobBsonPaths:
+    """Tests for blob migration with bson.Binary and error handling."""
+
+    def test_bson_binary_value_transcoded(self):
+        """A bson.Binary msgpack value is unwrapped and transcoded to json."""
+        packed = msgpack.packb({"x": 1})
+        doc = {"type": "msgpack", "checkpoint": bson.Binary(packed)}
+        new_type, new_value = _migrate_blob(doc)
+        assert new_type == "json"
+        # bson available, so the result is wrapped in a Binary of JSON bytes.
+        assert isinstance(new_value, bson.Binary)
+        assert json.loads(bytes(new_value).decode("utf-8")) == {"x": 1}
+
+    def test_blob_decode_exception_returns_none(self):
+        """A decode failure inside _migrate_blob returns (None, None)."""
+        # Valid bytes but invalid msgpack content triggers the except branch.
+        doc = {"type": "msgpack", "checkpoint": b"\xc1"}
+        new_type, new_value = _migrate_blob(doc)
+        assert new_type is None
+        assert new_value is None
+
+    def test_no_bson_produces_plain_bytes(self):
+        """When bson is unavailable, the new value is plain JSON bytes."""
+        packed = msgpack.packb({"y": 2})
+        doc = {"type": "msgpack", "checkpoint": packed}
+        with patch(
+            "bili.iris.checkpointers.migrations.mongo.v1_to_v2.BSON_AVAILABLE",
+            False,
+        ):
+            new_type, new_value = _migrate_blob(doc)
+        assert new_type == "json"
+        assert isinstance(new_value, bytes)
+        assert msgpack.packb is not None  # sanity
+        assert new_value == b'{"y": 2}'
+
+
+# =========================================================================
+# migrate_v1_to_v2 (blob migration application)
+# =========================================================================
+
+
+class TestMigrateV1ToV2BlobApplication:
+    """Tests that blob migration updates are applied to the document."""
+
+    def test_msgpack_blob_migrated_to_json(self):
+        """A msgpack checkpoint blob is transcoded and the type updated."""
+        packed = msgpack.packb({"channel_values": {"messages": []}})
+        doc = {
+            "thread_id": "t1",
+            "type": "msgpack",
+            "checkpoint": bson.Binary(packed),
+            "metadata": {"source": "loop", "step": 1},
+        }
+        result = migrate_v1_to_v2(doc)
+        assert result["type"] == "json"
+        assert isinstance(result["checkpoint"], bson.Binary)
+        assert result["metadata"]["source"] == ["json", '"loop"']
+
+    def test_value_field_blob_migrated(self):
+        """A document using the 'value' field instead of 'checkpoint' migrates."""
+        packed = msgpack.packb({"data": 1})
+        doc = {
+            "thread_id": "t2",
+            "type": "msgpack",
+            "value": bson.Binary(packed),
+        }
+        result = migrate_v1_to_v2(doc)
+        assert result["type"] == "json"
+        assert isinstance(result["value"], bson.Binary)
+
+
+# =========================================================================
+# migrate_all_collections
+# =========================================================================
+
+
+class TestMigrateAllCollections:
+    """Tests for the database-wide collection migration utility."""
+
+    def test_skips_absent_collections(self):
+        """Collections not present in the database are skipped."""
+        db = MagicMock()
+        db.list_collection_names.return_value = ["checkpoints"]
+        checkpoint_col = MagicMock()
+        checkpoint_col.find.return_value = []
+        db.__getitem__.return_value = checkpoint_col
+
+        all_stats = migrate_all_collections(db, dry_run=True)
+        # Only the present collection is reported on.
+        assert list(all_stats.keys()) == ["checkpoints"]
+        assert all_stats["checkpoints"] == {
+            "migrated": 0,
+            "skipped": 0,
+            "failed": 0,
+        }
+
+    def test_migrates_present_collections(self):
+        """Present collections are migrated and their stats collected."""
+        db = MagicMock()
+        db.list_collection_names.return_value = [
+            "checkpoints",
+            "checkpoint_writes",
+        ]
+        col = MagicMock()
+        col.find.return_value = [
+            {
+                "_id": "a",
+                "thread_id": "t1",
+                "type": "json",
+                "metadata": {"source": "loop"},
+            }
+        ]
+        db.__getitem__.return_value = col
+
+        all_stats = migrate_all_collections(db, dry_run=False)
+        assert set(all_stats.keys()) == {"checkpoints", "checkpoint_writes"}
+        assert all_stats["checkpoints"]["migrated"] == 1

--- a/bili/iris/checkpointers/migrations/mongo/v1_to_v2.py
+++ b/bili/iris/checkpointers/migrations/mongo/v1_to_v2.py
@@ -37,7 +37,7 @@ try:
     import msgpack
 
     MSGPACK_AVAILABLE = True
-except ImportError:
+except ImportError:  # pragma: no cover - msgpack is a hard dependency in this env
     MSGPACK_AVAILABLE = False
     LOGGER.warning(
         "msgpack not available - migration may fail for msgpack-encoded data"
@@ -48,7 +48,7 @@ try:
     import bson
 
     BSON_AVAILABLE = True
-except ImportError:
+except ImportError:  # pragma: no cover - bson ships with pymongo in this env
     BSON_AVAILABLE = False
     LOGGER.warning("bson not available - migration may have limited Binary support")
 

--- a/bili/iris/checkpointers/pg_checkpointer.py
+++ b/bili/iris/checkpointers/pg_checkpointer.py
@@ -43,6 +43,7 @@ Example:
     pg_checkpointer = get_pg_checkpointer()
 """
 
+import asyncio
 import atexit
 import contextlib
 import os
@@ -874,10 +875,10 @@ class PruningPostgresSaver(
                 msg_class = msg.get("type", msg.get("__class__", "unknown"))
                 # Handle serialized format where type might be in different places
                 if msg_class == "unknown" and "kwargs" in msg:
+                    raw_id = msg.get("id")
+                    # Guard against an empty id list: [][-1] would raise.
                     msg_class = (
-                        msg.get("id", ["unknown"])[-1]
-                        if isinstance(msg.get("id"), list)
-                        else "unknown"
+                        raw_id[-1] if isinstance(raw_id, list) and raw_id else "unknown"
                     )
             elif hasattr(msg, "__class__"):
                 msg_class = msg.__class__.__name__
@@ -1286,6 +1287,42 @@ class AsyncPruningPostgresSaver(
     def thread_exists(self, thread_id: str) -> bool:
         """Check whether a thread exists (delegates to the sync saver)."""
         return self._get_query_delegate().thread_exists(thread_id)
+
+    # Async variants: run the blocking sync query (and its lazy first-call
+    # schema migration) in a worker thread so async callers never block the
+    # event loop. These mirror the async Mongo saver's a*-prefixed methods.
+
+    async def aget_user_threads(
+        self, user_identifier: str, limit: int | None = None, offset: int = 0
+    ) -> list[dict[str, Any]]:
+        """Async variant of get_user_threads (runs off the event loop)."""
+        return await asyncio.to_thread(
+            self.get_user_threads, user_identifier, limit, offset
+        )
+
+    async def aget_thread_messages(
+        self,
+        thread_id: str,
+        limit: int | None = None,
+        offset: int = 0,
+        message_types: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Async variant of get_thread_messages (runs off the event loop)."""
+        return await asyncio.to_thread(
+            self.get_thread_messages, thread_id, limit, offset, message_types
+        )
+
+    async def adelete_thread(self, thread_id: str) -> bool:
+        """Async variant of delete_thread (runs off the event loop)."""
+        return await asyncio.to_thread(self.delete_thread, thread_id)
+
+    async def aget_user_stats(self, user_identifier: str) -> dict[str, Any]:
+        """Async variant of get_user_stats (runs off the event loop)."""
+        return await asyncio.to_thread(self.get_user_stats, user_identifier)
+
+    async def athread_exists(self, thread_id: str) -> bool:
+        """Async variant of thread_exists (runs off the event loop)."""
+        return await asyncio.to_thread(self.thread_exists, thread_id)
 
     async def aput(
         self,

--- a/bili/iris/checkpointers/pg_checkpointer.py
+++ b/bili/iris/checkpointers/pg_checkpointer.py
@@ -865,10 +865,11 @@ class PruningPostgresSaver(
 
         messages = []
         for msg in raw_messages:
-            # Get message type - handle both objects and dicts
-            if hasattr(msg, "__class__"):
-                msg_class = msg.__class__.__name__
-            elif isinstance(msg, dict):
+            # Get message type - handle both objects and dicts. Check dict
+            # first: every Python object (including dict) has __class__, so a
+            # leading hasattr(msg, "__class__") guard would always win and the
+            # dict-specific type extraction below would be dead code.
+            if isinstance(msg, dict):
                 # For dict-like messages, try to determine type from 'type' field
                 msg_class = msg.get("type", msg.get("__class__", "unknown"))
                 # Handle serialized format where type might be in different places
@@ -878,6 +879,8 @@ class PruningPostgresSaver(
                         if isinstance(msg.get("id"), list)
                         else "unknown"
                     )
+            elif hasattr(msg, "__class__"):
+                msg_class = msg.__class__.__name__
             else:
                 msg_class = "unknown"
 
@@ -1089,7 +1092,7 @@ async def get_async_pg_checkpointer(keep_last_n: int = 5, user_id: str | None = 
         checkpointer = AsyncPruningPostgresSaver(
             pg_pool, keep_last_n=keep_last_n, user_id=user_id
         )
-        await checkpointer.asetup()  # Async setup
+        await checkpointer.setup()  # Async setup (AsyncPostgresSaver.setup is a coroutine)
         await checkpointer.aensure_indexes()  # Create indexes
         return checkpointer
     return None

--- a/bili/iris/checkpointers/pg_checkpointer.py
+++ b/bili/iris/checkpointers/pg_checkpointer.py
@@ -1098,7 +1098,9 @@ async def get_async_pg_checkpointer(keep_last_n: int = 5, user_id: str | None = 
     return None
 
 
-class AsyncPruningPostgresSaver(VersionedCheckpointerMixin, AsyncPostgresSaver):
+class AsyncPruningPostgresSaver(
+    VersionedCheckpointerMixin, QueryableCheckpointerMixin, AsyncPostgresSaver
+):
     """
     Async version of PruningPostgresSaver for streaming operations.
 
@@ -1107,6 +1109,12 @@ class AsyncPruningPostgresSaver(VersionedCheckpointerMixin, AsyncPostgresSaver):
 
     Also implements:
     - VersionedCheckpointerMixin: Version detection and lazy migration
+    - QueryableCheckpointerMixin: Query methods for conversation data retrieval.
+      Thread-ownership validation (_validate_thread_ownership) lives in this
+      mixin, so it must be in the base list for aput/aget_tuple to enforce
+      multi-tenant isolation. The five query methods are satisfied by
+      delegating to a sync PruningPostgresSaver that shares this saver's sync
+      connection pool, reusing the tested sync SQL without duplicating it.
     """
 
     # Identify this checkpointer type for migrations
@@ -1140,6 +1148,9 @@ class AsyncPruningPostgresSaver(VersionedCheckpointerMixin, AsyncPostgresSaver):
         self._async_txn_conn = None
         # Lazy-initialized sync pool for migration operations
         self._sync_pool: ConnectionPool | None = None
+        # Lazy-initialized sync saver used to satisfy the QueryableCheckpointerMixin
+        # query methods (it reuses the sync SQL over this saver's sync pool).
+        self._query_delegate: "PruningPostgresSaver | None" = None
 
     @asynccontextmanager
     async def _cursor(self, *, pipeline: bool = False):
@@ -1224,6 +1235,57 @@ class AsyncPruningPostgresSaver(VersionedCheckpointerMixin, AsyncPostgresSaver):
             if not index_exists:
                 LOGGER.info("Creating user_id index on checkpoints table (async)")
                 await cur.execute(_SQL_CREATE_USER_ID_INDEX)
+
+    # ------------------------------------------------------------------
+    # QueryableCheckpointerMixin methods
+    #
+    # These are inherently synchronous (they return materialized lists, not
+    # awaitables). To avoid duplicating the sync SQL, they delegate to a
+    # PruningPostgresSaver that shares this saver's sync connection pool and
+    # user_id, so ownership validation and results match the sync path.
+    # ------------------------------------------------------------------
+
+    def _get_query_delegate(self) -> "PruningPostgresSaver":
+        """Return (lazily creating) the sync saver used for query methods."""
+        if self._query_delegate is None:
+            self._query_delegate = PruningPostgresSaver(
+                self._get_sync_pool(),
+                keep_last_n=self.keep_last_n,
+                user_id=self.user_id,
+            )
+        return self._query_delegate
+
+    def get_user_threads(
+        self, user_identifier: str, limit: int | None = None, offset: int = 0
+    ) -> list[dict[str, Any]]:
+        """Get all conversation threads for a user (delegates to the sync saver)."""
+        return self._get_query_delegate().get_user_threads(
+            user_identifier, limit, offset
+        )
+
+    def get_thread_messages(
+        self,
+        thread_id: str,
+        limit: int | None = None,
+        offset: int = 0,
+        message_types: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Get messages from a conversation thread (delegates to the sync saver)."""
+        return self._get_query_delegate().get_thread_messages(
+            thread_id, limit, offset, message_types
+        )
+
+    def delete_thread(self, thread_id: str) -> bool:
+        """Delete all checkpoints for a thread (delegates to the sync saver)."""
+        return self._get_query_delegate().delete_thread(thread_id)
+
+    def get_user_stats(self, user_identifier: str) -> dict[str, Any]:
+        """Get usage statistics for a user (delegates to the sync saver)."""
+        return self._get_query_delegate().get_user_stats(user_identifier)
+
+    def thread_exists(self, thread_id: str) -> bool:
+        """Check whether a thread exists (delegates to the sync saver)."""
+        return self._get_query_delegate().thread_exists(thread_id)
 
     async def aput(
         self,

--- a/bili/iris/checkpointers/pg_checkpointer.py
+++ b/bili/iris/checkpointers/pg_checkpointer.py
@@ -1152,6 +1152,10 @@ class AsyncPruningPostgresSaver(
         # Lazy-initialized sync saver used to satisfy the QueryableCheckpointerMixin
         # query methods (it reuses the sync SQL over this saver's sync pool).
         self._query_delegate: "PruningPostgresSaver | None" = None
+        # Guards lazy delegate construction: concurrent a*-query coroutines run
+        # in separate to_thread workers and would otherwise each build a delegate
+        # (and re-run its schema migration) in a check-then-act race.
+        self._query_delegate_lock = threading.Lock()
 
     @asynccontextmanager
     async def _cursor(self, *, pipeline: bool = False):
@@ -1248,12 +1252,17 @@ class AsyncPruningPostgresSaver(
 
     def _get_query_delegate(self) -> "PruningPostgresSaver":
         """Return (lazily creating) the sync saver used for query methods."""
+        # Double-checked locking: skip the lock on the hot path once built, but
+        # serialize the one-time construction (and its schema migration) so
+        # concurrent a*-query workers don't each build a delegate.
         if self._query_delegate is None:
-            self._query_delegate = PruningPostgresSaver(
-                self._get_sync_pool(),
-                keep_last_n=self.keep_last_n,
-                user_id=self.user_id,
-            )
+            with self._query_delegate_lock:
+                if self._query_delegate is None:
+                    self._query_delegate = PruningPostgresSaver(
+                        self._get_sync_pool(),
+                        keep_last_n=self.keep_last_n,
+                        user_id=self.user_id,
+                    )
         return self._query_delegate
 
     def get_user_threads(

--- a/bili/iris/checkpointers/tests/test_checkpointer_functions.py
+++ b/bili/iris/checkpointers/tests/test_checkpointer_functions.py
@@ -1,9 +1,16 @@
 """Tests for bili.iris.checkpointers.checkpointer_functions factory."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
-from bili.iris.checkpointers.checkpointer_functions import get_checkpointer
+import pytest
+
+from bili.iris.checkpointers.checkpointer_functions import (
+    get_async_checkpointer,
+    get_checkpointer,
+)
 from bili.iris.checkpointers.memory_checkpointer import QueryableMemorySaver
+
+pytestmark = pytest.mark.anyio
 
 
 class TestGetCheckpointer:
@@ -14,6 +21,38 @@ class TestGetCheckpointer:
         """With no database env vars, should fall back to QueryableMemorySaver."""
         checkpointer = get_checkpointer()
         assert isinstance(checkpointer, QueryableMemorySaver)
+
+    @patch("bili.iris.checkpointers.checkpointer_functions.get_pg_checkpointer")
+    @patch.dict(
+        "os.environ",
+        {"POSTGRES_CONNECTION_STRING": "postgresql://localhost"},
+        clear=True,
+    )
+    def test_returns_pg_checkpointer_when_postgres_set(self, mock_get_pg):
+        """POSTGRES_CONNECTION_STRING routes to the PostgreSQL checkpointer."""
+        sentinel = object()
+        mock_get_pg.return_value = sentinel
+        checkpointer = get_checkpointer()
+        assert checkpointer is sentinel
+        mock_get_pg.assert_called_once_with()
+
+    @patch("bili.iris.checkpointers.checkpointer_functions.get_mongo_checkpointer")
+    @patch("bili.iris.checkpointers.checkpointer_functions.get_pg_checkpointer")
+    @patch.dict(
+        "os.environ",
+        {"MONGO_CONNECTION_STRING": "mongodb://localhost"},
+        clear=True,
+    )
+    def test_returns_mongo_checkpointer_when_only_mongo_set(
+        self, mock_get_pg, mock_get_mongo
+    ):
+        """MONGO_CONNECTION_STRING routes to the Mongo checkpointer when PG is unset."""
+        sentinel = object()
+        mock_get_mongo.return_value = sentinel
+        checkpointer = get_checkpointer()
+        assert checkpointer is sentinel
+        mock_get_mongo.assert_called_once_with()
+        mock_get_pg.assert_not_called()
 
     @patch.dict(
         "os.environ",
@@ -31,3 +70,54 @@ class TestGetCheckpointer:
         # QueryableMemorySaver inherits from MemorySaver which is always functional
         assert hasattr(checkpointer, "get")
         assert hasattr(checkpointer, "put")
+
+
+class TestGetAsyncCheckpointer:
+    """Test the async checkpointer factory function."""
+
+    @patch.dict("os.environ", {}, clear=True)
+    async def test_returns_memory_saver_when_no_env_vars(self):
+        """With no database env vars, falls back to QueryableMemorySaver."""
+        checkpointer = await get_async_checkpointer()
+        assert isinstance(checkpointer, QueryableMemorySaver)
+
+    @patch(
+        "bili.iris.checkpointers.checkpointer_functions.get_async_pg_checkpointer",
+        new_callable=AsyncMock,
+    )
+    @patch.dict(
+        "os.environ",
+        {"POSTGRES_CONNECTION_STRING": "postgresql://localhost"},
+        clear=True,
+    )
+    async def test_returns_async_pg_when_postgres_set(self, mock_get_pg):
+        """POSTGRES_CONNECTION_STRING routes to the async PostgreSQL checkpointer."""
+        sentinel = object()
+        mock_get_pg.return_value = sentinel
+        checkpointer = await get_async_checkpointer()
+        assert checkpointer is sentinel
+        mock_get_pg.assert_awaited_once_with()
+
+    @patch(
+        "bili.iris.checkpointers.checkpointer_functions.get_async_mongo_checkpointer",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "bili.iris.checkpointers.checkpointer_functions.get_async_pg_checkpointer",
+        new_callable=AsyncMock,
+    )
+    @patch.dict(
+        "os.environ",
+        {"MONGO_CONNECTION_STRING": "mongodb://localhost"},
+        clear=True,
+    )
+    async def test_returns_async_mongo_when_only_mongo_set(
+        self, mock_get_pg, mock_get_mongo
+    ):
+        """MONGO_CONNECTION_STRING routes to async Mongo when PG is unset."""
+        sentinel = object()
+        mock_get_mongo.return_value = sentinel
+        checkpointer = await get_async_checkpointer()
+        assert checkpointer is sentinel
+        mock_get_mongo.assert_awaited_once_with()
+        mock_get_pg.assert_not_awaited()

--- a/bili/iris/checkpointers/tests/test_mongo_checkpointer.py
+++ b/bili/iris/checkpointers/tests/test_mongo_checkpointer.py
@@ -4,8 +4,9 @@ All MongoDB interactions are mocked — no real database is needed.
 """
 
 import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import anyio
 import pytest
 
 from bili.iris.checkpointers.mongo_checkpointer import PruningMongoDBSaver
@@ -1649,3 +1650,523 @@ class TestGetThreadMessagesMultimodal:
         msgs = saver.get_thread_messages("t1")
         assert "Part 1" in msgs[0]["content"]
         assert "Part 2" in msgs[0]["content"]
+
+
+# =========================================================================
+# Module-level factory functions
+# =========================================================================
+
+
+class TestModuleLevelFunctions:
+    """Tests for get_mongo_client, close_mongo_client, get_mongo_checkpointer."""
+
+    @patch("bili.iris.checkpointers.mongo_checkpointer.atexit.register")
+    @patch("bili.iris.checkpointers.mongo_checkpointer.MongoClient")
+    @patch.dict(
+        "os.environ", {"MONGO_CONNECTION_STRING": "mongodb://localhost"}, clear=True
+    )
+    def test_get_mongo_client_returns_langgraph_db(self, mock_client_cls, mock_atexit):
+        """A set connection string yields the 'langgraph' database and registers cleanup."""
+        from bili.iris.checkpointers.mongo_checkpointer import (
+            close_mongo_client,
+            get_mongo_client,
+        )
+
+        fake_client = MagicMock()
+        fake_db = MagicMock()
+        fake_client.__getitem__.return_value = fake_db
+        mock_client_cls.return_value = fake_client
+
+        db = get_mongo_client()
+        assert db is fake_db
+        mock_client_cls.assert_called_once_with("mongodb://localhost")
+        fake_client.__getitem__.assert_called_once_with("langgraph")
+        mock_atexit.assert_called_once_with(close_mongo_client, fake_client)
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_get_mongo_client_returns_none_without_env(self):
+        """No connection string returns None."""
+        from bili.iris.checkpointers.mongo_checkpointer import get_mongo_client
+
+        assert get_mongo_client() is None
+
+    def test_close_mongo_client_closes_active(self):
+        """An active client is closed."""
+        from bili.iris.checkpointers.mongo_checkpointer import close_mongo_client
+
+        client = MagicMock()
+        close_mongo_client(client)
+        client.close.assert_called_once_with()
+
+    def test_close_mongo_client_noop_for_none(self):
+        """Passing None does not raise."""
+        from bili.iris.checkpointers.mongo_checkpointer import close_mongo_client
+
+        # Should simply return without error.
+        assert close_mongo_client(None) is None
+
+    @patch("bili.iris.checkpointers.mongo_checkpointer.get_mongo_client")
+    def test_get_mongo_checkpointer_returns_saver(self, mock_get_client):
+        """A live db produces a PruningMongoDBSaver."""
+        from bili.iris.checkpointers.mongo_checkpointer import get_mongo_checkpointer
+
+        mock_get_client.return_value = MagicMock()
+        with patch.object(PruningMongoDBSaver, "_ensure_indexes"), patch(
+            "bili.iris.checkpointers.mongo_checkpointer.MongoDBSaver.__init__",
+            return_value=None,
+        ):
+            saver = get_mongo_checkpointer(keep_last_n=3, user_id="u@example.com")
+        assert isinstance(saver, PruningMongoDBSaver)
+        assert saver.keep_last_n == 3
+        assert saver.user_id == "u@example.com"
+
+    @patch("bili.iris.checkpointers.mongo_checkpointer.get_mongo_client")
+    def test_get_mongo_checkpointer_returns_none_without_db(self, mock_get_client):
+        """No db yields None."""
+        from bili.iris.checkpointers.mongo_checkpointer import get_mongo_checkpointer
+
+        mock_get_client.return_value = None
+        assert get_mongo_checkpointer() is None
+
+
+# =========================================================================
+# get_async_mongo_checkpointer
+# =========================================================================
+
+
+pytest_anyio_mark = pytest.mark.anyio
+
+
+class TestGetAsyncMongoCheckpointer:
+    """Tests for the async checkpointer factory."""
+
+    pytestmark = pytest.mark.anyio
+
+    @patch("bili.iris.checkpointers.mongo_checkpointer.get_mongo_client")
+    async def test_returns_saver_when_db_available(self, mock_get_client):
+        """A live db produces a PruningMongoDBSaver from the async factory."""
+        from bili.iris.checkpointers.mongo_checkpointer import (
+            get_async_mongo_checkpointer,
+        )
+
+        mock_get_client.return_value = MagicMock()
+        with patch.object(PruningMongoDBSaver, "_ensure_indexes"), patch(
+            "bili.iris.checkpointers.mongo_checkpointer.MongoDBSaver.__init__",
+            return_value=None,
+        ):
+            saver = await get_async_mongo_checkpointer(keep_last_n=2)
+        assert isinstance(saver, PruningMongoDBSaver)
+        assert saver.keep_last_n == 2
+
+    @patch("bili.iris.checkpointers.mongo_checkpointer.get_mongo_client")
+    async def test_returns_none_without_db(self, mock_get_client):
+        """No db yields None from the async factory."""
+        from bili.iris.checkpointers.mongo_checkpointer import (
+            get_async_mongo_checkpointer,
+        )
+
+        mock_get_client.return_value = None
+        assert await get_async_mongo_checkpointer() is None
+
+
+# =========================================================================
+# Index helper error paths
+# =========================================================================
+
+
+class TestIndexHelperErrorPaths:
+    """Tests for _drop_conflicting_indexes and _create_index_safe edge cases."""
+
+    def test_drop_conflicting_handles_operation_failure(self):
+        """An OperationFailure while listing indexes is logged, not raised."""
+        from pymongo.errors import OperationFailure
+
+        collection = MagicMock()
+        collection.name = "checkpoints"
+        collection.index_information.side_effect = OperationFailure("no perms")
+        # Should not raise.
+        PruningMongoDBSaver._drop_conflicting_indexes(
+            collection, [("thread_id", 1)], "idx_x"
+        )
+        collection.drop_index.assert_not_called()
+
+    def test_create_index_safe_code86_drops_by_name_then_retries(self):
+        """Code 86 conflict drops the same-named index and retries successfully."""
+        from pymongo.errors import OperationFailure
+
+        collection = MagicMock()
+        collection.name = "checkpoints"
+        collection.index_information.return_value = {}
+        # First create_index raises code 86, second succeeds.
+        collection.create_index.side_effect = [
+            OperationFailure("conflict", code=86),
+            None,
+        ]
+        PruningMongoDBSaver._create_index_safe(
+            collection, [("thread_id", 1)], "idx_dup"
+        )
+        collection.drop_index.assert_called_once_with("idx_dup")
+        assert collection.create_index.call_count == 2
+
+    def test_create_index_safe_code86_drop_failure_swallowed(self):
+        """A failure dropping the code-86 index by name is swallowed before retry."""
+        from pymongo.errors import OperationFailure
+
+        collection = MagicMock()
+        collection.name = "checkpoints"
+        collection.index_information.return_value = {}
+        collection.drop_index.side_effect = OperationFailure("drop failed")
+        collection.create_index.side_effect = [
+            OperationFailure("conflict", code=86),
+            None,
+        ]
+        PruningMongoDBSaver._create_index_safe(
+            collection, [("thread_id", 1)], "idx_dup"
+        )
+        assert collection.create_index.call_count == 2
+
+    def test_create_index_safe_unhandled_code_raises(self):
+        """An unhandled OperationFailure code propagates."""
+        from pymongo.errors import OperationFailure
+
+        collection = MagicMock()
+        collection.name = "checkpoints"
+        collection.create_index.side_effect = OperationFailure("fatal", code=999)
+        with pytest.raises(OperationFailure):
+            PruningMongoDBSaver._create_index_safe(
+                collection, [("thread_id", 1)], "idx_x"
+            )
+
+
+# =========================================================================
+# get_tuple / aget_tuple migration orchestration (sync saver)
+# =========================================================================
+
+
+class TestGetTupleMigration:
+    """Tests for PruningMongoDBSaver.get_tuple migration handling."""
+
+    def test_get_tuple_returns_none_on_migration_error(self):
+        """An exception during migration causes get_tuple to return None."""
+        saver = _make_saver()
+        config = {"configurable": {"thread_id": "t1", "checkpoint_ns": ""}}
+        with patch.object(
+            saver, "migrate_checkpoint_if_needed", side_effect=RuntimeError("boom")
+        ):
+            assert saver.get_tuple(config) is None
+
+    def test_get_tuple_returns_none_when_still_needs_migration(self):
+        """A checkpoint still needing migration after the attempt returns None."""
+        saver = _make_saver()
+        config = {"configurable": {"thread_id": "t1", "checkpoint_ns": ""}}
+        with patch.object(
+            saver, "migrate_checkpoint_if_needed", return_value=True
+        ), patch.object(
+            saver, "_get_raw_checkpoint", return_value={"type": "msgpack"}
+        ), patch.object(
+            saver, "_needs_migration", return_value=True
+        ):
+            assert saver.get_tuple(config) is None
+
+    def test_get_tuple_fixes_string_step(self):
+        """A string step value in returned metadata is coerced to int."""
+        saver = _make_saver()
+        config = {"configurable": {"thread_id": "t1", "checkpoint_ns": ""}}
+        fake_result = MagicMock()
+        fake_result.metadata = {"step": "4"}
+        with patch.object(
+            saver, "migrate_checkpoint_if_needed", return_value=False
+        ), patch.object(saver, "_get_raw_checkpoint", return_value={}), patch.object(
+            saver, "_needs_migration", return_value=False
+        ), patch(
+            "bili.iris.checkpointers.mongo_checkpointer.MongoDBSaver.get_tuple",
+            return_value=fake_result,
+        ):
+            result = saver.get_tuple(config)
+        assert result.metadata["step"] == 4
+
+    def test_get_tuple_handles_unconvertible_step(self):
+        """A non-numeric string step is left in place when conversion fails."""
+        saver = _make_saver()
+        config = {"configurable": {"thread_id": "t1", "checkpoint_ns": ""}}
+        fake_result = MagicMock()
+        fake_result.metadata = {"step": "abc"}
+        with patch.object(
+            saver, "migrate_checkpoint_if_needed", return_value=False
+        ), patch.object(saver, "_get_raw_checkpoint", return_value={}), patch.object(
+            saver, "_needs_migration", return_value=False
+        ), patch(
+            "bili.iris.checkpointers.mongo_checkpointer.MongoDBSaver.get_tuple",
+            return_value=fake_result,
+        ):
+            result = saver.get_tuple(config)
+        assert result.metadata["step"] == "abc"
+
+    def test_get_tuple_validates_ownership(self):
+        """Ownership is validated before migration in get_tuple."""
+        saver = _make_saver(user_id="alice@example.com")
+        config = {
+            "configurable": {"thread_id": "bob@example.com_c1", "checkpoint_ns": ""}
+        }
+        with pytest.raises(PermissionError, match="Access denied"):
+            saver.get_tuple(config)
+
+
+class TestAsyncGetTupleMigration:
+    """Tests for PruningMongoDBSaver.aget_tuple migration handling."""
+
+    pytestmark = pytest.mark.anyio
+
+    async def test_aget_tuple_returns_none_on_migration_error(self):
+        """An exception during migration causes aget_tuple to return None."""
+        saver = _make_saver()
+        config = {"configurable": {"thread_id": "t1", "checkpoint_ns": ""}}
+        with patch.object(
+            saver, "migrate_checkpoint_if_needed", side_effect=RuntimeError("boom")
+        ):
+            assert await saver.aget_tuple(config) is None
+
+    async def test_aget_tuple_returns_none_when_still_needs_migration(self):
+        """A checkpoint still needing migration after the attempt returns None."""
+        saver = _make_saver()
+        config = {"configurable": {"thread_id": "t1", "checkpoint_ns": ""}}
+        with patch.object(
+            saver, "migrate_checkpoint_if_needed", return_value=True
+        ), patch.object(
+            saver, "_get_raw_checkpoint", return_value={"type": "msgpack"}
+        ), patch.object(
+            saver, "_needs_migration", return_value=True
+        ):
+            assert await saver.aget_tuple(config) is None
+
+    async def test_aget_tuple_fixes_string_step(self):
+        """A string step in returned metadata is coerced to int (async path)."""
+        saver = _make_saver()
+        config = {"configurable": {"thread_id": "t1", "checkpoint_ns": ""}}
+        fake_result = MagicMock()
+        fake_result.metadata = {"step": "9"}
+        with patch.object(
+            saver, "migrate_checkpoint_if_needed", return_value=False
+        ), patch.object(saver, "_get_raw_checkpoint", return_value={}), patch.object(
+            saver, "_needs_migration", return_value=False
+        ), patch(
+            "bili.iris.checkpointers.mongo_checkpointer.MongoDBSaver.aget_tuple",
+            new_callable=AsyncMock,
+            return_value=fake_result,
+        ):
+            result = await saver.aget_tuple(config)
+        assert result.metadata["step"] == 9
+
+    async def test_aget_tuple_handles_unconvertible_step(self):
+        """A non-numeric step string is left in place (async path)."""
+        saver = _make_saver()
+        config = {"configurable": {"thread_id": "t1", "checkpoint_ns": ""}}
+        fake_result = MagicMock()
+        fake_result.metadata = {"step": "zzz"}
+        with patch.object(
+            saver, "migrate_checkpoint_if_needed", return_value=False
+        ), patch.object(saver, "_get_raw_checkpoint", return_value={}), patch.object(
+            saver, "_needs_migration", return_value=False
+        ), patch(
+            "bili.iris.checkpointers.mongo_checkpointer.MongoDBSaver.aget_tuple",
+            new_callable=AsyncMock,
+            return_value=fake_result,
+        ):
+            result = await saver.aget_tuple(config)
+        assert result.metadata["step"] == "zzz"
+
+
+# =========================================================================
+# AsyncPruningMongoDBSaver — raw checkpoint, archive, aput, aget_tuple
+# =========================================================================
+
+
+def _make_async_saver_mocked(user_id=None, keep_last_n=-1):
+    """Build an AsyncPruningMongoDBSaver with mocked MongoDB collections."""
+    from bili.iris.checkpointers.mongo_checkpointer import AsyncPruningMongoDBSaver
+
+    with patch(
+        "bili.iris.checkpointers.mongo_checkpointer.MongoDBSaver.__init__",
+        return_value=None,
+    ):
+        saver = AsyncPruningMongoDBSaver.__new__(AsyncPruningMongoDBSaver)
+        saver.keep_last_n = keep_last_n
+        saver.user_id = user_id
+        saver._indexes_ensured = True
+        saver.checkpoint_collection = MagicMock()
+        saver.writes_collection = MagicMock()
+        saver.db = MagicMock()
+        saver.serde = MagicMock()
+    return saver
+
+
+class TestAsyncSaverRawCheckpoint:
+    """Tests for AsyncPruningMongoDBSaver raw checkpoint helpers."""
+
+    def test_get_raw_checkpoint_queries_collection(self):
+        """_get_raw_checkpoint issues a find_one sorted by checkpoint_id."""
+        saver = _make_async_saver_mocked()
+        expected = {"_id": "x", "thread_id": "t1"}
+        saver.checkpoint_collection.find_one.return_value = expected
+        result = saver._get_raw_checkpoint("t1", "")
+        assert result is expected
+        args = saver.checkpoint_collection.find_one.call_args[0]
+        assert args[0] == {"thread_id": "t1", "checkpoint_ns": ""}
+
+    def test_replace_raw_checkpoint_without_id_returns_false(self):
+        """A document lacking _id cannot be replaced."""
+        saver = _make_async_saver_mocked()
+        assert saver._replace_raw_checkpoint("t1", {"thread_id": "t1"}) is False
+        saver.checkpoint_collection.replace_one.assert_not_called()
+
+    def test_replace_raw_checkpoint_success(self):
+        """A document with _id is replaced and reports matched."""
+        saver = _make_async_saver_mocked()
+        result_obj = MagicMock()
+        result_obj.matched_count = 1
+        saver.checkpoint_collection.replace_one.return_value = result_obj
+        doc = {"_id": "abc", "thread_id": "t1"}
+        assert saver._replace_raw_checkpoint("t1", doc) is True
+        saver.checkpoint_collection.replace_one.assert_called_once_with(
+            {"_id": "abc"}, doc
+        )
+
+    def test_archive_checkpoint_inserts_and_deletes(self):
+        """_archive_checkpoint inserts into archive and removes from main."""
+        saver = _make_async_saver_mocked()
+        archive_col = MagicMock()
+        saver.db.__getitem__.return_value = archive_col
+        doc = {"_id": "abc", "thread_id": "t1"}
+        saver._archive_checkpoint("t1", doc, RuntimeError("bad"))
+        archive_col.insert_one.assert_called_once()
+        saver.checkpoint_collection.delete_one.assert_called_once_with({"_id": "abc"})
+
+    def test_archive_checkpoint_handles_insert_error(self):
+        """An insert failure during archiving is swallowed."""
+        saver = _make_async_saver_mocked()
+        archive_col = MagicMock()
+        archive_col.insert_one.side_effect = RuntimeError("insert down")
+        saver.db.__getitem__.return_value = archive_col
+        # Should not raise.
+        saver._archive_checkpoint("t1", {"_id": "x"}, RuntimeError("orig"))
+        saver.checkpoint_collection.delete_one.assert_not_called()
+
+
+class TestAsyncSaverAput:
+    """Tests for AsyncPruningMongoDBSaver.aput pruning and versioning."""
+
+    pytestmark = pytest.mark.anyio
+
+    async def test_aput_adds_format_version_and_skips_pruning(self):
+        """aput stamps the format version and skips pruning when disabled."""
+        saver = _make_async_saver_mocked(keep_last_n=-1)
+        next_cfg = {"configurable": {"thread_id": "t1", "checkpoint_id": "c1"}}
+        config = {"configurable": {"thread_id": "t1"}}
+        with patch(
+            "bili.iris.checkpointers.mongo_checkpointer.MongoDBSaver.aput",
+            new_callable=AsyncMock,
+            return_value=next_cfg,
+        ) as mock_aput:
+            result = await saver.aput(config, {"v": 1}, {"source": "loop"}, {})
+        assert result is next_cfg
+        # versioned metadata includes format_version
+        passed_metadata = mock_aput.call_args[0][2]
+        assert passed_metadata["format_version"] == saver.format_version
+        saver.checkpoint_collection.find.assert_not_called()
+
+    async def test_aput_prunes_excess_checkpoints(self):
+        """aput deletes checkpoints beyond keep_last_n."""
+        saver = _make_async_saver_mocked(keep_last_n=1)
+        next_cfg = {"configurable": {"thread_id": "t1", "checkpoint_id": "c2"}}
+        config = {"configurable": {"thread_id": "t1"}}
+
+        # find().sort() returns two docs; keep_last_n=1 means one is deleted.
+        sort_cursor = [
+            {"checkpoint_id": "c2"},
+            {"checkpoint_id": "c1"},
+        ]
+        find_cursor = MagicMock()
+        find_cursor.sort.return_value = sort_cursor
+        saver.checkpoint_collection.find.return_value = find_cursor
+
+        with patch(
+            "bili.iris.checkpointers.mongo_checkpointer.MongoDBSaver.aput",
+            new_callable=AsyncMock,
+            return_value=next_cfg,
+        ):
+            await saver.aput(config, {"v": 1}, {}, {})
+
+        saver.checkpoint_collection.delete_one.assert_called_once_with(
+            {"thread_id": "t1", "checkpoint_id": "c1"}
+        )
+        saver.writes_collection.delete_many.assert_called_once_with(
+            {"thread_id": "t1", "checkpoint_id": "c1"}
+        )
+
+
+class TestAsyncSaverAgetTuple:
+    """Tests for AsyncPruningMongoDBSaver.aget_tuple migration handling."""
+
+    pytestmark = pytest.mark.anyio
+
+    async def test_aget_tuple_returns_none_on_migration_error(self):
+        """A migration error returns None from the async saver's aget_tuple."""
+        saver = _make_async_saver_mocked()
+        config = {"configurable": {"thread_id": "t1", "checkpoint_ns": ""}}
+        with patch.object(
+            saver, "migrate_checkpoint_if_needed", side_effect=RuntimeError("boom")
+        ):
+            assert await saver.aget_tuple(config) is None
+
+    async def test_aget_tuple_delegates_to_super(self):
+        """A clean migration delegates to the parent aget_tuple."""
+        saver = _make_async_saver_mocked()
+        config = {"configurable": {"thread_id": "t1", "checkpoint_ns": ""}}
+        sentinel = object()
+        with patch.object(
+            saver, "migrate_checkpoint_if_needed", return_value=False
+        ), patch(
+            "bili.iris.checkpointers.mongo_checkpointer.MongoDBSaver.aget_tuple",
+            new_callable=AsyncMock,
+            return_value=sentinel,
+        ):
+            assert await saver.aget_tuple(config) is sentinel
+
+
+class TestAsyncSaverQueryFilters:
+    """Tests for AsyncPruningMongoDBSaver query filtering and pagination."""
+
+    def test_get_thread_messages_filters_by_type(self):
+        """message_types filters out non-matching message classes."""
+        saver = _make_async_saver_mocked()
+        human = _human_msg("hi")
+        ai = _ai_msg("hello")
+        saver.checkpoint_collection.find_one.return_value = {
+            "thread_id": "t1",
+            "checkpoint": {"channel_values": {"messages": [human, ai]}},
+        }
+        msgs = saver.get_thread_messages("t1", message_types=["HumanMessage"])
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
+
+    def test_get_thread_messages_pagination(self):
+        """offset and limit slice the returned messages."""
+        saver = _make_async_saver_mocked()
+        msgs_in = [_human_msg(f"m{i}") for i in range(4)]
+        saver.checkpoint_collection.find_one.return_value = {
+            "thread_id": "t1",
+            "checkpoint": {"channel_values": {"messages": msgs_in}},
+        }
+        msgs = saver.get_thread_messages("t1", limit=2, offset=1)
+        assert len(msgs) == 2
+
+    def test_deserialize_returns_empty_for_missing_checkpoint(self):
+        """A document without a checkpoint yields an empty dict."""
+        saver = _make_async_saver_mocked()
+        assert saver._deserialize_checkpoint_data({}) == {}
+
+    def test_athread_exists_delegates(self):
+        """athread_exists delegates to the sync thread_exists."""
+        saver = _make_async_saver_mocked()
+        saver.checkpoint_collection.count_documents.return_value = 1
+        assert anyio.run(saver.athread_exists, "t1") is True

--- a/bili/iris/checkpointers/tests/test_pg_checkpointer.py
+++ b/bili/iris/checkpointers/tests/test_pg_checkpointer.py
@@ -1472,8 +1472,16 @@ class TestGetTuple:
 class TestDictMessages:
     """Tests for dict-based message handling in get_thread_messages."""
 
-    def test_dict_message_falls_to_unknown(self):
-        """Dict messages get __class__.__name__ = 'dict' mapped to unknown role."""
+    def test_dict_message_type_field_drives_role(self):
+        """A dict message resolves its role from the 'type' field.
+
+        Previously this asserted dict messages fell through to role "unknown",
+        which pinned a real bug: the type-detection guard checked
+        ``hasattr(msg, "__class__")`` first, and since every dict has
+        __class__, the dict-specific 'type' extraction was dead code. With the
+        guard reordered to check ``isinstance(msg, dict)`` first, a serialized
+        {"type": "human"} message correctly maps to role "user".
+        """
         saver = _make_saver()
         msg = {"type": "human", "content": "Hello dict"}
         checkpoint = {"channel_values": {"messages": [msg]}}
@@ -1483,7 +1491,7 @@ class TestDictMessages:
 
         result = saver.get_thread_messages("t1")
         assert len(result) == 1
-        assert result[0]["role"] == "unknown"
+        assert result[0]["role"] == "user"
         assert result[0]["content"] == "Hello dict"
 
     def test_function_message_mapped(self):

--- a/bili/iris/checkpointers/tests/test_pg_checkpointer_coverage.py
+++ b/bili/iris/checkpointers/tests/test_pg_checkpointer_coverage.py
@@ -828,36 +828,18 @@ class TestSyncQueryBranches:
         assert messages[0]["content"] == "hello there"
 
 
-class TestAsyncPgThreadOwnershipKnownBug:
-    """The async PG saver should validate thread ownership but currently cannot.
+class TestAsyncPgThreadOwnership:
+    """The async PG saver validates thread ownership on aput and aget_tuple.
 
-    KNOWN BUG awaiting a design decision. AsyncPruningPostgresSaver inherits
-    (VersionedCheckpointerMixin, AsyncPostgresSaver) but, unlike the sync
-    PruningPostgresSaver, NOT QueryableCheckpointerMixin, which is where
-    _validate_thread_ownership lives. So aput and aget_tuple call
-    self._validate_thread_ownership and raise AttributeError at runtime
-    instead of enforcing multi-tenant isolation. The mongo async saver mirrors
-    the mixin correctly; PG does not.
-
-    The correct fix is not a one-liner: QueryableCheckpointerMixin is abstract
-    with five query methods (get_user_threads, get_thread_messages,
-    delete_thread, get_user_stats, thread_exists), so either the async saver
-    must implement those, or _validate_thread_ownership must move to a
-    non-abstract base both savers share. That is a design decision.
-
-    This test asserts the correct behavior (a cross-tenant aput is rejected
-    with PermissionError) and is xfail(strict) until the decision is made and
-    the fix lands. When fixed, the test will XPASS and strict mode will fail
-    the suite, forcing this marker to be removed.
+    AsyncPruningPostgresSaver now inherits QueryableCheckpointerMixin (mirroring
+    the sync PruningPostgresSaver and the async Mongo saver), so it gets
+    _validate_thread_ownership and the five query methods. A cross-tenant
+    aput/aget_tuple is rejected with PermissionError instead of raising
+    AttributeError.
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="AsyncPruningPostgresSaver lacks QueryableCheckpointerMixin; "
-        "aput raises AttributeError instead of validating thread ownership "
-        "(pending design decision, see class docstring)",
-    )
     async def test_aput_rejects_cross_tenant_write(self):
+        """A write to another user's thread is rejected with PermissionError."""
         saver = _make_async_saver(user_id="owner@example.com")
         config = {
             "configurable": {
@@ -867,3 +849,54 @@ class TestAsyncPgThreadOwnershipKnownBug:
         }
         with pytest.raises(PermissionError):
             await saver.aput(config, {}, {}, {})
+
+    async def test_aget_tuple_rejects_cross_tenant_read(self):
+        """A read of another user's thread is rejected with PermissionError."""
+        saver = _make_async_saver(user_id="owner@example.com")
+        config = {
+            "configurable": {
+                "thread_id": "attacker@example.com_t1",
+                "checkpoint_ns": "",
+            }
+        }
+        with pytest.raises(PermissionError):
+            await saver.aget_tuple(config)
+
+    def test_owner_thread_passes_validation(self):
+        """The owner's own threads pass ownership validation without raising."""
+        saver = _make_async_saver(user_id="owner@example.com")
+        # Exact match and the "{user}_..." conversation form are both allowed.
+        saver._validate_thread_ownership("owner@example.com")
+        saver._validate_thread_ownership("owner@example.com_conv1")
+
+    def test_validation_disabled_without_user_id(self):
+        """With no user_id configured, ownership validation is a no-op."""
+        saver = _make_async_saver(user_id=None)
+        # Any thread id is accepted when validation is disabled.
+        saver._validate_thread_ownership("anyone@example.com_t9")
+
+    def test_query_methods_present(self):
+        """All five QueryableCheckpointerMixin methods exist on the async saver."""
+        saver = _make_async_saver(user_id="owner@example.com")
+        for name in (
+            "get_user_threads",
+            "get_thread_messages",
+            "delete_thread",
+            "get_user_stats",
+            "thread_exists",
+        ):
+            assert callable(getattr(saver, name))
+
+    def test_query_methods_delegate_to_sync_saver(self):
+        """The query methods forward to a sync delegate sharing the pool."""
+        saver = _make_async_saver(user_id="owner@example.com")
+        delegate = MagicMock()
+        delegate.get_user_threads.return_value = [{"thread_id": "owner@example.com"}]
+        delegate.thread_exists.return_value = True
+        saver._query_delegate = delegate
+
+        assert saver.get_user_threads("owner@example.com") == [
+            {"thread_id": "owner@example.com"}
+        ]
+        assert saver.thread_exists("owner@example.com_t1") is True
+        delegate.get_user_threads.assert_called_once_with("owner@example.com", None, 0)

--- a/bili/iris/checkpointers/tests/test_pg_checkpointer_coverage.py
+++ b/bili/iris/checkpointers/tests/test_pg_checkpointer_coverage.py
@@ -900,3 +900,23 @@ class TestAsyncPgThreadOwnership:
         ]
         assert saver.thread_exists("owner@example.com_t1") is True
         delegate.get_user_threads.assert_called_once_with("owner@example.com", None, 0)
+
+    async def test_async_query_variants_delegate_off_thread(self):
+        """The a*-prefixed variants run the sync query in a worker thread."""
+        saver = _make_async_saver(user_id="owner@example.com")
+        delegate = MagicMock()
+        delegate.get_user_threads.return_value = [{"thread_id": "t"}]
+        delegate.get_thread_messages.return_value = [{"role": "user"}]
+        delegate.delete_thread.return_value = False
+        delegate.get_user_stats.return_value = {"total_threads": 1}
+        delegate.thread_exists.return_value = True
+        saver._query_delegate = delegate
+
+        assert await saver.aget_user_threads("owner@example.com") == [
+            {"thread_id": "t"}
+        ]
+        assert await saver.aget_thread_messages("t1") == [{"role": "user"}]
+        assert await saver.adelete_thread("t1") is False
+        assert await saver.aget_user_stats("owner@example.com") == {"total_threads": 1}
+        assert await saver.athread_exists("t1") is True
+        delegate.get_user_threads.assert_called_once_with("owner@example.com", None, 0)

--- a/bili/iris/checkpointers/tests/test_pg_checkpointer_coverage.py
+++ b/bili/iris/checkpointers/tests/test_pg_checkpointer_coverage.py
@@ -920,3 +920,14 @@ class TestAsyncPgThreadOwnership:
         assert await saver.aget_user_stats("owner@example.com") == {"total_threads": 1}
         assert await saver.athread_exists("t1") is True
         delegate.get_user_threads.assert_called_once_with("owner@example.com", None, 0)
+
+    def test_query_delegate_built_once(self):
+        """The delegate is constructed a single time (double-checked lock)."""
+        saver = _make_async_saver(user_id="owner@example.com")
+        with patch(
+            "bili.iris.checkpointers.pg_checkpointer.PruningPostgresSaver"
+        ) as mock_cls, patch.object(saver, "_get_sync_pool", return_value=MagicMock()):
+            first = saver._get_query_delegate()
+            second = saver._get_query_delegate()
+        assert first is second
+        mock_cls.assert_called_once()

--- a/bili/iris/checkpointers/tests/test_pg_checkpointer_coverage.py
+++ b/bili/iris/checkpointers/tests/test_pg_checkpointer_coverage.py
@@ -1,0 +1,869 @@
+"""Additional coverage tests for pg_checkpointer.
+
+Covers the module-level pool factory functions, the sync atomic
+user_id put path, async saver lifecycle (pool, indexes, schema, aput,
+pruning), the sync migration helpers used by the async saver, and a
+handful of sync query branches not exercised elsewhere. All PostgreSQL
+interactions are mocked, no real database is used.
+"""
+
+# pylint: disable=protected-access,import-outside-toplevel
+
+import threading
+from contextlib import asynccontextmanager, contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+
+def _make_sync_saver(keep_last_n=5, user_id=None):
+    """Create a PruningPostgresSaver with mocked PG internals."""
+    with patch(
+        "bili.iris.checkpointers.pg_checkpointer"
+        ".PruningPostgresSaver._ensure_user_id_schema"
+    ), patch(
+        "bili.iris.checkpointers.pg_checkpointer.PruningPostgresSaver.setup"
+    ), patch(
+        "bili.iris.checkpointers.pg_checkpointer.PruningPostgresSaver.ensure_indexes"
+    ), patch(
+        "langgraph.checkpoint.postgres.PostgresSaver.__init__",
+        return_value=None,
+    ):
+        from bili.iris.checkpointers.pg_checkpointer import PruningPostgresSaver
+
+        saver = PruningPostgresSaver(
+            MagicMock(), keep_last_n=keep_last_n, user_id=user_id
+        )
+        saver.lock = threading.RLock()
+        saver.conn = MagicMock()
+        saver._txn_conn = None
+        return saver
+
+
+def _make_async_saver(keep_last_n=5, user_id=None):
+    """Create an AsyncPruningPostgresSaver with mocked PG internals."""
+    with patch(
+        "langgraph.checkpoint.postgres.aio.AsyncPostgresSaver.__init__",
+        return_value=None,
+    ):
+        from bili.iris.checkpointers.pg_checkpointer import AsyncPruningPostgresSaver
+
+        saver = AsyncPruningPostgresSaver(
+            MagicMock(), keep_last_n=keep_last_n, user_id=user_id
+        )
+        saver.conn = MagicMock()
+        saver._async_txn_conn = None
+        saver._sync_pool = None
+        return saver
+
+
+def _attach_sync_cursor(saver, mock_cur):
+    """Attach a fake sync _cursor context manager."""
+
+    @contextmanager
+    def fake_cursor(_pipeline=False):
+        yield mock_cur
+
+    object.__setattr__(saver, "_cursor", fake_cursor)
+
+
+def _attach_async_cursor(saver, mock_cur):
+    """Attach a fake async _cursor context manager."""
+
+    @asynccontextmanager
+    async def fake_cursor(_pipeline=False):
+        yield mock_cur
+
+    object.__setattr__(saver, "_cursor", fake_cursor)
+
+
+# =========================================================================
+# Module-level pool factories
+# =========================================================================
+
+
+class TestGetPgConnectionPool:
+    """Tests for get_pg_connection_pool and close_pg_connection_pool."""
+
+    @patch("bili.iris.checkpointers.pg_checkpointer.atexit.register")
+    @patch("bili.iris.checkpointers.pg_checkpointer.ConnectionPool")
+    @patch.dict(
+        "os.environ",
+        {
+            "POSTGRES_CONNECTION_STRING": "postgresql://host:5432",
+            "POSTGRES_CONNECTION_POOL_MIN_SIZE": "2",
+            "POSTGRES_CONNECTION_POOL_MAX_SIZE": "7",
+        },
+        clear=True,
+    )
+    def test_creates_pool_with_sizes_and_langgraph_db(self, mock_pool_cls, mock_atexit):
+        """A set connection string builds a pool against the langgraph database."""
+        from bili.iris.checkpointers.pg_checkpointer import (
+            close_pg_connection_pool,
+            get_pg_connection_pool,
+        )
+
+        fake_pool = MagicMock()
+        mock_pool_cls.return_value = fake_pool
+
+        pool = get_pg_connection_pool()
+        assert pool is fake_pool
+        _, kwargs = mock_pool_cls.call_args
+        assert kwargs["conninfo"] == "postgresql://host:5432/langgraph"
+        assert kwargs["min_size"] == 2
+        assert kwargs["max_size"] == 7
+        assert kwargs["kwargs"] == {"autocommit": True}
+        mock_atexit.assert_called_once_with(close_pg_connection_pool)
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_returns_none_without_connection_string(self):
+        """No connection string yields None."""
+        from bili.iris.checkpointers.pg_checkpointer import get_pg_connection_pool
+
+        assert get_pg_connection_pool() is None
+
+    @patch("bili.iris.checkpointers.pg_checkpointer.get_pg_connection_pool")
+    def test_close_closes_active_pool(self, mock_get_pool):
+        """close_pg_connection_pool closes an existing pool."""
+        from bili.iris.checkpointers.pg_checkpointer import close_pg_connection_pool
+
+        fake_pool = MagicMock()
+        mock_get_pool.return_value = fake_pool
+        close_pg_connection_pool()
+        fake_pool.close.assert_called_once_with()
+
+    @patch("bili.iris.checkpointers.pg_checkpointer.get_pg_connection_pool")
+    def test_close_noop_when_no_pool(self, mock_get_pool):
+        """close_pg_connection_pool is a no-op when there is no pool."""
+        from bili.iris.checkpointers.pg_checkpointer import close_pg_connection_pool
+
+        mock_get_pool.return_value = None
+        # Should not raise.
+        assert close_pg_connection_pool() is None
+
+
+# =========================================================================
+# get_pg_checkpointer factory
+# =========================================================================
+
+
+class TestGetPgCheckpointerFactory:
+    """Tests for the sync checkpointer factory wiring."""
+
+    @patch("bili.iris.checkpointers.pg_checkpointer.get_pg_connection_pool")
+    def test_returns_none_without_pool(self, mock_get_pool):
+        """No pool yields None."""
+        from bili.iris.checkpointers.pg_checkpointer import get_pg_checkpointer
+
+        mock_get_pool.return_value = None
+        assert get_pg_checkpointer() is None
+
+
+# =========================================================================
+# Sync atomic user_id put path
+# =========================================================================
+
+
+class TestPutWithUserId:
+    """Tests for PruningPostgresSaver._put_with_user_id atomic transaction."""
+
+    def test_atomic_put_sets_user_id_and_commits(self):
+        """The atomic path runs super().put, updates user_id, and commits."""
+        from psycopg_pool import ConnectionPool
+
+        saver = _make_sync_saver(user_id="alice@example.com", keep_last_n=-1)
+
+        # conn is a real-ish mock; isinstance check uses ConnectionPool.
+        conn = MagicMock()
+        cur = MagicMock()
+        cur.rowcount = 1
+        conn.cursor.return_value.__enter__.return_value = cur
+        pool = MagicMock(spec=ConnectionPool)
+        pool.connection.return_value.__enter__.return_value = conn
+        pool.connection.return_value.__exit__.return_value = False
+        saver.conn = pool
+
+        config = {"configurable": {"thread_id": "alice@example.com_c1"}}
+        next_cfg = {
+            "configurable": {
+                "thread_id": "alice@example.com_c1",
+                "checkpoint_id": "cp1",
+            }
+        }
+        with patch(
+            "langgraph.checkpoint.postgres.PostgresSaver.put",
+            return_value=next_cfg,
+        ):
+            result = saver._put_with_user_id(
+                config, {"v": 1}, {"source": "loop"}, {}, "alice@example.com_c1"
+            )
+
+        assert result is next_cfg
+        conn.commit.assert_called_once_with()
+        # The UPDATE was issued with user_id, thread_id, checkpoint_id.
+        update_args = cur.execute.call_args[0]
+        assert "UPDATE checkpoints SET user_id" in update_args[0]
+        assert update_args[1] == ("alice@example.com", "alice@example.com_c1", "cp1")
+
+    def test_atomic_put_rolls_back_on_missing_row(self):
+        """A zero-row user_id update raises and triggers rollback."""
+        from psycopg_pool import ConnectionPool
+
+        saver = _make_sync_saver(user_id="alice@example.com", keep_last_n=-1)
+        conn = MagicMock()
+        cur = MagicMock()
+        cur.rowcount = 0
+        conn.cursor.return_value.__enter__.return_value = cur
+        pool = MagicMock(spec=ConnectionPool)
+        pool.connection.return_value.__enter__.return_value = conn
+        pool.connection.return_value.__exit__.return_value = False
+        saver.conn = pool
+
+        config = {"configurable": {"thread_id": "alice@example.com_c1"}}
+        next_cfg = {
+            "configurable": {
+                "thread_id": "alice@example.com_c1",
+                "checkpoint_id": "cp1",
+            }
+        }
+        with patch(
+            "langgraph.checkpoint.postgres.PostgresSaver.put",
+            return_value=next_cfg,
+        ):
+            with pytest.raises(RuntimeError, match="Failed to set user_id"):
+                saver._put_with_user_id(
+                    config, {"v": 1}, {}, {}, "alice@example.com_c1"
+                )
+        conn.rollback.assert_called_once_with()
+
+    def test_put_routes_to_atomic_path_when_user_id_set(self):
+        """put() delegates to _put_with_user_id when user_id is configured."""
+        saver = _make_sync_saver(user_id="alice@example.com", keep_last_n=-1)
+        config = {"configurable": {"thread_id": "alice@example.com_c1"}}
+        next_cfg = {"configurable": {"thread_id": "alice@example.com_c1"}}
+        with patch.object(
+            saver, "_put_with_user_id", return_value=next_cfg
+        ) as mock_atomic:
+            result = saver.put(config, {"v": 1}, {"source": "loop"}, {})
+        assert result is next_cfg
+        mock_atomic.assert_called_once()
+        # Versioned metadata passed includes format_version.
+        passed_meta = mock_atomic.call_args[0][2]
+        assert passed_meta["format_version"] == saver.format_version
+
+
+# =========================================================================
+# Sync get_tuple delegation
+# =========================================================================
+
+
+class TestSyncGetTupleDelegates:
+    """Tests for PruningPostgresSaver.get_tuple delegating to parent."""
+
+    def test_get_tuple_calls_super_after_migration(self):
+        """get_tuple validates ownership, migrates, then calls super()."""
+        saver = _make_sync_saver()
+        config = {"configurable": {"thread_id": "t1", "checkpoint_ns": ""}}
+        sentinel = object()
+        with patch.object(
+            saver, "migrate_checkpoint_if_needed", return_value=False
+        ), patch(
+            "langgraph.checkpoint.postgres.PostgresSaver.get_tuple",
+            return_value=sentinel,
+        ):
+            assert saver.get_tuple(config) is sentinel
+
+
+# =========================================================================
+# Async pool manager and factories
+# =========================================================================
+
+
+class TestAsyncConnectionManagerPool:
+    """Tests for AsyncConnectionManager.get_pool."""
+
+    @patch("bili.iris.checkpointers.pg_checkpointer.atexit.register")
+    @patch("bili.iris.checkpointers.pg_checkpointer.AsyncConnectionPool")
+    @patch.dict(
+        "os.environ",
+        {
+            "POSTGRES_CONNECTION_STRING": "postgresql://host:5432",
+            "POSTGRES_CONNECTION_POOL_MIN_SIZE": "3",
+            "POSTGRES_CONNECTION_POOL_MAX_SIZE": "9",
+        },
+        clear=True,
+    )
+    async def test_get_pool_builds_async_pool(self, mock_pool_cls, mock_atexit):
+        """A set connection string builds an AsyncConnectionPool once."""
+        from bili.iris.checkpointers.pg_checkpointer import AsyncConnectionManager
+
+        fake_pool = MagicMock()
+        mock_pool_cls.return_value = fake_pool
+        manager = AsyncConnectionManager()
+
+        pool = await manager.get_pool()
+        assert pool is fake_pool
+        _, kwargs = mock_pool_cls.call_args
+        assert kwargs["conninfo"] == "postgresql://host:5432/langgraph"
+        assert kwargs["min_size"] == 3
+        assert kwargs["max_size"] == 9
+        mock_atexit.assert_called_once()
+
+        # Second call returns the cached pool without rebuilding.
+        again = await manager.get_pool()
+        assert again is fake_pool
+        assert mock_pool_cls.call_count == 1
+
+    @patch.dict("os.environ", {}, clear=True)
+    async def test_get_pool_returns_none_without_env(self):
+        """No connection string yields None."""
+        from bili.iris.checkpointers.pg_checkpointer import AsyncConnectionManager
+
+        manager = AsyncConnectionManager()
+        assert await manager.get_pool() is None
+
+    def test_close_pool_clears_reference(self):
+        """_close_pool clears the cached pool."""
+        from bili.iris.checkpointers.pg_checkpointer import AsyncConnectionManager
+
+        manager = AsyncConnectionManager()
+        manager._pool = MagicMock()
+        manager._close_pool()
+        assert manager._pool is None
+
+    async def test_get_async_pg_connection_pool_delegates(self):
+        """get_async_pg_connection_pool delegates to the module manager."""
+        from bili.iris.checkpointers import pg_checkpointer
+
+        with patch.object(
+            pg_checkpointer._async_pool_manager,
+            "get_pool",
+            new_callable=AsyncMock,
+            return_value="POOL",
+        ):
+            assert await pg_checkpointer.get_async_pg_connection_pool() == "POOL"
+
+    async def test_get_async_pg_checkpointer_returns_none_without_pool(self):
+        """get_async_pg_checkpointer returns None when no pool exists."""
+        from bili.iris.checkpointers import pg_checkpointer
+
+        with patch.object(
+            pg_checkpointer,
+            "get_async_pg_connection_pool",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            assert await pg_checkpointer.get_async_pg_checkpointer() is None
+
+    async def test_get_async_pg_checkpointer_success_path(self):
+        """With a live pool, the factory sets up the saver and returns it.
+
+        Regression test for the asetup/setup bug: get_async_pg_checkpointer
+        must call the AsyncPostgresSaver coroutine ``setup`` (not the
+        non-existent ``asetup``), then create indexes, then return the saver.
+        """
+        from bili.iris.checkpointers import pg_checkpointer
+
+        mock_saver = MagicMock()
+        mock_saver.setup = AsyncMock()
+        mock_saver.aensure_indexes = AsyncMock()
+
+        with patch.object(
+            pg_checkpointer,
+            "get_async_pg_connection_pool",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),  # a non-None pool
+        ), patch.object(
+            pg_checkpointer,
+            "AsyncPruningPostgresSaver",
+            return_value=mock_saver,
+        ):
+            result = await pg_checkpointer.get_async_pg_checkpointer(
+                keep_last_n=7, user_id="u@example.com"
+            )
+
+        assert result is mock_saver
+        mock_saver.setup.assert_awaited_once()
+        mock_saver.aensure_indexes.assert_awaited_once()
+
+
+# =========================================================================
+# Async index / schema migration
+# =========================================================================
+
+
+class TestAsyncIndexesAndSchema:
+    """Tests for aensure_indexes and _aensure_user_id_schema."""
+
+    async def test_aensure_indexes_creates_three_indexes(self):
+        """aensure_indexes issues three CREATE INDEX statements."""
+        saver = _make_async_saver(user_id=None)
+        cur = AsyncMock()
+        _attach_async_cursor(saver, cur)
+        await saver.aensure_indexes()
+        assert cur.execute.await_count == 3
+        statements = " ".join(call.args[0] for call in cur.execute.await_args_list)
+        assert "idx_checkpoints_thread_id" in statements
+        assert "idx_blobs_thread_id" in statements
+        assert "idx_writes_thread_id" in statements
+
+    async def test_aensure_indexes_triggers_user_id_schema(self):
+        """When user_id is set, aensure_indexes runs the user_id schema migration."""
+        saver = _make_async_saver(user_id="alice")
+        cur = AsyncMock()
+        _attach_async_cursor(saver, cur)
+        with patch.object(
+            saver, "_aensure_user_id_schema", new_callable=AsyncMock
+        ) as mock_schema:
+            await saver.aensure_indexes()
+        mock_schema.assert_awaited_once_with()
+
+    async def test_aensure_user_id_schema_adds_column_and_index(self):
+        """Missing column and index trigger ALTER TABLE and CREATE INDEX."""
+        saver = _make_async_saver(user_id="alice")
+        cur = AsyncMock()
+        # fetchone returns None for both existence checks (column, index missing).
+        cur.fetchone = AsyncMock(return_value=None)
+        _attach_async_cursor(saver, cur)
+        await saver._aensure_user_id_schema()
+        executed = " ".join(call.args[0] for call in cur.execute.await_args_list)
+        assert "ADD COLUMN user_id" in executed
+        assert "CREATE INDEX" in executed
+
+    async def test_aensure_user_id_schema_skips_when_present(self):
+        """Existing column and index skip the DDL statements."""
+        saver = _make_async_saver(user_id="alice")
+        cur = AsyncMock()
+        cur.fetchone = AsyncMock(return_value={"x": 1})
+        _attach_async_cursor(saver, cur)
+        await saver._aensure_user_id_schema()
+        executed = " ".join(call.args[0] for call in cur.execute.await_args_list)
+        assert "ADD COLUMN" not in executed
+        assert "CREATE INDEX" not in executed
+
+
+# =========================================================================
+# Async aput / pruning / atomic user_id
+# =========================================================================
+
+
+class TestAsyncAput:
+    """Tests for AsyncPruningPostgresSaver.aput helpers.
+
+    NOTE: The public ``aput`` and ``aget_tuple`` entry points cannot be
+    exercised on AsyncPruningPostgresSaver. They call
+    ``self._validate_thread_ownership(...)``, but that method lives only in
+    QueryableCheckpointerMixin, which this class does NOT inherit (its bases
+    are VersionedCheckpointerMixin and AsyncPostgresSaver). Those calls raise
+    AttributeError at runtime. See the bug report in the accompanying summary.
+    The atomic helper ``_aput_with_user_id`` and ``_aprune_checkpoints`` do not
+    touch ownership validation, so they are tested directly below.
+    """
+
+    async def test_aput_with_user_id_commits(self):
+        """The async atomic path saves, updates user_id, and commits."""
+        from psycopg_pool import AsyncConnectionPool
+
+        saver = _make_async_saver(user_id="alice@example.com", keep_last_n=-1)
+
+        conn = MagicMock()
+        conn.set_autocommit = AsyncMock()
+        conn.commit = AsyncMock()
+        conn.rollback = AsyncMock()
+        cur = AsyncMock()
+        cur.rowcount = 1
+        cur_ctx = MagicMock()
+        cur_ctx.__aenter__ = AsyncMock(return_value=cur)
+        cur_ctx.__aexit__ = AsyncMock(return_value=False)
+        conn.cursor.return_value = cur_ctx
+
+        conn_ctx = MagicMock()
+        conn_ctx.__aenter__ = AsyncMock(return_value=conn)
+        conn_ctx.__aexit__ = AsyncMock(return_value=False)
+        pool = MagicMock(spec=AsyncConnectionPool)
+        pool.connection.return_value = conn_ctx
+        saver.conn = pool
+
+        config = {"configurable": {"thread_id": "alice@example.com_c1"}}
+        next_cfg = {
+            "configurable": {
+                "thread_id": "alice@example.com_c1",
+                "checkpoint_id": "cp1",
+            }
+        }
+        with patch(
+            "langgraph.checkpoint.postgres.aio.AsyncPostgresSaver.aput",
+            new_callable=AsyncMock,
+            return_value=next_cfg,
+        ):
+            result = await saver._aput_with_user_id(
+                config, {"v": 1}, {}, {}, "alice@example.com_c1"
+            )
+        assert result is next_cfg
+        conn.commit.assert_awaited_once_with()
+        update_args = cur.execute.await_args[0]
+        assert "UPDATE checkpoints SET user_id" in update_args[0]
+        assert update_args[1] == ("alice@example.com", "alice@example.com_c1", "cp1")
+
+    async def test_aput_with_user_id_rolls_back_on_missing_row(self):
+        """A zero-row update raises and rolls back the async transaction."""
+        from psycopg_pool import AsyncConnectionPool
+
+        saver = _make_async_saver(user_id="alice@example.com", keep_last_n=-1)
+        conn = MagicMock()
+        conn.set_autocommit = AsyncMock()
+        conn.commit = AsyncMock()
+        conn.rollback = AsyncMock()
+        cur = AsyncMock()
+        cur.rowcount = 0
+        cur_ctx = MagicMock()
+        cur_ctx.__aenter__ = AsyncMock(return_value=cur)
+        cur_ctx.__aexit__ = AsyncMock(return_value=False)
+        conn.cursor.return_value = cur_ctx
+
+        conn_ctx = MagicMock()
+        conn_ctx.__aenter__ = AsyncMock(return_value=conn)
+        conn_ctx.__aexit__ = AsyncMock(return_value=False)
+        pool = MagicMock(spec=AsyncConnectionPool)
+        pool.connection.return_value = conn_ctx
+        saver.conn = pool
+
+        config = {"configurable": {"thread_id": "alice@example.com_c1"}}
+        next_cfg = {
+            "configurable": {
+                "thread_id": "alice@example.com_c1",
+                "checkpoint_id": "cp1",
+            }
+        }
+        with patch(
+            "langgraph.checkpoint.postgres.aio.AsyncPostgresSaver.aput",
+            new_callable=AsyncMock,
+            return_value=next_cfg,
+        ):
+            with pytest.raises(RuntimeError, match="Failed to set user_id"):
+                await saver._aput_with_user_id(
+                    config, {"v": 1}, {}, {}, "alice@example.com_c1"
+                )
+        conn.rollback.assert_awaited_once_with()
+
+    async def test_aprune_deletes_excess(self):
+        """_aprune_checkpoints deletes writes and checkpoints beyond the limit."""
+        saver = _make_async_saver(keep_last_n=1)
+        cur = AsyncMock()
+        cur.fetchall = AsyncMock(
+            return_value=[{"checkpoint_id": "c1"}, {"checkpoint_id": "c0"}]
+        )
+        _attach_async_cursor(saver, cur)
+        await saver._aprune_checkpoints("t1")
+        executed = [call.args[0] for call in cur.execute.await_args_list]
+        # 1 SELECT + 2 deletes per stale checkpoint (writes + checkpoints).
+        assert any("SELECT checkpoint_id" in s for s in executed)
+        delete_writes = [s for s in executed if "DELETE FROM checkpoint_writes" in s]
+        delete_cps = [
+            s
+            for s in executed
+            if "DELETE FROM checkpoints WHERE" in s and "writes" not in s
+        ]
+        assert len(delete_writes) == 2
+        assert len(delete_cps) == 2
+
+
+# =========================================================================
+# Async migration raw helpers (sync pool backed)
+# =========================================================================
+
+
+class TestAsyncMigrationRawHelpers:
+    """Tests for the sync-pool-backed migration methods on the async saver."""
+
+    def _setup_sync_pool(self, saver, cur):
+        """Wire a fake sync pool whose connection yields the given cursor."""
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+        conn.cursor.return_value.__exit__.return_value = False
+        pool = MagicMock()
+        pool.connection.return_value.__enter__.return_value = conn
+        pool.connection.return_value.__exit__.return_value = False
+        saver._sync_pool = pool
+        return conn
+
+    def test_get_sync_pool_raises_when_unavailable(self):
+        """_get_sync_pool raises when no sync pool can be created."""
+        saver = _make_async_saver()
+        saver._sync_pool = None
+        with patch(
+            "bili.iris.checkpointers.pg_checkpointer.get_pg_connection_pool",
+            return_value=None,
+        ):
+            with pytest.raises(
+                RuntimeError, match="Sync PostgreSQL pool not available"
+            ):
+                saver._get_sync_pool()
+
+    def test_get_sync_pool_caches(self):
+        """_get_sync_pool caches the created sync pool."""
+        saver = _make_async_saver()
+        saver._sync_pool = None
+        fake_pool = MagicMock()
+        with patch(
+            "bili.iris.checkpointers.pg_checkpointer.get_pg_connection_pool",
+            return_value=fake_pool,
+        ) as mock_get:
+            first = saver._get_sync_pool()
+            second = saver._get_sync_pool()
+        assert first is fake_pool
+        assert second is fake_pool
+        mock_get.assert_called_once_with()
+
+    def test_get_raw_checkpoint_returns_row(self):
+        """_get_raw_checkpoint maps a positional row tuple into a dict."""
+        saver = _make_async_saver()
+        cur = MagicMock()
+        cur.fetchone.return_value = ("t1", "", "cp1", b"blob", {"step": 1})
+        self._setup_sync_pool(saver, cur)
+        result = saver._get_raw_checkpoint("t1", "")
+        assert result == {
+            "thread_id": "t1",
+            "checkpoint_ns": "",
+            "checkpoint_id": "cp1",
+            "checkpoint": b"blob",
+            "metadata": {"step": 1},
+        }
+
+    def test_get_raw_checkpoint_returns_none(self):
+        """_get_raw_checkpoint returns None when no row is found."""
+        saver = _make_async_saver()
+        cur = MagicMock()
+        cur.fetchone.return_value = None
+        self._setup_sync_pool(saver, cur)
+        assert saver._get_raw_checkpoint("missing", "") is None
+
+    def test_replace_raw_checkpoint_no_id_returns_false(self):
+        """_replace_raw_checkpoint returns False without a checkpoint_id."""
+        saver = _make_async_saver()
+        assert saver._replace_raw_checkpoint("t1", {"thread_id": "t1"}) is False
+
+    def test_replace_raw_checkpoint_updates_and_commits(self):
+        """_replace_raw_checkpoint issues an UPDATE and commits."""
+        saver = _make_async_saver()
+        cur = MagicMock()
+        cur.rowcount = 1
+        conn = self._setup_sync_pool(saver, cur)
+        doc = {
+            "checkpoint_id": "cp1",
+            "checkpoint": b"new",
+            "metadata": {"step": 2},
+        }
+        assert saver._replace_raw_checkpoint("t1", doc, "") is True
+        conn.commit.assert_called_once_with()
+        assert "UPDATE checkpoints" in cur.execute.call_args[0][0]
+
+    def test_archive_checkpoint_inserts_and_deletes(self):
+        """_archive_checkpoint creates the archive table, inserts, and deletes."""
+        saver = _make_async_saver()
+        cur = MagicMock()
+        conn = self._setup_sync_pool(saver, cur)
+        doc = {
+            "checkpoint_id": "cp1",
+            "checkpoint": b"blob",
+            "metadata": {},
+            "checkpoint_ns": "",
+        }
+        saver._archive_checkpoint("t1", doc, RuntimeError("bad"))
+        statements = " ".join(call.args[0] for call in cur.execute.call_args_list)
+        assert "CREATE TABLE IF NOT EXISTS checkpoints_archive" in statements
+        assert "INSERT INTO checkpoints_archive" in statements
+        assert "DELETE FROM checkpoints" in statements
+        conn.commit.assert_called_once_with()
+
+    def test_archive_checkpoint_skips_delete_without_id(self):
+        """Archiving a doc without checkpoint_id skips the main-table delete."""
+        saver = _make_async_saver()
+        cur = MagicMock()
+        conn = self._setup_sync_pool(saver, cur)
+        saver._archive_checkpoint("t1", {"checkpoint": b"x"}, RuntimeError("bad"))
+        statements = " ".join(call.args[0] for call in cur.execute.call_args_list)
+        assert "INSERT INTO checkpoints_archive" in statements
+        assert "DELETE FROM checkpoints" not in statements
+        conn.commit.assert_called_once_with()
+
+
+# =========================================================================
+# Async aget_tuple
+# =========================================================================
+
+
+# NOTE: AsyncPruningPostgresSaver.aget_tuple is not directly testable because
+# it calls self._validate_thread_ownership(), which is not in this class's MRO
+# (see the TestAsyncAput docstring and the bug report). Exercising it would
+# require pinning the broken AttributeError path, which is disallowed.
+
+
+# =========================================================================
+# Cursor override branches
+# =========================================================================
+
+
+class TestCursorBranches:
+    """Tests for the sync and async _cursor transaction-sharing branches."""
+
+    def test_sync_cursor_uses_txn_conn_when_set(self):
+        """The sync _cursor reuses _txn_conn when an atomic transaction is active."""
+        saver = _make_sync_saver()
+        txn_conn = MagicMock()
+        shared_cur = MagicMock()
+        txn_conn.cursor.return_value.__enter__.return_value = shared_cur
+        txn_conn.cursor.return_value.__exit__.return_value = False
+        saver._txn_conn = txn_conn
+        with saver._cursor() as cur:
+            assert cur is shared_cur
+        txn_conn.cursor.assert_called_once()
+
+    def test_sync_cursor_falls_back_to_super(self):
+        """With no txn, the sync _cursor delegates to the parent's _cursor."""
+        saver = _make_sync_saver()
+        saver._txn_conn = None
+        parent_cur = MagicMock()
+        parent_ctx = MagicMock()
+        parent_ctx.__enter__.return_value = parent_cur
+        parent_ctx.__exit__.return_value = False
+        with patch(
+            "langgraph.checkpoint.postgres.PostgresSaver._cursor",
+            return_value=parent_ctx,
+        ):
+            with saver._cursor() as cur:
+                assert cur is parent_cur
+
+    async def test_async_cursor_uses_txn_conn_when_set(self):
+        """The async _cursor reuses _async_txn_conn during an atomic transaction."""
+        saver = _make_async_saver()
+        txn_conn = MagicMock()
+        shared_cur = AsyncMock()
+        cur_ctx = MagicMock()
+        cur_ctx.__aenter__ = AsyncMock(return_value=shared_cur)
+        cur_ctx.__aexit__ = AsyncMock(return_value=False)
+        txn_conn.cursor.return_value = cur_ctx
+        saver._async_txn_conn = txn_conn
+        async with saver._cursor() as cur:
+            assert cur is shared_cur
+        txn_conn.cursor.assert_called_once()
+
+
+# =========================================================================
+# Sync query branches: tags-from-writes and dict messages
+# =========================================================================
+
+
+class TestSyncQueryBranches:
+    """Tests for less-common sync query branches."""
+
+    def test_get_user_threads_reads_tags_from_writes(self):
+        """When channel_values lacks tags, tags are read from checkpoint_writes."""
+        import msgpack
+
+        saver = _make_sync_saver()
+
+        thread_rows = [
+            {
+                "thread_id": "alice@example.com",
+                "last_checkpoint_id": "cp1",
+                "checkpoint_count": 1,
+            }
+        ]
+        latest_row = {
+            "checkpoint": {
+                "ts": "2026-01-01T00:00:00Z",
+                "channel_values": {"title": "Hi", "tags": []},
+            }
+        }
+        tags_row = {"blob": msgpack.packb(["tagA", "tagB"])}
+
+        call_state = {"n": 0}
+
+        def fetchall_side():
+            # Only the first fetchall (thread listing) returns rows.
+            if call_state["n"] == 0:
+                call_state["n"] += 1
+                return thread_rows
+            return []
+
+        mock_cur = MagicMock()
+        mock_cur.fetchall.side_effect = fetchall_side
+        # fetchone is called twice per thread: latest checkpoint, then tags blob.
+        mock_cur.fetchone.side_effect = [latest_row, tags_row]
+        _attach_sync_cursor(saver, mock_cur)
+
+        # get_tuple is called per thread to count messages; stub it out.
+        with patch.object(saver, "get_tuple", return_value=None):
+            threads = saver.get_user_threads("alice@example.com")
+
+        assert threads[0]["tags"] == ["tagA", "tagB"]
+        assert threads[0]["title"] == "Hi"
+
+    def test_get_thread_messages_extracts_type_from_dict_message(self):
+        """A serialized dict message has its type read from the 'type' field.
+
+        Regression test for the dead-branch bug: type detection used to check
+        ``hasattr(msg, "__class__")`` first, which is always true (dicts have
+        __class__ too), so a dict message was labeled "dict" and resolved to
+        role "unknown". With ``isinstance(msg, dict)`` checked first, the
+        dict's 'type' field drives the mapping: {"type": "human"} -> "user".
+        """
+        saver = _make_sync_saver(user_id=None)
+        saver.user_id = None  # ownership validation disabled
+        dict_msg = {"type": "human", "content": "hello there"}
+        checkpoint_tuple = MagicMock()
+        checkpoint_tuple.checkpoint = {"channel_values": {"messages": [dict_msg]}}
+        with patch.object(type(saver), "get_tuple", return_value=checkpoint_tuple):
+            messages = saver.get_thread_messages("u@example.com_t1")
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"] == "hello there"
+
+
+class TestAsyncPgThreadOwnershipKnownBug:
+    """The async PG saver should validate thread ownership but currently cannot.
+
+    KNOWN BUG awaiting a design decision. AsyncPruningPostgresSaver inherits
+    (VersionedCheckpointerMixin, AsyncPostgresSaver) but, unlike the sync
+    PruningPostgresSaver, NOT QueryableCheckpointerMixin, which is where
+    _validate_thread_ownership lives. So aput and aget_tuple call
+    self._validate_thread_ownership and raise AttributeError at runtime
+    instead of enforcing multi-tenant isolation. The mongo async saver mirrors
+    the mixin correctly; PG does not.
+
+    The correct fix is not a one-liner: QueryableCheckpointerMixin is abstract
+    with five query methods (get_user_threads, get_thread_messages,
+    delete_thread, get_user_stats, thread_exists), so either the async saver
+    must implement those, or _validate_thread_ownership must move to a
+    non-abstract base both savers share. That is a design decision.
+
+    This test asserts the correct behavior (a cross-tenant aput is rejected
+    with PermissionError) and is xfail(strict) until the decision is made and
+    the fix lands. When fixed, the test will XPASS and strict mode will fail
+    the suite, forcing this marker to be removed.
+    """
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="AsyncPruningPostgresSaver lacks QueryableCheckpointerMixin; "
+        "aput raises AttributeError instead of validating thread ownership "
+        "(pending design decision, see class docstring)",
+    )
+    async def test_aput_rejects_cross_tenant_write(self):
+        saver = _make_async_saver(user_id="owner@example.com")
+        config = {
+            "configurable": {
+                "thread_id": "attacker@example.com_t1",
+                "checkpoint_ns": "",
+            }
+        }
+        with pytest.raises(PermissionError):
+            await saver.aput(config, {}, {}, {})

--- a/bili/iris/checkpointers/tests/test_versioning.py
+++ b/bili/iris/checkpointers/tests/test_versioning.py
@@ -5,6 +5,9 @@ calculation, and the VersionedCheckpointerMixin logic.
 """
 
 import json
+from unittest.mock import patch
+
+import pytest
 
 from bili.iris.checkpointers.versioning import (
     CURRENT_FORMAT_VERSION,
@@ -299,3 +302,207 @@ class TestVersionedCheckpointerMixin:
         assert vc.is_format_incompatibility_error(ValueError("not json serializable"))
         assert vc.is_format_incompatibility_error(TypeError("object of type bytes"))
         assert not vc.is_format_incompatibility_error(ValueError("some other error"))
+
+
+class TestGetDocumentVersionMsgpack:
+    """Tests for the msgpack serializer branch of _get_document_version."""
+
+    def test_msgpack_wrapper_with_json_bytes(self):
+        """A ['msgpack', json-bytes] wrapper is decoded as JSON first."""
+        vc = ConcreteVersionedCheckpointer()
+        doc = {
+            "metadata": {
+                "format_version": ["msgpack", b"2"],
+            }
+        }
+        # LangGraph's serializer actually JSON-encodes despite the msgpack tag.
+        assert vc.get_document_version(doc) == 2
+
+    def test_msgpack_wrapper_with_bson_binary(self):
+        """A bson.Binary serialized value is converted via __bytes__ then decoded."""
+        import bson
+
+        vc = ConcreteVersionedCheckpointer()
+        doc = {
+            "metadata": {
+                "format_version": ["msgpack", bson.Binary(b"3")],
+            }
+        }
+        assert vc.get_document_version(doc) == 3
+
+    def test_msgpack_wrapper_true_msgpack_payload(self):
+        """When JSON decode fails, true-msgpack bytes are unpacked to a list."""
+        import msgpack
+
+        vc = ConcreteVersionedCheckpointer()
+        # Pack the value ["json", "2"] which is not valid UTF-8 JSON on its own.
+        packed = msgpack.packb(["json", "2"])
+        doc = {
+            "metadata": {
+                "format_version": ["msgpack", packed],
+            }
+        }
+        assert vc.get_document_version(doc) == 2
+
+    def test_msgpack_wrapper_direct_int_payload(self):
+        """A msgpack payload that unpacks to a bare int returns that int."""
+        import msgpack
+
+        vc = ConcreteVersionedCheckpointer()
+        packed = msgpack.packb(7)
+        doc = {
+            "metadata": {
+                "format_version": ["msgpack", packed],
+            }
+        }
+        assert vc.get_document_version(doc) == 7
+
+    def test_msgpack_unavailable_falls_back_to_default(self):
+        """When msgpack import fails and JSON decode fails, defaults to v1."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "msgpack":
+                raise ImportError("no msgpack")
+            return real_import(name, *args, **kwargs)
+
+        vc = ConcreteVersionedCheckpointer()
+        # Non-UTF8 bytes force the JSON decode to fail, then msgpack is unavailable.
+        doc = {
+            "metadata": {
+                "format_version": ["msgpack", b"\xff\xfe"],
+            }
+        }
+        with patch("builtins.__import__", side_effect=fake_import):
+            assert vc.get_document_version(doc) == 1
+
+    def test_msgpack_outer_exception_falls_back_to_default(self):
+        """A msgpack unpack failure is swallowed and defaults to v1."""
+        vc = ConcreteVersionedCheckpointer()
+        # Bytes that fail UTF-8 JSON decode and also fail msgpack.unpackb,
+        # exercising the broad-except fallback around the msgpack branch.
+        doc = {
+            "metadata": {
+                "format_version": ["msgpack", b"\xc1"],
+            }
+        }
+        assert vc.get_document_version(doc) == 1
+
+    def test_json_wrapper_decode_failure_falls_through(self):
+        """Invalid JSON in a ['json', ...] wrapper falls through to default v1."""
+        vc = ConcreteVersionedCheckpointer()
+        doc = {
+            "metadata": {
+                "format_version": ["json", "{not valid json"],
+            }
+        }
+        assert vc.get_document_version(doc) == 1
+
+
+class TestMigrateDocumentPaths:
+    """Tests for _migrate_document path resolution and error handling."""
+
+    def test_no_path_just_stamps_version(self):
+        """With no registered migration path, the version stamp is applied."""
+        # checkpointer_type with no registered migrations and an old version.
+        vc = ConcreteVersionedCheckpointer()
+        vc.format_version = 2
+        doc = {"metadata": {"format_version": 1}}
+        result = vc.do_migrate_document(doc)
+        fv = result["metadata"]["format_version"]
+        assert fv == ["json", json.dumps(2)]
+
+    def test_missing_migration_raises_value_error(self):
+        """A path step with no registered function raises ValueError."""
+        # Register only the path-discovery key to produce a path, then remove the
+        # function so the lookup inside the apply loop returns None.
+        key = ("test_concrete", 1, 2)
+        vc = ConcreteVersionedCheckpointer()
+        vc.format_version = 2
+        doc = {"metadata": {"format_version": 1}}
+
+        # Patch get_migration_path to return a step that has no registered func.
+        with patch(
+            "bili.iris.checkpointers.versioning.get_migration_path",
+            return_value=[(1, 2)],
+        ):
+            MIGRATION_REGISTRY.pop(key, None)
+            with pytest.raises(ValueError, match="Missing test_concrete migration"):
+                vc.do_migrate_document(doc)
+
+    def test_migration_function_exception_propagates(self):
+        """An exception raised by a migration function propagates out."""
+        key = ("test_concrete", 1, 2)
+        try:
+
+            def boom(_doc):
+                """Raise to simulate a failing migration."""
+                raise RuntimeError("migration exploded")
+
+            MIGRATION_REGISTRY[key] = boom
+            vc = ConcreteVersionedCheckpointer()
+            vc.format_version = 2
+            doc = {"metadata": {"format_version": 1}}
+            with pytest.raises(RuntimeError, match="migration exploded"):
+                vc.do_migrate_document(doc)
+        finally:
+            MIGRATION_REGISTRY.pop(key, None)
+
+
+class TestMigrateCheckpointIfNeeded:
+    """Tests for migrate_checkpoint_if_needed orchestration."""
+
+    def test_successful_migration_returns_true_and_writes(self):
+        """A needed migration runs, writes back, and reports True."""
+        key = ("test_concrete", 1, 2)
+        try:
+
+            def add_marker(doc):
+                """Mark the document as migrated."""
+                doc["migrated"] = True
+                return doc
+
+            MIGRATION_REGISTRY[key] = add_marker
+            vc = ConcreteVersionedCheckpointer()
+            vc.format_version = 2
+            vc.storage["t1"] = {"metadata": {"format_version": 1}}
+            assert vc.migrate_checkpoint_if_needed("t1") is True
+            assert vc.storage["t1"]["migrated"] is True
+        finally:
+            MIGRATION_REGISTRY.pop(key, None)
+
+    def test_write_failure_returns_false(self):
+        """When the write-back fails, the method returns False."""
+        key = ("test_concrete", 1, 2)
+        try:
+            MIGRATION_REGISTRY[key] = lambda d: d
+            vc = ConcreteVersionedCheckpointer()
+            vc.format_version = 2
+            vc.storage["t1"] = {"metadata": {"format_version": 1}}
+            with patch.object(vc, "_replace_raw_checkpoint", return_value=False):
+                assert vc.migrate_checkpoint_if_needed("t1") is False
+        finally:
+            MIGRATION_REGISTRY.pop(key, None)
+
+    def test_failed_migration_archives_and_reraises(self):
+        """When migration raises, the checkpoint is archived and the error re-raises."""
+        key = ("test_concrete", 1, 2)
+        try:
+
+            def boom(_doc):
+                """Fail the migration."""
+                raise RuntimeError("cannot migrate")
+
+            MIGRATION_REGISTRY[key] = boom
+            vc = ConcreteVersionedCheckpointer()
+            vc.format_version = 2
+            vc.storage["t1"] = {"metadata": {"format_version": 1}}
+            with pytest.raises(RuntimeError, match="cannot migrate"):
+                vc.migrate_checkpoint_if_needed("t1")
+            # The archive hook should have captured the failure.
+            assert "archive_t1" in vc.storage
+            assert "cannot migrate" in vc.storage["archive_t1"]["error"]
+        finally:
+            MIGRATION_REGISTRY.pop(key, None)

--- a/bili/iris/conftest.py
+++ b/bili/iris/conftest.py
@@ -1,0 +1,19 @@
+"""Shared pytest setup for the IRIS test suites.
+
+Importing ``bili.iris.tools`` before ``bili.iris.loaders`` triggers a circular
+import: the tools package ``__init__`` imports ``faiss_memory_indexing``, which
+imports ``bili.iris.loaders.embeddings_loader``; loading the loaders package in
+turn runs ``tools_loader``, which imports ``init_faiss`` from the
+still-initializing tools package. pytest imports a test module's parent
+packages before the module itself, so collecting any module under
+``bili/iris/tools/tests/`` in isolation would import ``bili.iris.tools`` first
+and hit the cycle.
+
+pytest loads conftest files from the rootdir down toward each test file's
+directory and imports them before collecting test modules in or under that
+directory. Importing the loaders package here, at the ``bili/iris`` level,
+establishes the correct order so collection succeeds whether the tools suite
+runs alone or alongside the rest of the suite.
+"""
+
+import bili.iris.loaders  # noqa: F401  pylint: disable=unused-import

--- a/bili/iris/loaders/middleware_loader.py
+++ b/bili/iris/loaders/middleware_loader.py
@@ -49,7 +49,7 @@ try:
     )
 
     LANGCHAIN_MIDDLEWARE_AVAILABLE = True
-except ImportError:
+except ImportError:  # pragma: no cover - optional-dependency import fallback
     LANGCHAIN_MIDDLEWARE_AVAILABLE = False
 
 from bili.utils.logging_utils import get_logger

--- a/bili/iris/loaders/tests/test_llm_loader.py
+++ b/bili/iris/loaders/tests/test_llm_loader.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bili.iris.loaders.llm_loader import (
+    load_huggingface_model,
+    load_llamacpp_model,
     load_model,
     load_remote_azure_openai,
     load_remote_bedrock_model,
@@ -337,3 +339,223 @@ class TestDeviceDetection:
         mock_torch.cuda.is_available.return_value = False
         assert not mock_torch.backends.mps.is_available()
         assert not mock_torch.cuda.is_available()
+
+
+# ---------------------------------------------------------------------------
+# load_huggingface_model (local)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadHuggingFaceModel:
+    """Verify the local HuggingFace pipeline construction."""
+
+    @patch("bili.iris.loaders.llm_loader.ChatHuggingFace")
+    @patch("bili.iris.loaders.llm_loader.HuggingFacePipeline")
+    @patch("bili.iris.loaders.llm_loader.pipeline")
+    @patch("bili.iris.loaders.llm_loader.AutoModelForCausalLM")
+    @patch("bili.iris.loaders.llm_loader.torch")
+    @patch("bili.iris.loaders.llm_loader.load_huggingface_tokenizer")
+    def test_builds_chat_model_with_full_generation_config(
+        self,
+        mock_tokenizer_loader,
+        mock_torch,
+        mock_auto_model,
+        mock_pipeline,
+        mock_hf_pipeline,
+        mock_chat_hf,
+    ):
+        """Verify generation config is assembled and a ChatHuggingFace is returned."""
+        tokenizer = MagicMock()
+        tokenizer.pad_token = None
+        tokenizer.eos_token = "</s>"
+        mock_tokenizer_loader.return_value = tokenizer
+        mock_torch.cuda.is_available.return_value = True
+        model = MagicMock()
+        mock_auto_model.from_pretrained.return_value = model
+        mock_chat_hf.return_value = "chat_model"
+
+        result = load_huggingface_model(
+            model_name="gpt2",
+            max_tokens=128,
+            temperature=0.6,
+            top_p=0.9,
+            top_k=40,
+            seed=7,
+        )
+
+        assert result == "chat_model"
+        # Missing pad token is backfilled from the eos token.
+        assert tokenizer.pad_token == "</s>"
+        # CUDA cache is cleared when CUDA is available.
+        mock_torch.cuda.empty_cache.assert_called_once()
+        # The optional generation params are forwarded to pipeline().
+        pipeline_kwargs = mock_pipeline.call_args[1]
+        assert pipeline_kwargs["task"] == "text-generation"
+        assert pipeline_kwargs["return_full_text"] is False
+        assert pipeline_kwargs["model"] is model
+        assert pipeline_kwargs["max_new_tokens"] == 128
+        assert pipeline_kwargs["temperature"] == 0.6
+        assert pipeline_kwargs["top_p"] == 0.9
+        assert pipeline_kwargs["top_k"] == 40
+        assert pipeline_kwargs["seed"] == 7
+        mock_hf_pipeline.assert_called_once_with(pipeline=mock_pipeline.return_value)
+        mock_chat_hf.assert_called_once_with(llm=mock_hf_pipeline.return_value)
+
+    @patch("bili.iris.loaders.llm_loader.ChatHuggingFace")
+    @patch("bili.iris.loaders.llm_loader.HuggingFacePipeline")
+    @patch("bili.iris.loaders.llm_loader.pipeline")
+    @patch("bili.iris.loaders.llm_loader.AutoModelForCausalLM")
+    @patch("bili.iris.loaders.llm_loader.torch")
+    @patch("bili.iris.loaders.llm_loader.load_huggingface_tokenizer")
+    def test_minimal_config_omits_optional_params(
+        self,
+        mock_tokenizer_loader,
+        mock_torch,
+        mock_auto_model,
+        mock_pipeline,
+        mock_hf_pipeline,
+        mock_chat_hf,
+    ):
+        """Verify optional generation params are absent when not provided."""
+        tokenizer = MagicMock()
+        tokenizer.pad_token = "<pad>"
+        mock_tokenizer_loader.return_value = tokenizer
+        mock_torch.cuda.is_available.return_value = False
+        mock_chat_hf.return_value = "chat_model"
+
+        load_huggingface_model(model_name="gpt2")
+
+        # No CUDA cache clear when CUDA is unavailable.
+        mock_torch.cuda.empty_cache.assert_not_called()
+        pipeline_kwargs = mock_pipeline.call_args[1]
+        for absent in ("max_new_tokens", "temperature", "top_p", "top_k", "seed"):
+            assert absent not in pipeline_kwargs
+
+
+# ---------------------------------------------------------------------------
+# load_llamacpp_model (local)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadLlamaCppModel:
+    """Verify the local LlamaCpp model construction."""
+
+    @patch("bili.iris.loaders.llm_loader.ChatLlamaCpp")
+    def test_full_config_passes_all_params(self, mock_cls):
+        """Verify all optional params are merged into the LlamaCpp config."""
+        mock_cls.return_value = "llama_model"
+
+        result = load_llamacpp_model(
+            model_name="model.gguf",
+            max_tokens=256,
+            temperature=0.8,
+            top_p=0.95,
+            top_k=50,
+            seed=11,
+        )
+
+        assert result == "llama_model"
+        call_kwargs = mock_cls.call_args[1]
+        assert call_kwargs["model_path"] == "model.gguf"
+        assert call_kwargs["n_ctx"] == 4096
+        assert call_kwargs["max_tokens"] == 256
+        assert call_kwargs["temperature"] == 0.8
+        assert call_kwargs["top_p"] == 0.95
+        assert call_kwargs["top_k"] == 50
+        assert call_kwargs["seed"] == 11
+
+    @patch("bili.iris.loaders.llm_loader.ChatLlamaCpp")
+    def test_minimal_config_omits_optional_params(self, mock_cls):
+        """Verify optional params are omitted when falsy."""
+        mock_cls.return_value = "llama_model"
+
+        load_llamacpp_model(model_name="model.gguf")
+
+        call_kwargs = mock_cls.call_args[1]
+        assert call_kwargs["model_path"] == "model.gguf"
+        for absent in ("max_tokens", "temperature", "top_p", "top_k", "seed"):
+            assert absent not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Optional-parameter coverage for remote loaders
+# ---------------------------------------------------------------------------
+
+
+class TestRemoteLoaderOptionalParams:
+    """Verify optional config keys are set on the remote loaders."""
+
+    @patch("bili.iris.loaders.llm_loader.ChatVertexAI")
+    def test_vertex_all_optional_params(self, mock_cls):
+        """Verify every optional Vertex config key is forwarded."""
+        mock_cls.return_value = MagicMock()
+        schema = {"type": "object"}
+        load_remote_gcp_vertex_model(
+            model_name="gemini-pro",
+            max_tokens=100,
+            temperature=0.5,
+            top_p=0.9,
+            top_k=20,
+            seed=3,
+            response_mime_type="application/json",
+            response_schema=schema,
+        )
+        call_kwargs = mock_cls.call_args[1]
+        assert call_kwargs["max_output_tokens"] == 100
+        assert call_kwargs["temperature"] == 0.5
+        assert call_kwargs["top_p"] == 0.9
+        assert call_kwargs["top_k"] == 20
+        assert call_kwargs["seed"] == 3
+        assert call_kwargs["response_mime_type"] == "application/json"
+        assert call_kwargs["response_schema"] == schema
+
+    @patch("bili.iris.loaders.llm_loader.AzureChatOpenAI")
+    def test_azure_top_k_forwarded(self, mock_cls):
+        """Verify Azure top_k is forwarded."""
+        mock_cls.return_value = MagicMock()
+        load_remote_azure_openai(model_name="gpt-4", api_version="2024-01", top_k=15)
+        assert mock_cls.call_args[1]["top_k"] == 15
+
+    @patch("bili.iris.loaders.llm_loader.ChatOpenAI")
+    def test_openai_top_k_forwarded(self, mock_cls):
+        """Verify OpenAI top_k is forwarded."""
+        mock_cls.return_value = MagicMock()
+        load_remote_openai(model_name="gpt-4o", top_k=25)
+        assert mock_cls.call_args[1]["top_k"] == 25
+
+
+# ---------------------------------------------------------------------------
+# prepare_runtime_config — ThinkingConfig error handling
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareRuntimeConfigErrors:
+    """Verify ThinkingConfig value/type errors are caught and logged."""
+
+    def test_invalid_budget_string_is_handled(self):
+        """Verify a non-numeric budget string is caught without raising."""
+        fake_types = MagicMock()
+        fake_types.ThinkingConfig.side_effect = None
+        with patch.dict(
+            "sys.modules",
+            {"google.genai": MagicMock(types=fake_types)},
+        ):
+            # An int() conversion failure on the budget string is caught by
+            # the ValueError/TypeError handler, leaving the config empty.
+            result = prepare_runtime_config(
+                model_type="remote_google_vertex",
+                thinking_config={"budget": "not-a-number"},
+            )
+        assert "thinking_config" not in result
+
+    def test_none_budget_skips_thinking_config(self):
+        """Verify an explicit None budget produces no thinking_config."""
+        with patch.dict(
+            "sys.modules",
+            {"google.genai": MagicMock()},
+        ):
+            result = prepare_runtime_config(
+                model_type="remote_google_vertex",
+                thinking_config={"budget": None},
+            )
+        assert "thinking_config" not in result

--- a/bili/iris/loaders/tests/test_middleware_loader.py
+++ b/bili/iris/loaders/tests/test_middleware_loader.py
@@ -1,6 +1,6 @@
 """Tests for bili.iris.loaders.middleware_loader public API."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -75,3 +75,15 @@ class TestInitializeMiddleware:
         ):
             result = initialize_middleware(active_middleware=["summarization"])
             assert not result
+
+
+class TestInitializeMiddlewareFailure:
+    """initialize_middleware logs and re-raises when a factory fails."""
+
+    def test_reraises_factory_failure(self):
+        """A middleware factory raising propagates after being logged."""
+        boom = MagicMock(side_effect=RuntimeError("factory boom"))
+        with patch.dict(MIDDLEWARE_REGISTRY, {"summarization": boom}):
+            with pytest.raises(RuntimeError, match="factory boom"):
+                initialize_middleware(active_middleware=["summarization"])
+        boom.assert_called_once()

--- a/bili/iris/loaders/tests/test_streaming_utils.py
+++ b/bili/iris/loaders/tests/test_streaming_utils.py
@@ -2,12 +2,14 @@
 
 from unittest.mock import MagicMock
 
+import pytest
 from langchain_core.messages import AIMessageChunk, HumanMessage
 
 from bili.iris.loaders.streaming_utils import (
     _build_config,
     _build_input,
     _extract_token,
+    astream_agent,
     invoke_agent,
     stream_agent,
 )
@@ -255,3 +257,44 @@ class TestInvokeAgent:
 
         result = invoke_agent(mock_agent, "query")
         assert result == "result text"
+
+
+class TestAstreamAgent:
+    """Async streaming: astream_agent yields tokens and degrades on error."""
+
+    @pytest.mark.anyio
+    async def test_yields_content_from_chat_model_stream_events(self):
+        """Tokens are yielded from on_chat_model_stream events with content."""
+        chunk = MagicMock()
+        chunk.content = "hello"
+        empty_chunk = MagicMock()
+        empty_chunk.content = ""
+
+        async def fake_events(*_args, **_kwargs):
+            # A content chunk is yielded; an empty one and a non-stream event
+            # are both skipped.
+            yield {"event": "on_chat_model_stream", "data": {"chunk": chunk}}
+            yield {"event": "on_chat_model_stream", "data": {"chunk": empty_chunk}}
+            yield {"event": "on_chain_start", "data": {}}
+
+        agent = MagicMock()
+        agent.astream_events = fake_events
+
+        tokens = [tok async for tok in astream_agent(agent, "hi")]
+        assert tokens == ["hello"]
+
+    @pytest.mark.anyio
+    async def test_yields_error_message_when_stream_raises(self):
+        """A failure during streaming yields a single error token, not a crash."""
+
+        async def boom_events(*_args, **_kwargs):
+            raise RuntimeError("stream boom")
+            yield  # pragma: no cover  (makes this an async generator)
+
+        agent = MagicMock()
+        agent.astream_events = boom_events
+
+        tokens = [tok async for tok in astream_agent(agent, "hi")]
+        assert len(tokens) == 1
+        assert "Async streaming response failed" in tokens[0]
+        assert "RuntimeError" in tokens[0]

--- a/bili/iris/tools/tests/test_amazon_opensearch.py
+++ b/bili/iris/tools/tests/test_amazon_opensearch.py
@@ -1,0 +1,70 @@
+"""Tests for bili.iris.tools.amazon_opensearch.
+
+Covers the query-builder closure (similarity search dispatch, list joining,
+and error swallowing) and tool initialization. The OpenSearch vector store is
+mocked at load_opensearch_vector_search.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from unittest.mock import MagicMock, patch
+
+from langchain_core.tools import Tool
+
+from bili.iris.tools.amazon_opensearch import (
+    build_query_opensearch,
+    init_amazon_opensearch,
+)
+
+
+class TestBuildQueryOpensearch:
+    """Verify the closure returned by build_query_opensearch."""
+
+    @patch("bili.iris.tools.amazon_opensearch.load_opensearch_vector_search")
+    def test_joins_list_results_into_string(self, mock_load):
+        docsearch = MagicMock()
+        docsearch.similarity_search.return_value = ["doc one", "doc two"]
+        mock_load.return_value = docsearch
+        embed = MagicMock()
+
+        query_fn = build_query_opensearch(embed, "idx", k=3, score_threshold=0.2)
+        result = query_fn("hello")
+
+        assert result == "doc one doc two"
+        mock_load.assert_called_once_with(embed, "idx")
+        docsearch.similarity_search.assert_called_once_with(
+            "hello", k=3, score_threshold=0.2
+        )
+
+    @patch("bili.iris.tools.amazon_opensearch.load_opensearch_vector_search")
+    def test_non_list_result_is_stringified(self, mock_load):
+        docsearch = MagicMock()
+        docsearch.similarity_search.return_value = 12345
+        mock_load.return_value = docsearch
+
+        query_fn = build_query_opensearch(MagicMock(), "idx")
+        assert query_fn("q") == "12345"
+
+    @patch("bili.iris.tools.amazon_opensearch.load_opensearch_vector_search")
+    def test_search_error_returns_empty_string(self, mock_load):
+        docsearch = MagicMock()
+        docsearch.similarity_search.side_effect = RuntimeError("boom")
+        mock_load.return_value = docsearch
+
+        query_fn = build_query_opensearch(MagicMock(), "idx")
+        assert query_fn("q") == ""
+
+
+class TestInitAmazonOpensearch:
+    """Verify tool construction."""
+
+    @patch("bili.iris.tools.amazon_opensearch.load_opensearch_vector_search")
+    def test_builds_tool_with_query_function(self, mock_load):
+        mock_load.return_value = MagicMock()
+
+        tool = init_amazon_opensearch("os_tool", "desc", MagicMock(), "my_index")
+
+        assert isinstance(tool, Tool)
+        assert tool.name == "os_tool"
+        assert callable(tool.func)
+        mock_load.assert_called_once()

--- a/bili/iris/tools/tests/test_api_free_weather_api.py
+++ b/bili/iris/tools/tests/test_api_free_weather_api.py
@@ -1,0 +1,114 @@
+"""Tests for bili.iris.tools.api_free_weather_api.
+
+Covers the async fetch_weather function (endpoint construction, env-var
+guards, empty-response and error handling) and tool initialization. The
+async tests use anyio, matching the project's async test convention.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from langchain_core.tools import Tool
+
+from bili.iris.tools.api_free_weather_api import fetch_weather, init_weather_tool
+
+pytestmark = pytest.mark.anyio
+
+
+class TestFetchWeather:
+    """Verify async weather fetching against the free weather API."""
+
+    @patch.dict(
+        "os.environ",
+        {"WEATHER_API_KEY": "abc", "FREE_WEATHER_API": "http://api/?key="},
+        clear=False,
+    )
+    @patch("bili.iris.tools.api_free_weather_api.requests.get")
+    async def test_builds_endpoint_and_returns_wrapped_data(self, mock_get):
+        resp = MagicMock()
+        resp.json.return_value = {"current": {"temp_c": 20}}
+        mock_get.return_value = resp
+
+        result = await fetch_weather("boulder")
+
+        assert result == {"weather": {"current": {"temp_c": 20}}}
+        called_url = mock_get.call_args[0][0]
+        assert called_url == "http://api/?key=abc&q=boulder&aqi=no"
+        assert mock_get.call_args[1]["timeout"] == 5
+        resp.raise_for_status.assert_called_once()
+
+    @patch.dict(
+        "os.environ",
+        {"WEATHER_API_KEY": "abc", "FREE_WEATHER_API": "http://api/?key="},
+        clear=False,
+    )
+    @patch("bili.iris.tools.api_free_weather_api.requests.get")
+    async def test_empty_response_returns_empty_dict(self, mock_get):
+        resp = MagicMock()
+        resp.json.return_value = {}
+        mock_get.return_value = resp
+
+        assert await fetch_weather("denver") == {}
+
+    @patch.dict(
+        "os.environ",
+        {"WEATHER_API_KEY": "abc", "FREE_WEATHER_API": "http://api/?key="},
+        clear=False,
+    )
+    @patch("bili.iris.tools.api_free_weather_api.requests.get")
+    async def test_request_exception_returns_empty_dict(self, mock_get):
+        mock_get.side_effect = requests.exceptions.RequestException("down")
+
+        assert await fetch_weather("denver") == {}
+
+    @patch.dict(
+        "os.environ",
+        {"WEATHER_API_KEY": "abc", "FREE_WEATHER_API": "http://api/?key="},
+        clear=False,
+    )
+    @patch("bili.iris.tools.api_free_weather_api.requests.get")
+    async def test_generic_exception_returns_empty_dict(self, mock_get):
+        # A non-request error during parsing is caught by the broad handler.
+        resp = MagicMock()
+        resp.json.side_effect = ValueError("bad json")
+        mock_get.return_value = resp
+
+        assert await fetch_weather("denver") == {}
+
+    @patch.dict("os.environ", {"WEATHER_API_KEY": "", "FREE_WEATHER_API": "u"})
+    async def test_missing_api_key_raises_value_error(self):
+        with pytest.raises(ValueError, match="Weather API key is not set"):
+            await fetch_weather("denver")
+
+    @patch.dict("os.environ", {"WEATHER_API_KEY": "abc", "FREE_WEATHER_API": ""})
+    async def test_missing_url_raises_value_error(self):
+        with pytest.raises(ValueError, match="Weather URL is not set"):
+            await fetch_weather("denver")
+
+
+class TestInitWeatherTool:
+    """Verify tool construction wraps the async fetch in asyncio.run."""
+
+    def test_builds_tool(self):
+        tool = init_weather_tool("free_weather", "desc")
+        assert isinstance(tool, Tool)
+        assert tool.name == "free_weather"
+
+    @patch.dict(
+        "os.environ",
+        {"WEATHER_API_KEY": "abc", "FREE_WEATHER_API": "http://api/?key="},
+        clear=False,
+    )
+    @patch("bili.iris.tools.api_free_weather_api.requests.get")
+    def test_tool_func_runs_fetch_synchronously(self, mock_get):
+        resp = MagicMock()
+        resp.json.return_value = {"current": {"temp_c": 5}}
+        mock_get.return_value = resp
+
+        tool = init_weather_tool("free_weather", "desc")
+        result = tool.func("denver")
+
+        assert result == {"weather": {"current": {"temp_c": 5}}}

--- a/bili/iris/tools/tests/test_api_open_weather.py
+++ b/bili/iris/tools/tests/test_api_open_weather.py
@@ -1,0 +1,210 @@
+"""Tests for bili.iris.tools.api_open_weather.
+
+Covers input sanitization, geocoding by city and ZIP, weather retrieval,
+the execute_query dispatch logic, and tool initialization. All HTTP traffic
+is mocked at the requests layer; assertions check request URLs, parsed
+fields, and error handling.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from langchain_core.tools import Tool
+
+from bili.iris.tools import api_open_weather
+from bili.iris.tools.api_open_weather import (
+    execute_query,
+    get_geocode,
+    get_geocode_from_zip,
+    get_weather,
+    init_weather_api_tool,
+    sanitize_input,
+)
+
+
+class TestSanitizeInput:
+    """Verify input sanitization and URL encoding."""
+
+    def test_strips_unsafe_characters_and_collapses_whitespace(self):
+        # The comma is removed as unsafe; the newline and the run of spaces
+        # collapse to single spaces, each URL-encoded to %20.
+        assert sanitize_input("New\nYork,  CO") == "New%20York%20CO"
+
+    def test_preserves_hyphen_and_alphanumerics(self):
+        assert sanitize_input("Winston-Salem") == "Winston-Salem"
+
+    def test_trims_leading_and_trailing_whitespace(self):
+        assert sanitize_input("  Denver  ") == "Denver"
+
+
+class TestGetGeocode:
+    """Verify city geocoding against the OpenWeather direct API."""
+
+    @patch.dict("os.environ", {"OPENWEATHERMAP_API_KEY": "k123"}, clear=False)
+    @patch("bili.iris.tools.api_open_weather.requests.get")
+    def test_returns_lat_lon_from_first_result(self, mock_get):
+        resp = MagicMock()
+        resp.json.return_value = [{"lat": 39.7, "lon": -104.9}]
+        mock_get.return_value = resp
+
+        lat, lon = get_geocode("Denver", "CO", "US")
+
+        assert (lat, lon) == (39.7, -104.9)
+        called_url = mock_get.call_args[0][0]
+        assert "geo/1.0/direct?q=Denver,CO,US" in called_url
+        assert "appid=k123" in called_url
+        assert mock_get.call_args[1]["timeout"] == 10
+        resp.raise_for_status.assert_called_once()
+
+    @patch.dict("os.environ", {"OPENWEATHERMAP_API_KEY": "k123"}, clear=False)
+    @patch("bili.iris.tools.api_open_weather.requests.get")
+    def test_returns_none_pair_for_empty_response(self, mock_get):
+        resp = MagicMock()
+        resp.json.return_value = []
+        mock_get.return_value = resp
+
+        assert get_geocode("Nowhere") == (None, None)
+
+    @patch.dict("os.environ", {"OPENWEATHERMAP_API_KEY": "k123"}, clear=False)
+    @patch("bili.iris.tools.api_open_weather.requests.get")
+    def test_reraises_request_exception(self, mock_get):
+        mock_get.side_effect = requests.exceptions.RequestException("down")
+
+        with pytest.raises(requests.exceptions.RequestException, match="down"):
+            get_geocode("Denver")
+
+
+class TestGetGeocodeFromZip:
+    """Verify ZIP geocoding against the OpenWeather zip API."""
+
+    @patch.dict("os.environ", {"OPENWEATHERMAP_API_KEY": "zk"}, clear=False)
+    @patch("bili.iris.tools.api_open_weather.requests.get")
+    def test_returns_lat_lon_from_zip(self, mock_get):
+        resp = MagicMock()
+        resp.json.return_value = {"lat": 40.0, "lon": -105.0}
+        mock_get.return_value = resp
+
+        lat, lon = get_geocode_from_zip("80202")
+
+        assert (lat, lon) == (40.0, -105.0)
+        called_url = mock_get.call_args[0][0]
+        assert "geo/1.0/zip?zip=80202,US" in called_url
+        assert "appid=zk" in called_url
+
+    @patch.dict("os.environ", {"OPENWEATHERMAP_API_KEY": "zk"}, clear=False)
+    @patch("bili.iris.tools.api_open_weather.requests.get")
+    def test_returns_none_pair_on_request_exception(self, mock_get):
+        # Unlike get_geocode, the ZIP variant swallows the error and
+        # returns (None, None) rather than re-raising.
+        mock_get.side_effect = requests.exceptions.RequestException("oops")
+
+        assert get_geocode_from_zip("80202") == (None, None)
+
+
+class TestGetWeather:
+    """Verify current-weather retrieval."""
+
+    @patch.dict("os.environ", {"OPENWEATHERMAP_API_KEY": "wk"}, clear=False)
+    @patch("bili.iris.tools.api_open_weather.requests.get")
+    def test_returns_parsed_json(self, mock_get):
+        resp = MagicMock()
+        resp.json.return_value = {"weather": [{"main": "Clear"}]}
+        mock_get.return_value = resp
+
+        data = get_weather(39.7, -104.9)
+
+        assert data == {"weather": [{"main": "Clear"}]}
+        called_url = mock_get.call_args[0][0]
+        assert "data/2.5/weather?lat=39.7&lon=-104.9" in called_url
+        assert "appid=wk" in called_url
+
+    @patch.dict("os.environ", {"OPENWEATHERMAP_API_KEY": "wk"}, clear=False)
+    @patch("bili.iris.tools.api_open_weather.requests.get")
+    def test_reraises_request_exception(self, mock_get):
+        mock_get.side_effect = requests.exceptions.RequestException("net")
+
+        with pytest.raises(requests.exceptions.RequestException, match="net"):
+            get_weather(1.0, 2.0)
+
+
+class TestExecuteQuery:
+    """Verify the query-dispatch and error-message paths."""
+
+    @patch("bili.iris.tools.api_open_weather.get_weather")
+    @patch("bili.iris.tools.api_open_weather.get_geocode_from_zip")
+    def test_zip_code_path(self, mock_zip, mock_weather):
+        mock_zip.return_value = (40.0, -105.0)
+        mock_weather.return_value = {"main": "Clouds"}
+
+        result = execute_query("80202")
+
+        mock_zip.assert_called_once_with("80202")
+        mock_weather.assert_called_once_with(40.0, -105.0)
+        assert result == "{'main': 'Clouds'}"
+
+    @patch("bili.iris.tools.api_open_weather.get_weather")
+    @patch("bili.iris.tools.api_open_weather.get_geocode")
+    def test_city_comma_state_path(self, mock_geo, mock_weather):
+        mock_geo.return_value = (39.7, -104.9)
+        mock_weather.return_value = {"main": "Sun"}
+
+        result = execute_query("Denver, CO")
+
+        # City and state are sanitized before geocoding.
+        mock_geo.assert_called_once_with("Denver", "CO")
+        assert result == "{'main': 'Sun'}"
+
+    @patch("bili.iris.tools.api_open_weather.get_weather")
+    @patch("bili.iris.tools.api_open_weather.get_geocode")
+    def test_city_space_state_path(self, mock_geo, mock_weather):
+        mock_geo.return_value = (1.0, 2.0)
+        mock_weather.return_value = {"main": "Rain"}
+
+        execute_query("Boulder CO")
+
+        mock_geo.assert_called_once_with("Boulder", "CO")
+
+    @patch("bili.iris.tools.api_open_weather.get_weather")
+    @patch("bili.iris.tools.api_open_weather.get_geocode")
+    def test_city_only_defaults_state_to_co(self, mock_geo, mock_weather):
+        mock_geo.return_value = (1.0, 2.0)
+        mock_weather.return_value = {"main": "Snow"}
+
+        execute_query("Aspen")
+
+        mock_geo.assert_called_once_with("Aspen", "CO")
+
+    @patch("bili.iris.tools.api_open_weather.get_geocode")
+    def test_location_not_found_returns_message(self, mock_geo):
+        mock_geo.return_value = (None, None)
+
+        assert execute_query("Atlantis") == "Could not find the location."
+
+    @patch("bili.iris.tools.api_open_weather.get_weather")
+    @patch("bili.iris.tools.api_open_weather.get_geocode")
+    def test_weather_none_returns_failure_message(self, mock_geo, mock_weather):
+        mock_geo.return_value = (1.0, 2.0)
+        mock_weather.return_value = None
+
+        assert execute_query("Denver") == "Failed to retrieve weather data."
+
+
+class TestInitWeatherApiTool:
+    """Verify tool construction and missing-key guard."""
+
+    @patch.dict("os.environ", {"OPENWEATHERMAP_API_KEY": "x"}, clear=False)
+    def test_builds_tool(self):
+        tool = init_weather_api_tool("ow", "desc")
+        assert isinstance(tool, Tool)
+        assert tool.name == "ow"
+        assert tool.func is execute_query
+
+    def test_missing_key_raises_value_error(self):
+        env = {k: v for k, v in api_open_weather.os.environ.items()}
+        env.pop("OPENWEATHERMAP_API_KEY", None)
+        with patch.dict("os.environ", env, clear=True):
+            with pytest.raises(ValueError, match="OPENWEATHERMAP_API_KEY"):
+                init_weather_api_tool("ow", "desc")

--- a/bili/iris/tools/tests/test_api_serp.py
+++ b/bili/iris/tools/tests/test_api_serp.py
@@ -1,0 +1,140 @@
+"""Tests for bili.iris.tools.api_serp.
+
+Covers query sanitization, response filtering, the execute_query HTTP path,
+and tool initialization including the missing-key guard.
+"""
+
+# pylint: disable=missing-function-docstring
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.tools import Tool
+
+from bili.iris.tools import api_serp
+from bili.iris.tools.api_serp import (
+    execute_query,
+    filter_serp_results,
+    init_serp_api_tool,
+    sanitize_serp_query,
+)
+
+
+class TestSanitizeSerpQuery:
+    """Verify SERP query sanitization."""
+
+    def test_empty_query_returns_empty_string(self):
+        assert sanitize_serp_query("") == ""
+
+    def test_strips_injection_characters_and_control_chars(self):
+        # Angle brackets and quotes are removed; a control char (bell) too.
+        assert sanitize_serp_query("a<b>\"c'\x07d") == "abcd"
+
+    def test_normalizes_whitespace_and_url_encodes(self):
+        assert sanitize_serp_query("hello   world") == "hello%20world"
+
+    def test_truncates_to_500_characters_before_encoding(self):
+        raw = "a" * 600
+        # 500 'a' characters, none needing encoding.
+        assert sanitize_serp_query(raw) == "a" * 500
+
+
+class TestFilterSerpResults:
+    """Verify the token-reducing result filter."""
+
+    def test_extracts_query_and_top_results(self):
+        data = {
+            "search_parameters": {"q": "weather"},
+            "organic_results": [
+                {
+                    "title": "T1",
+                    "link": "http://a",
+                    "snippet": "s1",
+                    "source": "src1",
+                },
+                {"title": "T2", "link": "http://b", "snippet": "s2"},
+            ],
+        }
+        filtered = filter_serp_results(data, max_results=1)
+
+        assert filtered["query"] == "weather"
+        assert len(filtered["results"]) == 1
+        assert filtered["results"][0] == {
+            "title": "T1",
+            "link": "http://a",
+            "snippet": "s1",
+            "source": "src1",
+        }
+
+    def test_truncates_long_snippet_to_300_chars(self):
+        data = {"organic_results": [{"title": "x", "snippet": "y" * 400}]}
+        filtered = filter_serp_results(data)
+        assert len(filtered["results"][0]["snippet"]) == 300
+
+    def test_includes_knowledge_panel_when_present(self):
+        data = {
+            "organic_results": [],
+            "knowledge_graph": {"title": "Denver", "description": "A city."},
+        }
+        filtered = filter_serp_results(data)
+        assert filtered["knowledge_panel"] == {
+            "title": "Denver",
+            "description": "A city.",
+        }
+
+    def test_includes_answer_box_with_snippet_fallback(self):
+        data = {
+            "organic_results": [],
+            "answer_box": {"title": "Ans", "snippet": "42"},
+        }
+        filtered = filter_serp_results(data)
+        # answer falls back to snippet when no explicit answer key.
+        assert filtered["answer_box"] == {"title": "Ans", "answer": "42"}
+
+    def test_omits_optional_sections_when_absent(self):
+        filtered = filter_serp_results({"organic_results": []})
+        assert "knowledge_panel" not in filtered
+        assert "answer_box" not in filtered
+
+
+class TestExecuteQuery:
+    """Verify the SERP HTTP execution path."""
+
+    @patch.dict("os.environ", {"SERP_API_KEY": "sk"}, clear=False)
+    @patch("bili.iris.tools.api_serp.requests.get")
+    def test_builds_url_and_returns_filtered_json(self, mock_get):
+        resp = MagicMock()
+        resp.json.return_value = {
+            "search_parameters": {"q": "cats"},
+            "organic_results": [{"title": "Cats", "link": "http://c"}],
+        }
+        mock_get.return_value = resp
+
+        result = execute_query("cats")
+
+        called_url = mock_get.call_args[0][0]
+        assert "serpapi.com/search.json?q=cats" in called_url
+        assert "api_key=sk" in called_url
+        assert mock_get.call_args[1]["timeout"] == 10
+        parsed = json.loads(result)
+        assert parsed["query"] == "cats"
+        assert parsed["results"][0]["title"] == "Cats"
+
+
+class TestInitSerpApiTool:
+    """Verify tool construction and missing-key guard."""
+
+    @patch.dict("os.environ", {"SERP_API_KEY": "sk"}, clear=False)
+    def test_builds_tool(self):
+        tool = init_serp_api_tool("serp", "desc")
+        assert isinstance(tool, Tool)
+        assert tool.name == "serp"
+        assert tool.func is execute_query
+
+    def test_missing_key_raises_value_error(self):
+        env = {k: v for k, v in api_serp.os.environ.items()}
+        env.pop("SERP_API_KEY", None)
+        with patch.dict("os.environ", env, clear=True):
+            with pytest.raises(ValueError, match="SERP_API_KEY"):
+                init_serp_api_tool("serp", "desc")

--- a/bili/iris/tools/tests/test_api_weather_gov.py
+++ b/bili/iris/tools/tests/test_api_weather_gov.py
@@ -1,0 +1,131 @@
+"""Tests for bili.iris.tools.api_weather_gov.
+
+Covers the two-hop forecast fetch and field trimming, query validation and
+sanitization in execute_query, and tool initialization. HTTP traffic is
+mocked at the requests layer.
+"""
+
+# pylint: disable=missing-function-docstring
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from langchain_core.tools import Tool, ToolException
+
+from bili.iris.tools.api_weather_gov import (
+    execute_query,
+    get_forecast_context_4k,
+    init_weather_gov_api_tool,
+)
+
+
+def _points_response(forecast_url):
+    resp = MagicMock()
+    resp.json.return_value = {"properties": {"forecast": forecast_url}}
+    return resp
+
+
+def _forecast_response(periods):
+    resp = MagicMock()
+    resp.json.return_value = {"properties": {"periods": periods}}
+    return resp
+
+
+class TestGetForecastContext4k:
+    """Verify the two-request forecast fetch and field trimming."""
+
+    @patch("bili.iris.tools.api_weather_gov.requests.get")
+    def test_trims_to_name_and_detailed_forecast(self, mock_get):
+        period = {
+            "name": "Tonight",
+            "number": 1,
+            "isDaytime": False,
+            "startTime": "2026-01-01T18:00",
+            "endTime": "2026-01-02T06:00",
+            "temperature": 30,
+            "temperatureUnit": "F",
+            "temperatureTrend": None,
+            "probabilityOfPrecipitation": {"value": 10},
+            "relativeHumidity": {"value": 80},
+            "dewpoint": {"value": 1},
+            "windSpeed": "5 mph",
+            "windDirection": "N",
+            "icon": "url",
+            "shortForecast": "Clear",
+            "detailedForecast": "Clear skies overnight.",
+        }
+        mock_get.side_effect = [
+            _points_response("https://api.weather.gov/forecast/1"),
+            _forecast_response([period]),
+        ]
+
+        result = get_forecast_context_4k("https://api.weather.gov/points/39,-104")
+
+        parsed = json.loads(result)
+        assert parsed == [
+            {"name": "Tonight", "detailedForecast": "Clear skies overnight."}
+        ]
+        # Two GET calls: first for points, then for the forecast URL.
+        assert mock_get.call_args_list[0][0][0].endswith("points/39,-104")
+        assert mock_get.call_args_list[1][0][0] == (
+            "https://api.weather.gov/forecast/1"
+        )
+
+    @patch("bili.iris.tools.api_weather_gov.requests.get")
+    def test_request_exception_becomes_tool_exception(self, mock_get):
+        mock_get.side_effect = requests.exceptions.RequestException("boom")
+
+        with pytest.raises(ToolException, match="API_WeatherGOVTool"):
+            get_forecast_context_4k("https://api.weather.gov/points/1,2")
+
+
+class TestExecuteQuery:
+    """Verify coordinate validation, sanitization, and dispatch."""
+
+    @patch("bili.iris.tools.api_weather_gov.get_forecast_context_4k")
+    def test_valid_coordinates_call_forecast(self, mock_forecast):
+        mock_forecast.return_value = "[]"
+
+        result = execute_query("39.7,-104.9")
+
+        mock_forecast.assert_called_once_with(
+            "https://api.weather.gov/points/39.7,-104.9"
+        )
+        assert result == "[]"
+
+    @patch("bili.iris.tools.api_weather_gov.get_forecast_context_4k")
+    def test_strips_unsafe_characters_before_matching(self, mock_forecast):
+        mock_forecast.return_value = "[]"
+
+        # Letters and spaces are stripped, leaving a valid lat,lon pair.
+        execute_query("lat 39.7, lon -104.9")
+
+        mock_forecast.assert_called_once_with(
+            "https://api.weather.gov/points/39.7,-104.9"
+        )
+
+    @patch("bili.iris.tools.api_weather_gov.get_forecast_context_4k")
+    def test_extra_commas_truncated_to_two_parts(self, mock_forecast):
+        mock_forecast.return_value = "[]"
+
+        execute_query("39.7,-104.9,500")
+
+        mock_forecast.assert_called_once_with(
+            "https://api.weather.gov/points/39.7,-104.9"
+        )
+
+    def test_invalid_query_returns_error_message(self):
+        result = execute_query("not-a-coordinate-pair")
+        assert result.startswith("Invalid query.")
+
+
+class TestInitWeatherGovApiTool:
+    """Verify tool construction."""
+
+    def test_builds_tool(self):
+        tool = init_weather_gov_api_tool("wgov", "desc")
+        assert isinstance(tool, Tool)
+        assert tool.name == "wgov"
+        assert tool.func is execute_query

--- a/bili/iris/tools/tests/test_faiss_memory_indexing.py
+++ b/bili/iris/tools/tests/test_faiss_memory_indexing.py
@@ -1,0 +1,105 @@
+"""Tests for bili.iris.tools.faiss_memory_indexing.
+
+Covers retriever construction, the cached index loader, path validation
+security rules, and init_faiss dispatch. FAISS, the embedding loader, and
+directory preprocessing are all mocked.
+"""
+
+# pylint: disable=missing-function-docstring
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bili.iris.tools.faiss_memory_indexing import (
+    ALLOWED_PREFIXES,
+    create_faiss_retriever,
+    init_faiss,
+    load_faiss_index,
+    validate_path,
+)
+
+
+class TestCreateFaissRetriever:
+    """Verify retriever construction from documents."""
+
+    @patch("bili.iris.tools.faiss_memory_indexing.FAISS")
+    @patch("bili.iris.tools.faiss_memory_indexing.load_embedding_function")
+    def test_builds_retriever_with_expected_search_kwargs(self, mock_embed, mock_faiss):
+        mock_embed.return_value = "embed_fn"
+        faiss_index = MagicMock()
+        retriever = MagicMock()
+        faiss_index.as_retriever.return_value = retriever
+        mock_faiss.from_documents.return_value = faiss_index
+
+        docs = ["d1", "d2"]
+        result = create_faiss_retriever(docs)
+
+        assert result is retriever
+        mock_embed.assert_called_once_with("sentence_transformer")
+        mock_faiss.from_documents.assert_called_once_with(
+            documents=docs, embedding="embed_fn"
+        )
+        faiss_index.as_retriever.assert_called_once_with(
+            search_kwargs={"k": 50, "fetch_k": 500}
+        )
+
+
+class TestLoadFaissIndex:
+    """Verify the cached preprocessing-and-index path."""
+
+    @patch("bili.iris.tools.faiss_memory_indexing.create_faiss_retriever")
+    @patch("bili.iris.tools.faiss_memory_indexing.preprocess_directory")
+    def test_preprocesses_then_builds_retriever(self, mock_prep, mock_create):
+        mock_prep.return_value = ["doc"]
+        mock_create.return_value = "retriever"
+
+        result = load_faiss_index("data/memory")
+
+        assert result == "retriever"
+        mock_prep.assert_called_once_with("data/memory")
+        mock_create.assert_called_once_with(["doc"])
+
+
+class TestValidatePath:
+    """Verify the path-validation security rules."""
+
+    def test_allows_path_under_allowed_prefix(self):
+        allowed = os.path.join(ALLOWED_PREFIXES[0], "subdir")
+        assert validate_path(allowed) is True
+
+    def test_allows_relative_data_path(self):
+        assert validate_path("data/memory") is True
+
+    def test_rejects_path_outside_allowed_locations(self):
+        assert validate_path("/etc/passwd") is False
+
+    def test_rejects_traversal_escaping_data(self):
+        # Normalization resolves the traversal to a path outside data/.
+        assert validate_path("data/../../etc/passwd") is False
+
+
+class TestInitFaiss:
+    """Verify init_faiss validation and dispatch."""
+
+    @patch("bili.iris.tools.faiss_memory_indexing.load_faiss_index")
+    def test_valid_path_returns_retriever(self, mock_load):
+        mock_load.return_value = "retriever"
+
+        result = init_faiss("data/memory")
+
+        assert result == "retriever"
+        mock_load.assert_called_once_with("data/memory")
+
+    def test_invalid_path_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid path"):
+            init_faiss("/not/allowed")
+
+    def test_default_data_dir_is_valid(self):
+        with patch(
+            "bili.iris.tools.faiss_memory_indexing.load_faiss_index"
+        ) as mock_load:
+            mock_load.return_value = "r"
+            assert init_faiss() == "r"
+            mock_load.assert_called_once_with("data")

--- a/bili/streamlit_ui/query/tests/__init__.py
+++ b/bili/streamlit_ui/query/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the streamlit_ui.query package."""

--- a/bili/streamlit_ui/query/tests/test_streamlit_query_handler.py
+++ b/bili/streamlit_ui/query/tests/test_streamlit_query_handler.py
@@ -1,0 +1,72 @@
+"""Tests for streamlit_ui.query.streamlit_query_handler."""
+
+from unittest.mock import MagicMock, patch
+
+from bili.streamlit_ui.query.streamlit_query_handler import (
+    process_query,
+    process_query_streaming,
+)
+
+_MODULE = "bili.streamlit_ui.query.streamlit_query_handler"
+
+
+class TestProcessQuery:
+    """process_query invokes the chain and returns the final message text."""
+
+    def test_returns_final_message_pretty_repr(self):
+        """The last message's pretty_repr is returned for a dict result."""
+        final_msg = MagicMock()
+        final_msg.pretty_repr.return_value = "the answer"
+        chain = MagicMock()
+        chain.invoke.return_value = {"messages": [MagicMock(), final_msg]}
+
+        with patch(
+            f"{_MODULE}.get_state_config",
+            return_value={"configurable": {"thread_id": "u@example.com"}},
+        ):
+            result = process_query(chain, "What is the weather?")
+
+        assert result == "the answer"
+        # The query is wrapped as a HumanMessage in a messages list.
+        sent_state = chain.invoke.call_args[0][0]
+        assert sent_state["messages"][0].content == "What is the weather?"
+        assert sent_state["verbose"] is False
+
+    def test_returns_fallback_for_unexpected_result(self):
+        """A non-dict result yields the no-response fallback string."""
+        chain = MagicMock()
+        chain.invoke.return_value = "unexpected"
+
+        with patch(f"{_MODULE}.get_state_config", return_value={}):
+            result = process_query(chain, "Hello")
+
+        assert result == "No response or invalid format."
+
+
+class TestProcessQueryStreaming:
+    """process_query_streaming delegates to stream_agent with the thread id."""
+
+    def test_yields_tokens_from_stream_agent(self):
+        """Tokens from stream_agent are yielded through with the thread id."""
+        chain = MagicMock()
+        config = {"configurable": {"thread_id": "thread-7"}}
+        with patch(f"{_MODULE}.get_state_config", return_value=config), patch(
+            "bili.iris.loaders.streaming_utils.stream_agent",
+            return_value=iter(["a", "b", "c"]),
+        ) as mock_stream:
+            tokens = list(process_query_streaming(chain, "Hi"))
+
+        assert tokens == ["a", "b", "c"]
+        mock_stream.assert_called_once_with(chain, "Hi", thread_id="thread-7")
+
+    def test_handles_missing_thread_id(self):
+        """A config without a thread id passes thread_id=None to stream_agent."""
+        chain = MagicMock()
+        with patch(f"{_MODULE}.get_state_config", return_value={}), patch(
+            "bili.iris.loaders.streaming_utils.stream_agent",
+            return_value=iter(["x"]),
+        ) as mock_stream:
+            tokens = list(process_query_streaming(chain, "Hi"))
+
+        assert tokens == ["x"]
+        assert mock_stream.call_args.kwargs["thread_id"] is None

--- a/bili/streamlit_ui/tests/test_auth_ui.py
+++ b/bili/streamlit_ui/tests/test_auth_ui.py
@@ -1,12 +1,15 @@
 """Tests for bili.streamlit_ui.ui.auth_ui module.
 
-Tests non-Streamlit logic: initialize_auth_manager and
-is_authenticated session-state checking.
+Tests non-Streamlit logic (initialize_auth_manager and is_authenticated
+session-state checking) plus the Streamlit rendering functions
+display_login_signup and check_auth via AppTest.
 """
 
 # pylint: disable=import-outside-toplevel
 
 from unittest.mock import patch
+
+from streamlit.testing.v1 import AppTest
 
 from bili.streamlit_ui.tests.conftest import FakeSessionState
 
@@ -140,3 +143,247 @@ class TestIsAuthenticated:
         from bili.streamlit_ui.ui.auth_ui import is_authenticated
 
         assert is_authenticated() is False
+
+
+# =========================================================================
+# display_login_signup -- rendering and button flows
+# =========================================================================
+
+
+class TestDisplayLoginSignup:
+    """Tests for the display_login_signup rendering function."""
+
+    def test_renders_welcome_and_widgets(self):
+        """The login/signup view renders the welcome heading and inputs."""
+        at = AppTest.from_string(
+            """
+from unittest.mock import MagicMock
+import streamlit as st
+from bili.streamlit_ui.ui.auth_ui import display_login_signup
+st.session_state.auth_manager = MagicMock()
+display_login_signup()
+""",
+            default_timeout=15,
+        )
+        at.run()
+        assert not at.exception
+        all_md = " ".join(m.value for m in at.markdown)
+        assert "Welcome to BiliCore" in all_md
+        assert len(at.selectbox) >= 1
+        assert len(at.text_input) >= 2
+
+    def test_shows_auth_warning_and_clears_it(self):
+        """A pending auth_warning is displayed then cleared from state."""
+        at = AppTest.from_string(
+            """
+from unittest.mock import MagicMock
+import streamlit as st
+from bili.streamlit_ui.ui.auth_ui import display_login_signup
+st.session_state.auth_manager = MagicMock()
+st.session_state.auth_warning = "Bad credentials"
+display_login_signup()
+st.markdown(f"warn_cleared:{st.session_state.auth_warning == ''}")
+""",
+            default_timeout=15,
+        )
+        at.run()
+        assert not at.exception
+        assert any("Bad credentials" in w.value for w in at.warning)
+        assert "warn_cleared:True" in " ".join(m.value for m in at.markdown)
+
+    def test_shows_auth_success_and_clears_it(self):
+        """A pending auth_success is displayed then cleared from state."""
+        at = AppTest.from_string(
+            """
+from unittest.mock import MagicMock
+import streamlit as st
+from bili.streamlit_ui.ui.auth_ui import display_login_signup
+st.session_state.auth_manager = MagicMock()
+st.session_state.auth_success = "Signed in"
+display_login_signup()
+st.markdown(f"ok_cleared:{st.session_state.auth_success == ''}")
+""",
+            default_timeout=15,
+        )
+        at.run()
+        assert not at.exception
+        assert any("Signed in" in s.value for s in at.success)
+        assert "ok_cleared:True" in " ".join(m.value for m in at.markdown)
+
+    def test_needs_profile_creation_defaults_to_signup(self):
+        """When needs_profile_creation is set the Signup tab is preselected."""
+        at = AppTest.from_string(
+            """
+from unittest.mock import MagicMock
+import streamlit as st
+from bili.streamlit_ui.ui.auth_ui import display_login_signup
+st.session_state.auth_manager = MagicMock()
+st.session_state.needs_profile_creation = True
+display_login_signup()
+st.markdown(f"choice:{at_choice if False else st.session_state.get('_x','')}")
+""",
+            default_timeout=15,
+        )
+        at.run()
+        assert not at.exception
+        # index=1 means the Signup option is selected by default
+        assert at.selectbox[0].value == "Signup"
+
+    def test_login_button_calls_sign_in(self):
+        """Clicking Log In calls auth_manager.sign_in with email and password."""
+        at = AppTest.from_string(
+            """
+from unittest.mock import MagicMock
+import streamlit as st
+from bili.streamlit_ui.ui.auth_ui import display_login_signup
+mgr = MagicMock()
+mgr.sign_in.return_value = {"uid": "u1"}
+st.session_state.auth_manager = mgr
+display_login_signup()
+""",
+            default_timeout=15,
+        )
+        at.run()
+        assert not at.exception
+        at.text_input[0].set_value("user@example.com")
+        at.text_input[1].set_value("secret")
+        login_buttons = [b for b in at.button if b.label == "Log In"]
+        assert login_buttons
+        login_buttons[0].click()
+        at.run()
+        assert not at.exception
+        mgr = at.session_state["auth_manager"]
+        mgr.sign_in.assert_called_once_with("user@example.com", "secret")
+        assert at.session_state["password"] == "secret"
+        assert at.session_state["auth_info"] == {"uid": "u1"}
+
+    def test_forgot_password_button_calls_reset(self):
+        """Clicking Forgot Password calls auth_manager.reset_password."""
+        at = AppTest.from_string(
+            """
+from unittest.mock import MagicMock
+import streamlit as st
+from bili.streamlit_ui.ui.auth_ui import display_login_signup
+st.session_state.auth_manager = MagicMock()
+display_login_signup()
+""",
+            default_timeout=15,
+        )
+        at.run()
+        assert not at.exception
+        at.text_input[0].set_value("forgot@example.com")
+        forgot_buttons = [b for b in at.button if b.label == "Forgot Password"]
+        assert forgot_buttons
+        forgot_buttons[0].click()
+        at.run()
+        assert not at.exception
+        mgr = at.session_state["auth_manager"]
+        mgr.reset_password.assert_called_once_with("forgot@example.com")
+
+    def test_signup_create_account_button_calls_create(self):
+        """Selecting Signup and clicking Create Account calls create_account."""
+        at = AppTest.from_string(
+            """
+from unittest.mock import MagicMock
+import streamlit as st
+from bili.streamlit_ui.ui.auth_ui import display_login_signup
+st.session_state.auth_manager = MagicMock()
+display_login_signup()
+""",
+            default_timeout=15,
+        )
+        at.run()
+        assert not at.exception
+        at.selectbox[0].set_value("Signup")
+        at.run()
+        assert not at.exception
+        at.text_input[0].set_value("new@example.com")
+        at.text_input[1].set_value("pw123")
+        # first_name / last_name inputs appear after the password input
+        at.text_input[2].set_value("Jane")
+        at.text_input[3].set_value("Roe")
+        create_buttons = [b for b in at.button if b.label == "Create Account"]
+        assert create_buttons
+        create_buttons[0].click()
+        at.run()
+        assert not at.exception
+        mgr = at.session_state["auth_manager"]
+        mgr.create_account.assert_called_once_with(
+            "new@example.com", "pw123", "Jane", "Roe", False
+        )
+
+
+# =========================================================================
+# check_auth
+# =========================================================================
+
+
+class TestCheckAuth:
+    """Tests for the check_auth function."""
+
+    def test_unauthenticated_renders_login_and_stops(self):
+        """When not authenticated check_auth renders login and stops the script."""
+        at = AppTest.from_string(
+            """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from bili.streamlit_ui.ui import auth_ui
+st.session_state.auth_manager = MagicMock()
+with patch.object(auth_ui, "is_authenticated", return_value=False):
+    auth_ui.check_auth()
+st.markdown("after_stop")
+""",
+            default_timeout=15,
+        )
+        at.run()
+        assert not at.exception
+        # check_auth renders the login/signup view (welcome heading present).
+        all_md = " ".join(m.value for m in at.markdown)
+        assert "Welcome to BiliCore" in all_md
+        # st.stop() halts execution, so the trailing markdown never renders.
+        assert "after_stop" not in all_md
+
+    def test_authenticated_shows_welcome_and_signout_button(self):
+        """When authenticated check_auth greets the user and shows Sign Out."""
+        at = AppTest.from_string(
+            """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from bili.streamlit_ui.ui import auth_ui
+st.session_state.auth_manager = MagicMock()
+st.session_state.user_info = {"email": "u@test.com"}
+with patch.object(auth_ui, "is_authenticated", return_value=True):
+    auth_ui.check_auth()
+""",
+            default_timeout=15,
+        )
+        at.run()
+        assert not at.exception
+        assert any("Welcome u@test.com" in s.value for s in at.success)
+        assert any(b.label == "Sign Out" for b in at.button)
+
+    def test_sign_out_button_calls_sign_out(self):
+        """Clicking Sign Out calls auth_manager.sign_out and shows confirmation."""
+        at = AppTest.from_string(
+            """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from bili.streamlit_ui.ui import auth_ui
+# setdefault keeps the SAME mock object across reruns so the assertion
+# observes the call made during the button-click rerun.
+st.session_state.setdefault("auth_manager", MagicMock())
+st.session_state.user_info = {"email": "u@test.com"}
+with patch.object(auth_ui, "is_authenticated", return_value=True):
+    auth_ui.check_auth()
+""",
+            default_timeout=15,
+        )
+        at.run()
+        assert not at.exception
+        signout = [b for b in at.button if b.label == "Sign Out"]
+        assert signout
+        signout[0].click()
+        at.run()
+        assert not at.exception
+        mgr = at.session_state["auth_manager"]
+        mgr.sign_out.assert_called_once()

--- a/bili/streamlit_ui/tests/test_chat_interface.py
+++ b/bili/streamlit_ui/tests/test_chat_interface.py
@@ -6,6 +6,7 @@ triggers ``st.set_page_config()`` and other runtime side-effects.
 
 # pylint: disable=import-outside-toplevel, protected-access
 
+import pytest
 from streamlit.testing.v1 import AppTest
 
 
@@ -942,3 +943,536 @@ ci.display_model_configuration()
     )
     at.run()
     assert not at.exception
+
+
+# ---------------------------------------------------------------------------
+# load_system_components
+# ---------------------------------------------------------------------------
+
+
+def test_load_system_components_basic_flow():
+    """load_system_components builds a chain with tools and stores it in state."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from bili.streamlit_ui.ui import chat_interface as ci
+
+st.session_state["model_type"] = "remote_aws_bedrock"
+st.session_state["model_id"] = "model.id"
+st.session_state["model_kwargs"] = {}
+st.session_state["supports_structured_output"] = False
+st.session_state["supports_tools"] = True
+st.session_state["selected_tools"] = ["aws_opensearch_retriever"]
+st.session_state["aws_opensearch_retriever_prompt"] = "Search the index"
+st.session_state["memory_strategy"] = "summarize"
+st.session_state["memory_limit_type"] = "message_count"
+st.session_state["memory_limit_value"] = 15
+st.session_state["memory_limit_trim_value"] = 15
+st.session_state["persona"] = "You are helpful"
+st.session_state["user_profile"] = {"name": "U"}
+st.session_state["thinking_budget"] = 0
+
+with patch.object(ci, "load_model", return_value="MODEL") as m_load:
+    with patch.object(ci, "initialize_tools", return_value=["TOOL"]) as m_tools:
+        with patch.object(ci, "build_agent_graph", return_value="AGENT") as m_graph:
+            ci.load_system_components(None)
+            st.session_state["_load_called"] = m_load.called
+            st.session_state["_tools_called"] = m_tools.called
+            st.session_state["_graph_called"] = m_graph.called
+st.markdown(f"chain:{st.session_state.get('conversation_chain')}")
+st.markdown(f"cfg:{st.session_state.get('model_config')}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "chain:AGENT" in all_md
+    assert "cfg:MODEL" in all_md
+    assert at.session_state["_load_called"] is True
+    assert at.session_state["_tools_called"] is True
+    assert at.session_state["_graph_called"] is True
+
+
+def test_load_system_components_structured_output_valid_schema():
+    """A valid JSON response schema is parsed into model_kwargs."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+import streamlit as st
+from bili.streamlit_ui.ui import chat_interface as ci
+
+st.session_state["model_type"] = "remote_google_vertex"
+st.session_state["model_id"] = "gemini"
+st.session_state["model_kwargs"] = {}
+st.session_state["supports_structured_output"] = True
+st.session_state["response_mime_type"] = "application/json"
+st.session_state["custom_response_schema"] = '{"type": "object"}'
+st.session_state["supports_tools"] = False
+st.session_state["thinking_budget"] = 0
+
+captured = {}
+def fake_load_model(**kwargs):
+    captured.update(kwargs)
+    return "MODEL"
+
+with patch.object(ci, "load_model", side_effect=fake_load_model):
+    with patch.object(ci, "initialize_tools", return_value=[]):
+        with patch.object(ci, "build_agent_graph", return_value="AGENT"):
+            ci.load_system_components(None)
+st.markdown(f"schema_obj:{captured.get('response_schema') == {'type': 'object'}}")
+st.markdown(f"mime:{captured.get('response_mime_type')}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "schema_obj:True" in all_md
+    assert "mime:application/json" in all_md
+
+
+def test_load_system_components_structured_output_invalid_schema():
+    """An invalid JSON response schema falls back to the default string schema."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+import streamlit as st
+from bili.streamlit_ui.ui import chat_interface as ci
+
+st.session_state["model_type"] = "remote_google_vertex"
+st.session_state["model_id"] = "gemini"
+st.session_state["model_kwargs"] = {}
+st.session_state["supports_structured_output"] = True
+st.session_state["response_mime_type"] = "application/json"
+st.session_state["custom_response_schema"] = "{not valid"
+st.session_state["supports_tools"] = False
+st.session_state["thinking_budget"] = 0
+
+captured = {}
+def fake_load_model(**kwargs):
+    captured.update(kwargs)
+    return "MODEL"
+
+with patch.object(ci, "load_model", side_effect=fake_load_model):
+    with patch.object(ci, "initialize_tools", return_value=[]):
+        with patch.object(ci, "build_agent_graph", return_value="AGENT"):
+            ci.load_system_components(None)
+st.markdown(f"fallback:{captured.get('response_schema') == {'type': 'string'}}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert "fallback:True" in " ".join(m.value for m in at.markdown)
+
+
+def test_load_system_components_structured_output_no_custom_schema():
+    """Structured output with no custom schema defaults to a string schema."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+import streamlit as st
+from bili.streamlit_ui.ui import chat_interface as ci
+
+st.session_state["model_type"] = "remote_google_vertex"
+st.session_state["model_id"] = "gemini"
+st.session_state["model_kwargs"] = {}
+st.session_state["supports_structured_output"] = True
+st.session_state["response_mime_type"] = "application/json"
+st.session_state.pop("custom_response_schema", None)
+st.session_state["supports_tools"] = False
+st.session_state["thinking_budget"] = 0
+
+captured = {}
+def fake_load_model(**kwargs):
+    captured.update(kwargs)
+    return "MODEL"
+
+with patch.object(ci, "load_model", side_effect=fake_load_model):
+    with patch.object(ci, "initialize_tools", return_value=[]):
+        with patch.object(ci, "build_agent_graph", return_value="AGENT"):
+            ci.load_system_components(None)
+st.markdown(f"default:{captured.get('response_schema') == {'type': 'string'}}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert "default:True" in " ".join(m.value for m in at.markdown)
+
+
+def test_load_system_components_text_plain_mime():
+    """A text/plain MIME type sets the plain-text response MIME on model_kwargs."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+import streamlit as st
+from bili.streamlit_ui.ui import chat_interface as ci
+
+st.session_state["model_type"] = "remote_google_vertex"
+st.session_state["model_id"] = "gemini"
+st.session_state["model_kwargs"] = {}
+st.session_state["supports_structured_output"] = True
+st.session_state["response_mime_type"] = "text/plain"
+st.session_state["supports_tools"] = False
+st.session_state["thinking_budget"] = 0
+
+captured = {}
+def fake_load_model(**kwargs):
+    captured.update(kwargs)
+    return "MODEL"
+
+with patch.object(ci, "load_model", side_effect=fake_load_model):
+    with patch.object(ci, "initialize_tools", return_value=[]):
+        with patch.object(ci, "build_agent_graph", return_value="AGENT"):
+            ci.load_system_components(None)
+st.markdown(f"mime:{captured.get('response_mime_type')}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert "mime:text/plain" in " ".join(m.value for m in at.markdown)
+
+
+def test_load_system_components_thinking_budget_branch():
+    """A positive thinking budget inserts the prepare_llm_config node and config."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+import streamlit as st
+from bili.streamlit_ui.ui import chat_interface as ci
+
+st.session_state["model_type"] = "remote_google_vertex"
+st.session_state["model_id"] = "gemini"
+st.session_state["model_kwargs"] = {}
+st.session_state["supports_structured_output"] = False
+st.session_state["supports_tools"] = False
+st.session_state["thinking_budget"] = 8192
+st.session_state["memory_strategy"] = "summarize"
+st.session_state["memory_limit_type"] = "message_count"
+st.session_state["memory_limit_value"] = 15
+st.session_state["memory_limit_trim_value"] = 15
+
+captured = {}
+def fake_build(**kwargs):
+    captured.update(kwargs)
+    return "AGENT"
+
+with patch.object(ci, "load_model", return_value="MODEL"):
+    with patch.object(ci, "initialize_tools", return_value=[]):
+        with patch.object(ci, "build_agent_graph", side_effect=fake_build):
+            ci.load_system_components(None)
+node_kwargs = captured.get("node_kwargs", {})
+st.markdown(f"thinking:{node_kwargs.get('thinking_config')}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert "thinking:{'budget': 8192}" in " ".join(m.value for m in at.markdown)
+
+
+def test_load_system_components_no_tools_branch():
+    """When tools are unsupported, the loader passes no active tools."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+import streamlit as st
+from bili.streamlit_ui.ui import chat_interface as ci
+
+st.session_state["model_type"] = "remote_aws_bedrock"
+st.session_state["model_id"] = "model.id"
+st.session_state["model_kwargs"] = {}
+st.session_state["supports_structured_output"] = False
+st.session_state["supports_tools"] = False
+st.session_state["thinking_budget"] = 0
+st.session_state["memory_strategy"] = "trim"
+st.session_state["memory_limit_type"] = "token_length"
+st.session_state["memory_limit_value"] = 10000
+st.session_state["memory_limit_trim_value"] = 8000
+
+captured = {}
+def fake_tools(**kwargs):
+    captured.update(kwargs)
+    return []
+
+with patch.object(ci, "load_model", return_value="MODEL"):
+    with patch.object(ci, "initialize_tools", side_effect=fake_tools):
+        with patch.object(ci, "build_agent_graph", return_value="AGENT"):
+            ci.load_system_components(None)
+st.markdown(f"active:{captured.get('active_tools')}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert "active:None" in " ".join(m.value for m in at.markdown)
+
+
+# ---------------------------------------------------------------------------
+# run_app_page -- Load Configuration button and form submission
+# ---------------------------------------------------------------------------
+
+
+def test_load_configuration_button_click_loads_components():
+    """Clicking Load Configuration invokes load_system_components."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+from bili.streamlit_ui.ui import chat_interface as ci
+with patch.object(ci, "is_authenticated", return_value=True):
+    with patch.object(ci, "display_configuration_panels"):
+        with patch.object(ci, "display_state_management_management"):
+            with patch.object(ci, "display_model_configuration"):
+                with patch.object(ci, "load_system_components"):
+                    # Patch rerun so the success message survives for the assertion.
+                    with patch.object(ci.st, "rerun"):
+                        ci.run_app_page("CHECKPOINTER")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    load_buttons = [b for b in at.button if b.label == "Load Configuration"]
+    assert load_buttons
+    load_buttons[0].click()
+    at.run()
+    assert not at.exception
+    assert any("loaded successfully" in s.value for s in at.success)
+
+
+def test_form_submit_non_streaming_processes_query():
+    """Submitting the conversation form without streaming calls process_query."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch, MagicMock
+import streamlit as st
+from bili.streamlit_ui.ui import chat_interface as ci
+st.session_state.setdefault("conversation_chain", MagicMock())
+st.session_state["is_processing_query"] = False
+st.session_state["streaming_enabled"] = False
+with patch.object(ci, "is_authenticated", return_value=True):
+    with patch.object(ci, "display_configuration_panels"):
+        with patch.object(ci, "display_state_management_management"):
+            with patch.object(ci, "display_model_configuration"):
+                with patch.object(ci, "display_state_management"):
+                    with patch.object(ci, "process_query") as mock_pq:
+                        with patch.object(ci.st, "rerun"):
+                            ci.run_app_page()
+                            st.session_state["_pq"] = mock_pq
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    submit = [b for b in at.button if b.label == "Submit"]
+    assert submit
+    submit[0].click()
+    at.run()
+    assert not at.exception
+    assert at.session_state["_pq"].called
+
+
+def test_form_submit_streaming_processes_query():
+    """Submitting the form with streaming enabled calls process_query_streaming."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch, MagicMock
+import streamlit as st
+from bili.streamlit_ui.ui import chat_interface as ci
+st.session_state.setdefault("conversation_chain", MagicMock())
+st.session_state["is_processing_query"] = False
+st.session_state["streaming_enabled"] = True
+with patch.object(ci, "is_authenticated", return_value=True):
+    with patch.object(ci, "display_configuration_panels"):
+        with patch.object(ci, "display_state_management_management"):
+            with patch.object(ci, "display_model_configuration"):
+                with patch.object(ci, "display_state_management"):
+                    with patch.object(
+                        ci, "process_query_streaming",
+                        return_value=iter(["a", "b"]),
+                    ) as mock_stream:
+                        with patch.object(ci.st, "write_stream"):
+                            ci.run_app_page()
+                            st.session_state["_stream"] = mock_stream
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    submit = [b for b in at.button if b.label == "Submit"]
+    assert submit
+    submit[0].click()
+    at.run()
+    assert not at.exception
+    assert at.session_state["_stream"].called
+
+
+# ---------------------------------------------------------------------------
+# display_state_management -- intermediate steps, clear/export/import buttons
+# ---------------------------------------------------------------------------
+
+
+def test_display_state_management_renders_intermediate_steps_area():
+    """Intermediate steps render when the last human message is not first."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from langchain_core.messages import HumanMessage, AIMessage, ToolMessage
+from bili.streamlit_ui.ui import chat_interface as ci
+
+mock_chain = MagicMock()
+mock_state = MagicMock()
+# Leading AI message keeps the last human index > 0 so the processing
+# message slice between the human and the final AI message is non-empty.
+mock_state.values = {
+    "messages": [
+        AIMessage(content="Welcome"),
+        HumanMessage(content="Use a tool"),
+        ToolMessage(content="tool output", tool_call_id="tc1"),
+        AIMessage(content="Done"),
+    ]
+}
+mock_chain.get_state.return_value = mock_state
+st.session_state["conversation_chain"] = mock_chain
+
+form = st.form(key="inter_form")
+with patch.object(ci, "get_state_config", return_value={"configurable": {"thread_id": "t"}}):
+    ci.display_state_management(form)
+form.form_submit_button("submit")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    # A processing-message text area is rendered for the intermediate tool call.
+    labels = [t.label for t in at.text_area]
+    assert any("Processing Message" in (l or "") for l in labels)
+
+
+def test_clear_conversation_state_button_updates_state():
+    """Clicking Clear Conversation State updates the chain state and flags it."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from langchain_core.messages import HumanMessage, AIMessage
+from bili.streamlit_ui.ui import chat_interface as ci
+
+mock_chain = MagicMock()
+mock_state = MagicMock()
+mock_state.values = {"messages": [HumanMessage(content="Hi"), AIMessage(content="Hello")]}
+mock_chain.get_state.return_value = mock_state
+st.session_state.setdefault("conversation_chain", mock_chain)
+
+form = st.form(key="clear_form")
+with patch.object(ci, "get_state_config", return_value={"configurable": {"thread_id": "t"}}):
+    with patch.object(ci, "clear_state", return_value={"messages": []}):
+        with patch.object(ci.st, "rerun"):
+            ci.display_state_management(form)
+form.form_submit_button("submit")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    clear_buttons = [b for b in at.button if b.label == "Clear Conversation State"]
+    assert clear_buttons
+    clear_buttons[0].click()
+    at.run()
+    assert not at.exception
+    chain = at.session_state["conversation_chain"]
+    chain.update_state.assert_called()
+    # The cleared confirmation renders on the click rerun (the flag is then
+    # reset to False within the same run after the success is shown).
+    assert any("cleared" in s.value for s in at.success)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "BUG: Export handler calls JsonPlusSerializer().dumps() "
+        "(chat_interface.py line 391), but the installed langgraph "
+        "JsonPlusSerializer exposes dumps_typed/loads_typed, not "
+        "dumps/loads. Clicking Export raises AttributeError and crashes "
+        "the panel."
+    ),
+)
+def test_export_conversation_state_button_renders_download():
+    """Clicking Export Conversation State should render a download button."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from langchain_core.messages import HumanMessage, AIMessage
+from bili.streamlit_ui.ui import chat_interface as ci
+
+mock_chain = MagicMock()
+mock_state = MagicMock()
+mock_state.values = {"messages": [HumanMessage(content="Hi"), AIMessage(content="Yo")]}
+mock_chain.get_state.return_value = mock_state
+st.session_state.setdefault("conversation_chain", mock_chain)
+
+form = st.form(key="export_form")
+with patch.object(ci, "get_state_config", return_value={"configurable": {"thread_id": "t"}}):
+    ci.display_state_management(form)
+form.form_submit_button("submit")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    export_buttons = [b for b in at.button if "Export Conversation State" in b.label]
+    assert export_buttons
+    export_buttons[0].click()
+    at.run()
+    assert not at.exception
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "BUG: Import handler calls JsonPlusSerializer().loads() "
+        "(chat_interface.py line 405), but the installed langgraph "
+        "JsonPlusSerializer exposes dumps_typed/loads_typed, not "
+        "dumps/loads. Uploading a state file raises AttributeError and "
+        "crashes the panel."
+    ),
+)
+def test_import_conversation_state_applies_uploaded_state():
+    """Uploading a conversation state should import messages and summary."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from langchain_core.messages import HumanMessage, AIMessage
+from bili.streamlit_ui.ui import chat_interface as ci
+
+mock_chain = MagicMock()
+mock_state = MagicMock()
+mock_state.values = {"messages": [HumanMessage(content="Hi"), AIMessage(content="Yo")]}
+mock_chain.get_state.return_value = mock_state
+st.session_state["conversation_chain"] = mock_chain
+st.session_state.pop("state_imported", None)
+
+fake_upload = MagicMock()
+fake_upload.read.return_value = b"serialized"
+
+with patch.object(ci, "get_state_config", return_value={"configurable": {"thread_id": "t"}}):
+    with patch.object(ci, "clear_state", return_value={"messages": []}):
+        with patch.object(ci.st, "file_uploader", return_value=fake_upload):
+            with patch.object(ci.st, "rerun"):
+                form = st.form(key="import_form")
+                ci.display_state_management(form)
+                form.form_submit_button("submit")
+st.markdown(f"imported:{st.session_state.get('state_imported')}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert "imported:True" in " ".join(m.value for m in at.markdown)

--- a/bili/streamlit_ui/tests/test_chat_interface.py
+++ b/bili/streamlit_ui/tests/test_chat_interface.py
@@ -6,7 +6,6 @@ triggers ``st.set_page_config()`` and other runtime side-effects.
 
 # pylint: disable=import-outside-toplevel, protected-access
 
-import pytest
 from streamlit.testing.v1 import AppTest
 
 
@@ -1392,16 +1391,6 @@ form.form_submit_button("submit")
     assert any("cleared" in s.value for s in at.success)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "BUG: Export handler calls JsonPlusSerializer().dumps() "
-        "(chat_interface.py line 391), but the installed langgraph "
-        "JsonPlusSerializer exposes dumps_typed/loads_typed, not "
-        "dumps/loads. Clicking Export raises AttributeError and crashes "
-        "the panel."
-    ),
-)
 def test_export_conversation_state_button_renders_download():
     """Clicking Export Conversation State should render a download button."""
     at = AppTest.from_string(
@@ -1433,23 +1422,16 @@ form.form_submit_button("submit")
     assert not at.exception
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "BUG: Import handler calls JsonPlusSerializer().loads() "
-        "(chat_interface.py line 405), but the installed langgraph "
-        "JsonPlusSerializer exposes dumps_typed/loads_typed, not "
-        "dumps/loads. Uploading a state file raises AttributeError and "
-        "crashes the panel."
-    ),
-)
 def test_import_conversation_state_applies_uploaded_state():
     """Uploading a conversation state should import messages and summary."""
     at = AppTest.from_string(
         """
+import base64
+import json
 from unittest.mock import MagicMock, patch
 import streamlit as st
 from langchain_core.messages import HumanMessage, AIMessage
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from bili.streamlit_ui.ui import chat_interface as ci
 
 mock_chain = MagicMock()
@@ -1459,8 +1441,20 @@ mock_chain.get_state.return_value = mock_state
 st.session_state["conversation_chain"] = mock_chain
 st.session_state.pop("state_imported", None)
 
+# Build a valid export envelope (the inverse of the Export handler).
+serde_type, serde_bytes = JsonPlusSerializer().dumps_typed(
+    {"messages": [HumanMessage(content="Imported")], "summary": "s"}
+)
+envelope = json.dumps(
+    {
+        "serde": "jsonplus_typed",
+        "type": serde_type,
+        "data": base64.b64encode(serde_bytes).decode("ascii"),
+    }
+).encode("utf-8")
+
 fake_upload = MagicMock()
-fake_upload.read.return_value = b"serialized"
+fake_upload.read.return_value = envelope
 
 with patch.object(ci, "get_state_config", return_value={"configurable": {"thread_id": "t"}}):
     with patch.object(ci, "clear_state", return_value={"messages": []}):

--- a/bili/streamlit_ui/tests/test_chat_interface.py
+++ b/bili/streamlit_ui/tests/test_chat_interface.py
@@ -23,7 +23,7 @@ with patch.object(ci, "is_authenticated", return_value=False):
         st.session_state.auth_manager = mock_auth
         ci.run_app_page()
 """,
-        default_timeout=10,
+        default_timeout=30,
     )
     at.run()
     assert not at.exception
@@ -573,7 +573,7 @@ with patch.object(ci, "get_state_config", return_value={"configurable": {"thread
     ci.display_state_management(form)
 form.form_submit_button("submit")
 """,
-        default_timeout=10,
+        default_timeout=30,
     )
     at.run()
     assert not at.exception

--- a/bili/streamlit_ui/tests/test_chat_interface.py
+++ b/bili/streamlit_ui/tests/test_chat_interface.py
@@ -1506,3 +1506,49 @@ st.markdown(f"imported:{st.session_state.get('state_imported')}")
     # An error is surfaced and the import is not marked complete.
     assert any("Could not import conversation state" in e.value for e in at.error)
     assert "imported:None" in " ".join(m.value for m in at.markdown)
+
+
+def test_import_conversation_state_corrupt_payload_shows_error():
+    """A valid envelope whose inner bytes are corrupt fails gracefully."""
+    at = AppTest.from_string(
+        """
+import base64
+import json
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from bili.streamlit_ui.ui import chat_interface as ci
+
+mock_chain = MagicMock()
+mock_state = MagicMock()
+mock_state.values = {"messages": []}
+mock_chain.get_state.return_value = mock_state
+st.session_state["conversation_chain"] = mock_chain
+st.session_state.pop("state_imported", None)
+st.session_state.pop("state_import_failed", None)
+
+# A well-formed envelope whose data base64-decodes to random, non-msgpack
+# bytes. json.loads/base64 succeed, but loads_typed raises a msgpack error,
+# which the broadened except must catch.
+envelope = json.dumps({
+    "serde": "jsonplus_typed",
+    "type": "msgpack",
+    "data": base64.b64encode(b"\\xde\\xad\\xbe\\xef not msgpack").decode("ascii"),
+}).encode("utf-8")
+fake_upload = MagicMock()
+fake_upload.getvalue.return_value = envelope
+
+with patch.object(ci, "get_state_config", return_value={"configurable": {"thread_id": "t"}}):
+    with patch.object(ci.st, "file_uploader", return_value=fake_upload):
+        with patch.object(ci.st, "rerun"):
+            form = st.form(key="import_form")
+            ci.display_state_management(form)
+            form.form_submit_button("submit")
+st.markdown(f"failed:{st.session_state.get('state_import_failed')}")
+""",
+        default_timeout=30,
+    )
+    at.run()
+    assert not at.exception
+    assert any("Could not import conversation state" in e.value for e in at.error)
+    # The failure is remembered so it is not re-parsed every rerun.
+    assert "failed:True" in " ".join(m.value for m in at.markdown)

--- a/bili/streamlit_ui/tests/test_chat_interface.py
+++ b/bili/streamlit_ui/tests/test_chat_interface.py
@@ -1454,7 +1454,7 @@ envelope = json.dumps(
 ).encode("utf-8")
 
 fake_upload = MagicMock()
-fake_upload.read.return_value = envelope
+fake_upload.getvalue.return_value = envelope
 
 with patch.object(ci, "get_state_config", return_value={"configurable": {"thread_id": "t"}}):
     with patch.object(ci, "clear_state", return_value={"messages": []}):
@@ -1470,3 +1470,39 @@ st.markdown(f"imported:{st.session_state.get('state_imported')}")
     at.run()
     assert not at.exception
     assert "imported:True" in " ".join(m.value for m in at.markdown)
+
+
+def test_import_conversation_state_malformed_shows_error():
+    """A malformed upload surfaces st.error and does not mark state imported."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import MagicMock, patch
+import streamlit as st
+from bili.streamlit_ui.ui import chat_interface as ci
+
+mock_chain = MagicMock()
+mock_state = MagicMock()
+mock_state.values = {"messages": []}
+mock_chain.get_state.return_value = mock_state
+st.session_state["conversation_chain"] = mock_chain
+st.session_state.pop("state_imported", None)
+
+# Not valid JSON -> deserialization fails gracefully.
+fake_upload = MagicMock()
+fake_upload.getvalue.return_value = b"not valid json"
+
+with patch.object(ci, "get_state_config", return_value={"configurable": {"thread_id": "t"}}):
+    with patch.object(ci.st, "file_uploader", return_value=fake_upload):
+        with patch.object(ci.st, "rerun"):
+            form = st.form(key="import_form")
+            ci.display_state_management(form)
+            form.form_submit_button("submit")
+st.markdown(f"imported:{st.session_state.get('state_imported')}")
+""",
+        default_timeout=30,
+    )
+    at.run()
+    assert not at.exception
+    # An error is surfaced and the import is not marked complete.
+    assert any("Could not import conversation state" in e.value for e in at.error)
+    assert "imported:None" in " ".join(m.value for m in at.markdown)

--- a/bili/streamlit_ui/tests/test_configuration_panels.py
+++ b/bili/streamlit_ui/tests/test_configuration_panels.py
@@ -1689,6 +1689,9 @@ cp_mod.display_configuration_panels()
     at.run()
     assert not at.exception
     assert "array" in at.session_state["custom_response_schema"]
+    # The textarea widget key is also updated so the box reflects the preset
+    # (otherwise the switch is invisible and the next keystroke undoes it).
+    assert "array" in at.session_state["custom_response_schema_input"]
 
 
 def test_schema_textarea_edit_switches_to_custom():

--- a/bili/streamlit_ui/tests/test_configuration_panels.py
+++ b/bili/streamlit_ui/tests/test_configuration_panels.py
@@ -11,6 +11,7 @@ scripts which execute within a proper Streamlit runtime context.
 
 # pylint: disable=import-outside-toplevel, protected-access
 
+import pytest
 from streamlit.testing.v1 import AppTest
 
 # ------------------------------------------------------------------
@@ -1165,3 +1166,570 @@ def test_llm_model_entries_have_model_name():
     for key, info in LLM_MODELS.items():
         for model in info["models"]:
             assert "model_name" in model, f"Provider '{key}' model missing model_name"
+
+
+# ------------------------------------------------------------------
+# Model-capability dependent branches
+# ------------------------------------------------------------------
+
+
+def test_gemini_structured_output_block_renders():
+    """Selecting a Gemini model renders the structured-output configuration."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "remote_google_vertex"
+st.session_state["model_name"] = "Gemini 2.5 Pro"
+cp_mod.display_configuration_panels()
+st.markdown(f"struct:{st.session_state.get('supports_structured_output')}")
+st.markdown(f"mime:{'response_mime_type' in st.session_state}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "struct:True" in all_md
+    assert "mime:True" in all_md
+
+
+def test_gemini_json_mime_renders_schema_editor():
+    """Choosing the JSON MIME type renders the custom schema editor and validation."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "remote_google_vertex"
+st.session_state["model_name"] = "Gemini 2.5 Pro"
+st.session_state["response_mime_type"] = "application/json"
+st.session_state["custom_response_schema"] = '{"type": "string"}'
+st.session_state["schema_preset"] = "Custom"
+cp_mod.display_configuration_panels()
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    # A valid JSON schema shows a success message.
+    assert any("Valid JSON schema" in s.value for s in at.success)
+
+
+def test_gemini_json_invalid_schema_shows_error():
+    """An invalid custom JSON schema renders an error message."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "remote_google_vertex"
+st.session_state["model_name"] = "Gemini 2.5 Pro"
+st.session_state["response_mime_type"] = "application/json"
+st.session_state["custom_response_schema"] = "{not valid json"
+st.session_state["schema_preset"] = "Custom"
+cp_mod.display_configuration_panels()
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert any("Invalid JSON" in e.value for e in at.error)
+
+
+def test_gemini_text_mime_clears_schema_state():
+    """Switching back to text MIME type clears the custom schema session keys."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "remote_google_vertex"
+st.session_state["model_name"] = "Gemini 2.5 Pro"
+st.session_state["response_mime_type"] = "text/plain"
+st.session_state["custom_response_schema"] = '{"type": "string"}'
+st.session_state["schema_preset"] = "Custom"
+cp_mod.display_configuration_panels()
+st.markdown(f"schema_gone:{'custom_response_schema' not in st.session_state}")
+st.markdown(f"preset_gone:{'schema_preset' not in st.session_state}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "schema_gone:True" in all_md
+    assert "preset_gone:True" in all_md
+
+
+def test_gemini_thinking_budget_block_renders():
+    """A Gemini model renders the thinking-budget control and initializes it."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "remote_google_vertex"
+st.session_state["model_name"] = "Gemini 2.5 Pro"
+cp_mod.display_configuration_panels()
+st.markdown(f"thinking:{st.session_state.get('thinking_budget') is not None}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert "thinking:True" in " ".join(m.value for m in at.markdown)
+
+
+def test_openai_max_retries_block_renders():
+    """An OpenAI model renders the max-retries control and initializes it."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "remote_openai"
+st.session_state["model_name"] = "OpenAI GPT-4o Omni"
+cp_mod.display_configuration_panels()
+st.markdown(f"retries:{st.session_state.get('max_retries') is not None}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert "retries:True" in " ".join(m.value for m in at.markdown)
+
+
+def test_model_lacking_top_k_sets_none():
+    """A model without top_k support leaves top_k as None."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "remote_aws_bedrock"
+st.session_state["model_name"] = "AI21 Jamba 1.5 Large"
+cp_mod.display_configuration_panels()
+st.markdown(f"top_k:{st.session_state.get('top_k')}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert "top_k:None" in " ".join(m.value for m in at.markdown)
+
+
+def test_model_lacking_temperature_sets_none():
+    """A model without temperature support leaves temperature as None."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "remote_azure_openai"
+st.session_state["model_name"] = "Azure OpenAI o1-mini"
+cp_mod.display_configuration_panels()
+st.markdown(f"temp:{st.session_state.get('temperature')}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert "temp:None" in " ".join(m.value for m in at.markdown)
+
+
+def test_model_lacking_seed_sets_none():
+    """A model without seed support leaves seed_value as None."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "remote_aws_bedrock"
+st.session_state["model_name"] = "DeepSeek-R1"
+cp_mod.display_configuration_panels()
+st.markdown(f"seed:{st.session_state.get('seed_value')}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert "seed:None" in " ".join(m.value for m in at.markdown)
+
+
+def test_model_lacking_max_output_tokens_sets_none():
+    """A model without max-output-token support leaves max_output_tokens as None."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "remote_azure_openai"
+st.session_state["model_name"] = "Azure OpenAI o3"
+cp_mod.display_configuration_panels()
+st.markdown(f"max_out:{st.session_state.get('max_output_tokens')}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert "max_out:None" in " ".join(m.value for m in at.markdown)
+
+
+def test_unsupported_tools_model_shows_warning():
+    """A model that does not support tools renders a warning and clears the flag."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "remote_aws_bedrock"
+st.session_state["model_name"] = "Amazon Titan Text G1 - Premier"
+cp_mod.display_configuration_panels()
+st.markdown(f"supports:{st.session_state.get('supports_tools')}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert any("does not support tools" in w.value for w in at.warning)
+    assert "supports:False" in " ".join(m.value for m in at.markdown)
+
+
+def test_custom_model_path_renders_text_input():
+    """A model with custom_model_path renders the custom model path input."""
+    at = AppTest.from_string(
+        """
+import os
+os.environ["ENV"] = "development"
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "local_llamacpp"
+st.session_state["model_name"] = "LlamaCpp Local (In Memory) Model"
+cp_mod.display_configuration_panels()
+st.markdown(f"has_id:{'model_id' in st.session_state}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert "has_id:True" in " ".join(m.value for m in at.markdown)
+
+
+# ------------------------------------------------------------------
+# Enable / Disable all tools button clicks
+# ------------------------------------------------------------------
+
+
+def test_enable_all_tools_button_click_enables_tools():
+    """Clicking Enable All Tools enables non-local tools in session state."""
+    at = AppTest.from_string(
+        """
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+cp_mod.display_configuration_panels()
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    enable_buttons = [b for b in at.button if "Enable All" in b.label]
+    assert enable_buttons
+    enable_buttons[0].click()
+    at.run()
+    assert not at.exception
+
+
+def test_disable_all_tools_button_click_disables_tools():
+    """Clicking Disable All Tools disables non-local tools in session state."""
+    at = AppTest.from_string(
+        """
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+cp_mod.display_configuration_panels()
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    disable_buttons = [b for b in at.button if "Disable All" in b.label]
+    assert disable_buttons
+    disable_buttons[0].click()
+    at.run()
+    assert not at.exception
+
+
+# ------------------------------------------------------------------
+# Import configuration flow
+# ------------------------------------------------------------------
+
+
+def test_import_configuration_applies_uploaded_values():
+    """Uploading a JSON config writes its keys into session state."""
+    at = AppTest.from_string(
+        """
+import io, json
+from unittest.mock import patch
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+
+class _Upload(io.BytesIO):
+    pass
+
+upload = _Upload(json.dumps({"persona": "imported-persona"}).encode("utf-8"))
+st.session_state.pop("config_imported", None)
+# Patch rerun to a no-op so the import branch (which calls st.rerun) does
+# not trigger an AppTest re-run loop; we assert directly on the state it set.
+with patch.object(cp_mod.st, "file_uploader", return_value=upload):
+    with patch.object(cp_mod.st, "rerun"):
+        cp_mod.display_configuration_panels()
+st.markdown(f"persona:{st.session_state.get('persona')}")
+st.markdown(f"flag:{st.session_state.get('config_imported')}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "persona:imported-persona" in all_md
+    assert "flag:True" in all_md
+
+
+def test_import_configuration_already_imported_shows_success():
+    """When config was already imported the success message is shown."""
+    at = AppTest.from_string(
+        """
+import io, json
+from unittest.mock import patch
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+
+class _Upload(io.BytesIO):
+    pass
+
+upload = _Upload(json.dumps({"persona": "x"}).encode("utf-8"))
+st.session_state["config_imported"] = True
+with patch.object(cp_mod.st, "file_uploader", return_value=upload):
+    cp_mod.display_configuration_panels()
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert any("imported successfully" in s.value for s in at.success)
+
+
+# ------------------------------------------------------------------
+# reset_model_name on-change callback
+# ------------------------------------------------------------------
+
+
+def test_model_type_change_resets_model_name():
+    """Changing the LLM type selectbox clears the previously chosen model name."""
+    at = AppTest.from_string(
+        """
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+cp_mod.display_configuration_panels()
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    type_selectbox = at.selectbox[0]
+    options = type_selectbox.options
+    # Choose a different LLM type option to fire the reset_model_name callback.
+    different = next(o for o in options if o != type_selectbox.value)
+    type_selectbox.set_value(different)
+    at.run()
+    assert not at.exception
+
+
+# ------------------------------------------------------------------
+# Boolean tool parameter widget
+# ------------------------------------------------------------------
+
+
+def test_bool_tool_param_renders_checkbox():
+    """A tool with a boolean parameter renders a checkbox for that parameter."""
+    at = AppTest.from_string(
+        """
+from unittest.mock import patch
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+
+bool_tools = {
+    "bool_param_tool": {
+        "enabled": True,
+        "description": "A tool with a boolean parameter",
+        "default_prompt": "Use the bool tool",
+        "params": {
+            "flag": {
+                "type": "bool",
+                "default": True,
+                "description": "A boolean flag",
+            }
+        },
+    }
+}
+with patch.object(cp_mod, "TOOLS", bool_tools):
+    cp_mod.display_configuration_panels()
+st.markdown(f"flag_key:{'bool_param_tool_flag' in st.session_state}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    assert "flag_key:True" in " ".join(m.value for m in at.markdown)
+
+
+# ------------------------------------------------------------------
+# Schema preset reset/clear buttons
+# ------------------------------------------------------------------
+
+
+def test_reset_schema_button_present_for_json():
+    """The schema reset and clear buttons render in JSON MIME mode."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "remote_google_vertex"
+st.session_state["model_name"] = "Gemini 2.5 Pro"
+st.session_state["response_mime_type"] = "application/json"
+cp_mod.display_configuration_panels()
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    labels = [b.label for b in at.button]
+    assert any("Reset to Default Schema" in l for l in labels)
+    assert any("Clear Schema" in l for l in labels)
+
+
+# ------------------------------------------------------------------
+# Temperature clamping and schema callback / button branches
+# ------------------------------------------------------------------
+
+
+def test_temperature_above_max_is_clamped():
+    """A stored temperature above the model maximum is clamped down."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+# Nova Pro supports temperature; seed an out-of-range value to force clamping.
+st.session_state["model_type"] = "remote_aws_bedrock"
+st.session_state["model_name"] = "Amazon Nova Pro"
+st.session_state["temperature"] = 9999.0
+cp_mod.display_configuration_panels()
+st.markdown(f"temp:{st.session_state.get('temperature')}")
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    # The clamped temperature must be a finite value well below the seeded 9999.
+    all_md = " ".join(m.value for m in at.markdown)
+    assert "temp:9999" not in all_md
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "BUG: Reset to Default Schema handler assigns st.session_state["
+        "'schema_preset'] (configuration_panels.py line 571), but schema_preset "
+        "is a widget key, so Streamlit raises StreamlitAPIException on the "
+        "click rerun. The button crashes the panel instead of resetting it."
+    ),
+)
+def test_reset_schema_button_click_sets_object_preset():
+    """Clicking Reset to Default Schema should set the object-response preset."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "remote_google_vertex"
+st.session_state["model_name"] = "Gemini 2.5 Pro"
+st.session_state["response_mime_type"] = "application/json"
+cp_mod.display_configuration_panels()
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    reset_buttons = [b for b in at.button if "Reset to Default Schema" in b.label]
+    assert reset_buttons
+    reset_buttons[0].click()
+    at.run()
+    assert not at.exception
+    assert at.session_state["schema_preset"] == "Object Response"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "BUG: Clear Schema handler assigns st.session_state['schema_preset'] "
+        "(configuration_panels.py line 576), but schema_preset is a widget key, "
+        "so Streamlit raises StreamlitAPIException on the click rerun. The "
+        "button crashes the panel instead of clearing the schema."
+    ),
+)
+def test_clear_schema_button_click_empties_schema():
+    """Clicking Clear Schema should empty the custom schema and reset the preset."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "remote_google_vertex"
+st.session_state["model_name"] = "Gemini 2.5 Pro"
+st.session_state["response_mime_type"] = "application/json"
+cp_mod.display_configuration_panels()
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    clear_buttons = [b for b in at.button if "Clear Schema" in b.label]
+    assert clear_buttons
+    clear_buttons[0].click()
+    at.run()
+    assert not at.exception
+    assert at.session_state["custom_response_schema"] == "{}"
+    assert at.session_state["schema_preset"] == "Custom"
+
+
+def test_schema_preset_change_updates_schema():
+    """Selecting a non-custom schema preset updates the custom schema text."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "remote_google_vertex"
+st.session_state["model_name"] = "Gemini 2.5 Pro"
+st.session_state["response_mime_type"] = "application/json"
+cp_mod.display_configuration_panels()
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    preset_boxes = [s for s in at.selectbox if s.label == "Schema Preset"]
+    assert preset_boxes
+    preset_boxes[0].set_value("Array Response")
+    at.run()
+    assert not at.exception
+    assert "array" in at.session_state["custom_response_schema"]
+
+
+def test_schema_textarea_edit_switches_to_custom():
+    """Editing the schema text area switches the preset back to Custom."""
+    at = AppTest.from_string(
+        """
+import streamlit as st
+from bili.streamlit_ui.ui import configuration_panels as cp_mod
+st.session_state["model_type"] = "remote_google_vertex"
+st.session_state["model_name"] = "Gemini 2.5 Pro"
+st.session_state["response_mime_type"] = "application/json"
+st.session_state["schema_preset"] = "Object Response"
+cp_mod.display_configuration_panels()
+""",
+        default_timeout=20,
+    )
+    at.run()
+    assert not at.exception
+    schema_areas = [t for t in at.text_area if "JSON Schema" in (t.label or "")]
+    assert schema_areas
+    schema_areas[0].set_value('{"type": "number"}')
+    at.run()
+    assert not at.exception
+    # The on_change callback syncs the edited text into custom_response_schema.
+    assert at.session_state["custom_response_schema"] == '{"type": "number"}'

--- a/bili/streamlit_ui/tests/test_configuration_panels.py
+++ b/bili/streamlit_ui/tests/test_configuration_panels.py
@@ -11,7 +11,6 @@ scripts which execute within a proper Streamlit runtime context.
 
 # pylint: disable=import-outside-toplevel, protected-access
 
-import pytest
 from streamlit.testing.v1 import AppTest
 
 # ------------------------------------------------------------------
@@ -1622,15 +1621,6 @@ st.markdown(f"temp:{st.session_state.get('temperature')}")
     assert "temp:9999" not in all_md
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "BUG: Reset to Default Schema handler assigns st.session_state["
-        "'schema_preset'] (configuration_panels.py line 571), but schema_preset "
-        "is a widget key, so Streamlit raises StreamlitAPIException on the "
-        "click rerun. The button crashes the panel instead of resetting it."
-    ),
-)
 def test_reset_schema_button_click_sets_object_preset():
     """Clicking Reset to Default Schema should set the object-response preset."""
     at = AppTest.from_string(
@@ -1654,15 +1644,6 @@ cp_mod.display_configuration_panels()
     assert at.session_state["schema_preset"] == "Object Response"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "BUG: Clear Schema handler assigns st.session_state['schema_preset'] "
-        "(configuration_panels.py line 576), but schema_preset is a widget key, "
-        "so Streamlit raises StreamlitAPIException on the click rerun. The "
-        "button crashes the panel instead of clearing the schema."
-    ),
-)
 def test_clear_schema_button_click_empties_schema():
     """Clicking Clear Schema should empty the custom schema and reset the preset."""
     at = AppTest.from_string(

--- a/bili/streamlit_ui/tests/test_state_management.py
+++ b/bili/streamlit_ui/tests/test_state_management.py
@@ -1,0 +1,46 @@
+"""Tests for streamlit_ui.utils.state_management form-state helpers."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from bili.streamlit_ui.utils import state_management
+
+
+class TestFormProcessingState:
+    """disable_form and enable_form toggle the processing flag."""
+
+    def test_disable_form_sets_processing_true(self):
+        """disable_form marks the form as processing a query."""
+        fake_st = MagicMock()
+        fake_st.session_state = SimpleNamespace()
+        with patch.object(state_management, "st", fake_st):
+            state_management.disable_form()
+        assert fake_st.session_state.is_processing_query is True
+
+    def test_enable_form_sets_processing_false(self):
+        """enable_form clears the processing flag."""
+        fake_st = MagicMock()
+        fake_st.session_state = SimpleNamespace()
+        with patch.object(state_management, "st", fake_st):
+            state_management.enable_form()
+        assert fake_st.session_state.is_processing_query is False
+
+
+class TestGetStateConfig:
+    """get_state_config derives the thread_id from the user's email."""
+
+    def test_config_uses_email_as_thread_id(self):
+        """The configurable thread_id is the session user's email."""
+        fake_st = MagicMock()
+        fake_st.session_state = {"user_info": {"email": "u@example.com"}}
+        with patch.object(state_management, "st", fake_st):
+            config = state_management.get_state_config()
+        assert config == {"configurable": {"thread_id": "u@example.com"}}
+
+    def test_config_handles_missing_user_info(self):
+        """A missing user_info yields a None-derived thread_id, not a crash."""
+        fake_st = MagicMock()
+        fake_st.session_state = {}
+        with patch.object(state_management, "st", fake_st):
+            config = state_management.get_state_config()
+        assert config == {"configurable": {"thread_id": "None"}}

--- a/bili/streamlit_ui/tests/test_streamlit_app.py
+++ b/bili/streamlit_ui/tests/test_streamlit_app.py
@@ -2,12 +2,21 @@
 
 Validates that main() can be called with mocked Streamlit and
 that the page navigation dict contains IRIS, AETHER, and AEGIS
-sections with the expected pages.
+sections with the expected pages. Also exercises the individual
+page-render callbacks that st.navigation wires up.
 """
 
 from unittest.mock import MagicMock, patch
 
-from bili.streamlit_app import main
+from bili.streamlit_app import (
+    _run_aether_page,
+    _run_attack_page,
+    _run_attack_results_page,
+    _run_baseline_runner_page,
+    _run_bilicore_page,
+    _run_results_page,
+    main,
+)
 from bili.streamlit_ui.tests.conftest import FakeSessionState
 
 _MODULE = "bili.streamlit_app"
@@ -273,3 +282,106 @@ class TestStreamlitAppMain:
             if c.kwargs.get("unsafe_allow_html")
         ]
         assert len(html_calls) >= 1
+
+
+class TestPageRenderCallbacks:
+    """Tests for the individual page-render callbacks wired into navigation."""
+
+    @patch(f"{_MODULE}.run_app_page")
+    @patch(f"{_MODULE}.get_checkpointer")
+    @patch(f"{_MODULE}.Image")
+    @patch(f"{_MODULE}.st")
+    def test_run_bilicore_page_renders_and_runs_app(
+        self,
+        mock_st,
+        mock_image,
+        mock_get_checkpointer,
+        mock_run_app_page,
+    ):
+        """The IRIS page renders the header and delegates to run_app_page."""
+        mock_image.open.return_value = MagicMock()
+        mock_get_checkpointer.return_value = "CHECKPOINTER"
+
+        _run_bilicore_page()
+
+        # The checkpointer is fetched and handed to the IRIS chat page.
+        mock_get_checkpointer.assert_called_once()
+        mock_run_app_page.assert_called_once_with("CHECKPOINTER")
+        # The IRIS heading is rendered.
+        markdown_calls = " ".join(str(c) for c in mock_st.markdown.call_args_list)
+        assert "IRIS" in markdown_calls
+
+    @patch(f"{_MODULE}.run_app_page")
+    @patch(f"{_MODULE}.get_checkpointer")
+    @patch(f"{_MODULE}.Image")
+    @patch(f"{_MODULE}.st")
+    def test_run_bilicore_page_shows_logo_when_present(
+        self,
+        mock_st,
+        mock_image,
+        _mock_get_checkpointer,
+        _mock_run_app_page,
+    ):
+        """The IRIS page shows the sidebar logo when the logo file exists."""
+        mock_image.open.return_value = MagicMock()
+
+        with patch(f"{_MODULE}.LOGO_PATH") as mock_logo_path:
+            mock_logo_path.exists.return_value = True
+            mock_logo_path.as_posix.return_value = "/tmp/logo.png"
+            _run_bilicore_page()
+
+        # st.image is called for the sidebar logo and the header logo.
+        assert mock_st.image.call_count >= 1
+
+    @patch(f"{_MODULE}.run_app_page")
+    @patch(f"{_MODULE}.get_checkpointer")
+    @patch(f"{_MODULE}.Image")
+    @patch(f"{_MODULE}.st")
+    def test_run_bilicore_page_skips_logo_when_absent(
+        self,
+        mock_st,
+        mock_image,
+        _mock_get_checkpointer,
+        _mock_run_app_page,
+    ):
+        """The IRIS page skips the sidebar logo when the logo file is absent."""
+        mock_image.open.return_value = MagicMock()
+
+        with patch(f"{_MODULE}.LOGO_PATH") as mock_logo_path:
+            mock_logo_path.exists.return_value = False
+            mock_logo_path.as_posix.return_value = "/tmp/logo.png"
+            _run_bilicore_page()
+
+        # The header logo (Image.open + st.image) still renders even with no
+        # sidebar logo, so the page does not crash.
+        assert mock_st.markdown.called
+
+    @patch(f"{_MODULE}.render_aether_page")
+    def test_run_aether_page_delegates(self, mock_render):
+        """The AETHER page delegates to render_aether_page."""
+        _run_aether_page()
+        mock_render.assert_called_once_with()
+
+    @patch(f"{_MODULE}.render_baseline_runner_page")
+    def test_run_baseline_runner_page_delegates(self, mock_render):
+        """The baseline runner page delegates to render_baseline_runner_page."""
+        _run_baseline_runner_page()
+        mock_render.assert_called_once_with()
+
+    @patch(f"{_MODULE}.render_results_page")
+    def test_run_results_page_delegates(self, mock_render):
+        """The baseline results page delegates to render_results_page."""
+        _run_results_page()
+        mock_render.assert_called_once_with()
+
+    @patch(f"{_MODULE}.render_attack_results_page")
+    def test_run_attack_results_page_delegates(self, mock_render):
+        """The attack results page delegates to render_attack_results_page."""
+        _run_attack_results_page()
+        mock_render.assert_called_once_with()
+
+    @patch(f"{_MODULE}.render_attack_page")
+    def test_run_attack_page_delegates(self, mock_render):
+        """The attack page delegates to render_attack_page."""
+        _run_attack_page()
+        mock_render.assert_called_once_with()

--- a/bili/streamlit_ui/tests/test_streamlit_utils.py
+++ b/bili/streamlit_ui/tests/test_streamlit_utils.py
@@ -1,0 +1,52 @@
+"""Tests for streamlit_ui.utils.streamlit_utils conditional cache decorators."""
+
+from unittest.mock import patch
+
+from bili.streamlit_ui.utils.streamlit_utils import (
+    conditional_cache_data,
+    conditional_cache_resource,
+)
+
+
+def _sample():
+    return "value"
+
+
+class TestConditionalCacheResource:
+    """conditional_cache_resource wraps with st.cache_resource only in Streamlit."""
+
+    def test_wraps_with_cache_resource_in_streamlit_env(self):
+        """In a Streamlit environment the function is cache_resource wrapped."""
+        sentinel = object()
+        with patch.dict("os.environ", {"STREAMLIT_SERVER_ADDRESS": "0.0.0.0"}), patch(
+            "streamlit.cache_resource", return_value=sentinel
+        ) as mock_cache:
+            decorated = conditional_cache_resource()(_sample)
+        assert decorated is sentinel
+        mock_cache.assert_called_once_with(_sample)
+
+    def test_returns_function_unchanged_outside_streamlit(self):
+        """Outside Streamlit the original function is returned unmodified."""
+        with patch.dict("os.environ", {}, clear=True):
+            decorated = conditional_cache_resource()(_sample)
+        assert decorated is _sample
+
+
+class TestConditionalCacheData:
+    """conditional_cache_data wraps with st.cache_data only in Streamlit."""
+
+    def test_wraps_with_cache_data_in_streamlit_env(self):
+        """In a Streamlit environment the function is cache_data wrapped."""
+        sentinel = object()
+        with patch.dict("os.environ", {"STREAMLIT_SERVER_ADDRESS": "0.0.0.0"}), patch(
+            "streamlit.cache_data", return_value=sentinel
+        ) as mock_cache:
+            decorated = conditional_cache_data()(_sample)
+        assert decorated is sentinel
+        mock_cache.assert_called_once_with(_sample)
+
+    def test_returns_function_unchanged_outside_streamlit(self):
+        """Outside Streamlit the original function is returned unmodified."""
+        with patch.dict("os.environ", {}, clear=True):
+            decorated = conditional_cache_data()(_sample)
+        assert decorated is _sample

--- a/bili/streamlit_ui/tests/test_ui_auth_manager.py
+++ b/bili/streamlit_ui/tests/test_ui_auth_manager.py
@@ -8,7 +8,9 @@ All Streamlit session_state and provider interactions are mocked.
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
+from bili.auth.providers.auth.in_memory_auth_provider import InMemoryAuthProvider
 from bili.streamlit_ui.tests.conftest import FakeSessionState
 
 
@@ -222,4 +224,165 @@ class TestCreateAccount:
         mgr.create_account("u@test.com", "pass", "John", "Doe", False)
 
         assert "error" in mock_st.session_state.auth_warning.lower()
+        mock_st.rerun.assert_called_once()
+
+
+# =========================================================================
+# sign_in
+# =========================================================================
+
+
+class TestSignIn:
+    """Tests for UIAuthManager.sign_in covering each role and error branch."""
+
+    def _wire_auth(self, mgr, email_verified=True):
+        """Configure the auth_provider mock with a signed-in response."""
+        mgr.auth_provider.sign_in.return_value = {"uid": "uid1", "token": "tok1"}
+        mgr.auth_provider.get_account_info.return_value = {
+            "email": "u@test.com",
+            "emailVerified": email_verified,
+        }
+
+    def test_researcher_signs_in_successfully(self, ui_mgr):
+        """A researcher role yields a success message and a rerun."""
+        mgr, mock_st = ui_mgr
+        self._wire_auth(mgr)
+        mgr.role_provider.get_user_role.return_value = "researcher"
+        mgr.profile_provider.get_user_profile.return_value = {"name": "U"}
+
+        mgr.sign_in("u@test.com", "pass")
+
+        assert mock_st.session_state.role == "researcher"
+        assert mock_st.session_state.auth_success == "Signed in successfully"
+        assert mock_st.session_state.user_info["email"] == "u@test.com"
+        mock_st.rerun.assert_called()
+
+    def test_admin_signs_in_successfully(self, ui_mgr):
+        """An admin role yields a success message."""
+        mgr, mock_st = ui_mgr
+        self._wire_auth(mgr)
+        mgr.role_provider.get_user_role.return_value = "admin"
+        mgr.profile_provider.get_user_profile.return_value = {"name": "A"}
+
+        mgr.sign_in("a@test.com", "pass")
+
+        assert mock_st.session_state.role == "admin"
+        assert mock_st.session_state.auth_success == "Signed in successfully"
+
+    def test_user_role_under_review_warning(self, ui_mgr):
+        """A user role (not yet approved) triggers an under-review warning."""
+        mgr, mock_st = ui_mgr
+        self._wire_auth(mgr)
+        mgr.role_provider.get_user_role.return_value = "user"
+        mgr.profile_provider.get_user_profile.return_value = {"name": "U"}
+
+        mgr.sign_in("u@test.com", "pass")
+
+        assert mock_st.session_state.role == "user"
+        mock_st.warning.assert_called()
+        assert "under review" in mock_st.warning.call_args[0][0]
+
+    def test_unknown_role_errors_and_stops(self, ui_mgr):
+        """An unrecognized role shows an authorization error and stops."""
+        mgr, mock_st = ui_mgr
+        mock_st.stop = MagicMock()
+        self._wire_auth(mgr)
+        mgr.role_provider.get_user_role.return_value = "banned"
+        mgr.profile_provider.get_user_profile.return_value = {"name": "B"}
+
+        mgr.sign_in("b@test.com", "pass")
+
+        assert mock_st.session_state.role == "banned"
+        mock_st.error.assert_called()
+        mock_st.stop.assert_called_once()
+
+    def test_unverified_email_sends_verification(self, ui_mgr):
+        """An unverified email triggers a verification email and a warning."""
+        mgr, mock_st = ui_mgr
+        self._wire_auth(mgr, email_verified=False)
+        mgr.role_provider.get_user_role.return_value = "researcher"
+        mgr.profile_provider.get_user_profile.return_value = {"name": "U"}
+
+        mgr.sign_in("u@test.com", "pass")
+
+        mgr.auth_provider.send_email_verification.assert_called_once()
+        assert "verify your email" in mock_st.session_state.auth_warning
+
+    def test_profile_404_prompts_for_name(self, ui_mgr):
+        """A 404 on role lookup with no name prompts for profile creation."""
+        mgr, mock_st = ui_mgr
+        self._wire_auth(mgr)
+        error = requests.exceptions.HTTPError()
+        error.response = MagicMock()
+        error.response.status_code = 404
+        mgr.role_provider.get_user_role.side_effect = error
+
+        mgr.sign_in("u@test.com", "pass")
+
+        assert mock_st.session_state.needs_profile_creation is True
+        assert "complete your profile" in mock_st.session_state.auth_warning
+
+    def test_profile_404_with_name_creates_profile(self, ui_mgr):
+        """A 404 on role lookup with a name creates the profile and reviews it."""
+        mgr, mock_st = ui_mgr
+        self._wire_auth(mgr)
+        error = requests.exceptions.HTTPError()
+        error.response = MagicMock()
+        error.response.status_code = 404
+        mgr.role_provider.get_user_role.side_effect = error
+
+        with patch("bili.streamlit_ui.ui.ui_auth_manager.time.sleep"):
+            mgr.sign_in("u@test.com", "pass", first_name="Jane", last_name="Roe")
+
+        mgr.profile_provider.create_user_profile.assert_called_once()
+        assert mock_st.session_state.role == "user"
+        assert mock_st.session_state.needs_profile_creation is False
+
+    def test_profile_non_404_http_error_reraised(self, ui_mgr):
+        """A non-404 HTTPError is surfaced through the outer error handler."""
+        mgr, mock_st = ui_mgr
+        self._wire_auth(mgr)
+        error = requests.exceptions.HTTPError()
+        error.response = MagicMock()
+        error.response.status_code = 500
+        mgr.role_provider.get_user_role.side_effect = error
+
+        mgr.sign_in("u@test.com", "pass")
+
+        # The inner handler warns, re-raises, then the outer handler clears
+        # state and records the unexpected error.
+        assert "Unexpected error" in mock_st.session_state.auth_warning
+
+    def test_unexpected_error_clears_session(self, ui_mgr):
+        """An unexpected error during sign-in clears the session state."""
+        mgr, mock_st = ui_mgr
+        mock_st.session_state["leftover"] = "value"
+        mgr.auth_provider.sign_in.side_effect = ValueError("boom")
+
+        mgr.sign_in("u@test.com", "pass")
+
+        assert "leftover" not in mock_st.session_state
+        assert "Unexpected error" in mock_st.session_state.auth_warning
+        mock_st.rerun.assert_called()
+
+
+# =========================================================================
+# create_account -- in-memory provider success message
+# =========================================================================
+
+
+class TestCreateAccountInMemory:  # pylint: disable=too-few-public-methods
+    """Tests for create_account when using the in-memory auth provider."""
+
+    def test_in_memory_provider_success_message(self, ui_mgr):
+        """An in-memory provider yields the plain account-created message."""
+        mgr, mock_st = ui_mgr
+        provider = InMemoryAuthProvider()
+        provider.create_user = MagicMock(return_value={"uid": "uid1", "token": "tok1"})
+        provider.send_email_verification = MagicMock()
+        mgr.auth_provider = provider
+
+        mgr.create_account("u@test.com", "pass", "Jane", "Roe", False)
+
+        assert mock_st.session_state.auth_success == "Account created successfully"
         mock_st.rerun.assert_called_once()

--- a/bili/streamlit_ui/ui/chat_interface.py
+++ b/bili/streamlit_ui/ui/chat_interface.py
@@ -58,6 +58,7 @@ Example:
     run_app_page()
 """
 
+import base64
 import copy
 import json
 
@@ -386,9 +387,25 @@ def display_state_management(question_form):
 
         # Export button
         if st.button("Export Conversation State as JSON", use_container_width=True):
+            # Export the state values dict (messages, summary, ...), which is
+            # what the import handler reconstructs via .get(). langgraph's
+            # JsonPlusSerializer exposes dumps_typed/loads_typed (it returns a
+            # (type, bytes) pair so LangChain message objects round-trip). Wrap
+            # that pair in a JSON envelope so the download is a single JSON file
+            # and the import side can reconstruct the pair.
+            serde_type, serde_bytes = JsonPlusSerializer().dumps_typed(
+                latest_state.values
+            )
+            export_payload = json.dumps(
+                {
+                    "serde": "jsonplus_typed",
+                    "type": serde_type,
+                    "data": base64.b64encode(serde_bytes).decode("ascii"),
+                }
+            )
             st.download_button(
                 label="Download Conversation State as JSON",
-                data=JsonPlusSerializer().dumps(latest_state),
+                data=export_payload,
                 file_name="conversation_state.json",
                 mime="application/json",
                 use_container_width=True,
@@ -402,7 +419,12 @@ def display_state_management(question_form):
         )
         if uploaded_file is not None:
             if not st.session_state.get("state_imported", False):
-                imported_state = JsonPlusSerializer().loads(uploaded_file.read())
+                # Reconstruct the (type, bytes) pair from the export envelope and
+                # deserialize via loads_typed (the inverse of the export above).
+                envelope = json.loads(uploaded_file.read())
+                imported_state = JsonPlusSerializer().loads_typed(
+                    (envelope["type"], base64.b64decode(envelope["data"]))
+                )
                 # If imported_state is a list, take first value as state
                 if isinstance(imported_state, list):
                     imported_state = imported_state[0]

--- a/bili/streamlit_ui/ui/chat_interface.py
+++ b/bili/streamlit_ui/ui/chat_interface.py
@@ -59,7 +59,6 @@ Example:
 """
 
 import base64
-import binascii
 import copy
 import json
 
@@ -114,13 +113,13 @@ def _deserialize_conversation_state(raw_bytes):
             raise ValueError(f"unsupported serde type: {serde_type!r}")
         data = base64.b64decode(envelope["data"])
         return JsonPlusSerializer().loads_typed((serde_type, data))
-    except (
-        ValueError,
-        KeyError,
-        TypeError,
-        json.JSONDecodeError,
-        binascii.Error,
-    ) as exc:
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        # Deliberately broad: this deserializes an arbitrary user-uploaded file.
+        # Beyond malformed envelopes (ValueError/KeyError/JSONDecodeError/
+        # binascii.Error), a valid envelope with corrupt or stale inner bytes can
+        # make loads_typed raise msgpack errors, AttributeError, or ImportError
+        # (a renamed/removed message class). Any failure should surface as a
+        # friendly error, never an uncaught Streamlit traceback.
         st.error(
             "Could not import conversation state: the file is malformed or from "
             "an incompatible release. Please re-export it. "
@@ -418,6 +417,9 @@ def display_state_management(question_form):
             st.session_state["conversation_chain"].update_state(
                 config, clear_state(latest_state)
             )
+            # Drop any cached export so the download button does not keep
+            # offering the now-cleared conversation's state.
+            st.session_state.pop("conversation_state_export", None)
             st.session_state["state_cleared"] = True
             st.rerun()
         if st.session_state.get("state_cleared", False):
@@ -455,21 +457,30 @@ def display_state_management(question_form):
                 use_container_width=True,
             )
 
-        # Import uploader
+        # Import uploader. on_change resets both flags so a freshly uploaded
+        # file is processed again (and any prior failure is retried).
         uploaded_file = st.file_uploader(
             "Import Conversation State from JSON",
             type="json",
-            on_change=lambda: st.session_state.update({"state_imported": False}),
+            on_change=lambda: st.session_state.update(
+                {"state_imported": False, "state_import_failed": False}
+            ),
         )
         if uploaded_file is not None:
-            if not st.session_state.get("state_imported", False):
+            if not st.session_state.get(
+                "state_imported", False
+            ) and not st.session_state.get("state_import_failed", False):
                 # getvalue() is position-independent; read() would consume the
                 # BytesIO cursor and return b"" on a later rerun, crashing
                 # json.loads. Returns None (after st.error) on a bad upload.
                 imported_state = _deserialize_conversation_state(
                     uploaded_file.getvalue()
                 )
-                if imported_state is not None:
+                if imported_state is None:
+                    # Remember the failure so we do not re-parse (and re-emit the
+                    # error) on every rerun until a new file is uploaded.
+                    st.session_state["state_import_failed"] = True
+                else:
                     # If imported_state is a list, take first value as state
                     if isinstance(imported_state, list):
                         imported_state = imported_state[0]
@@ -489,7 +500,7 @@ def display_state_management(question_form):
                     )
                     st.session_state["state_imported"] = True
                     st.rerun()
-            elif "state_imported" in st.session_state:
+            elif st.session_state.get("state_imported", False):
                 st.success("Configuration imported successfully!")
 
         container = st.expander("Current Conversation State", expanded=False)

--- a/bili/streamlit_ui/ui/chat_interface.py
+++ b/bili/streamlit_ui/ui/chat_interface.py
@@ -59,6 +59,7 @@ Example:
 """
 
 import base64
+import binascii
 import copy
 import json
 
@@ -88,6 +89,44 @@ from bili.streamlit_ui.utils.state_management import (
     get_state_config,
 )
 from bili.utils.langgraph_utils import State, clear_state, format_message_with_citations
+
+# langgraph's JsonPlusSerializer.dumps_typed tags payloads as "json" or
+# "msgpack"; reject anything else so an attacker-supplied envelope cannot steer
+# loads_typed into an unexpected decoder branch.
+_VALID_EXPORT_SERDE_TYPES = {"json", "msgpack"}
+
+
+def _deserialize_conversation_state(raw_bytes):
+    """Deserialize an uploaded conversation-state export envelope.
+
+    Expects the typed JSON envelope produced by the Export handler. Returns the
+    state dict on success, or None (after surfacing st.error) when the upload is
+    malformed, has an unsupported serde type, or is from an incompatible older
+    release whose format predates the envelope.
+
+    :param raw_bytes: Raw bytes read from the uploaded file.
+    :return: The deserialized state, or None on failure.
+    """
+    try:
+        envelope = json.loads(raw_bytes)
+        serde_type = envelope["type"]
+        if serde_type not in _VALID_EXPORT_SERDE_TYPES:
+            raise ValueError(f"unsupported serde type: {serde_type!r}")
+        data = base64.b64decode(envelope["data"])
+        return JsonPlusSerializer().loads_typed((serde_type, data))
+    except (
+        ValueError,
+        KeyError,
+        TypeError,
+        json.JSONDecodeError,
+        binascii.Error,
+    ) as exc:
+        st.error(
+            "Could not import conversation state: the file is malformed or from "
+            "an incompatible release. Please re-export it. "
+            f"({type(exc).__name__})"
+        )
+        return None
 
 
 def run_app_page(checkpointer=None):
@@ -352,7 +391,7 @@ def display_state_management(question_form):
             last_ai_message_index = None
 
         processing_messages = []
-        if last_human_message_index and last_ai_message_index:
+        if last_human_message_index is not None and last_ai_message_index is not None:
             processing_messages = latest_state_messages[
                 last_human_message_index + 1 : last_ai_message_index
             ]
@@ -385,7 +424,11 @@ def display_state_management(question_form):
             st.success("Conversation state cleared!")
             st.session_state.update({"state_cleared": False})
 
-        # Export button
+        # Export button. Build the envelope on click and stash it in session
+        # state, then render the download_button unconditionally. A
+        # download_button rendered only inside the click branch disappears on
+        # the next rerun (sibling widget, uploader on_change, external rerun)
+        # before the user clicks Download, discarding the serialized state.
         if st.button("Export Conversation State as JSON", use_container_width=True):
             # Export the state values dict (messages, summary, ...), which is
             # what the import handler reconstructs via .get(). langgraph's
@@ -396,16 +439,17 @@ def display_state_management(question_form):
             serde_type, serde_bytes = JsonPlusSerializer().dumps_typed(
                 latest_state.values
             )
-            export_payload = json.dumps(
+            st.session_state["conversation_state_export"] = json.dumps(
                 {
                     "serde": "jsonplus_typed",
                     "type": serde_type,
                     "data": base64.b64encode(serde_bytes).decode("ascii"),
                 }
             )
+        if st.session_state.get("conversation_state_export"):
             st.download_button(
                 label="Download Conversation State as JSON",
-                data=export_payload,
+                data=st.session_state["conversation_state_export"],
                 file_name="conversation_state.json",
                 mime="application/json",
                 use_container_width=True,
@@ -419,31 +463,32 @@ def display_state_management(question_form):
         )
         if uploaded_file is not None:
             if not st.session_state.get("state_imported", False):
-                # Reconstruct the (type, bytes) pair from the export envelope and
-                # deserialize via loads_typed (the inverse of the export above).
-                envelope = json.loads(uploaded_file.read())
-                imported_state = JsonPlusSerializer().loads_typed(
-                    (envelope["type"], base64.b64decode(envelope["data"]))
+                # getvalue() is position-independent; read() would consume the
+                # BytesIO cursor and return b"" on a later rerun, crashing
+                # json.loads. Returns None (after st.error) on a bad upload.
+                imported_state = _deserialize_conversation_state(
+                    uploaded_file.getvalue()
                 )
-                # If imported_state is a list, take first value as state
-                if isinstance(imported_state, list):
-                    imported_state = imported_state[0]
+                if imported_state is not None:
+                    # If imported_state is a list, take first value as state
+                    if isinstance(imported_state, list):
+                        imported_state = imported_state[0]
 
-                # Clear state first to remove existing messages and summary
-                st.session_state["conversation_chain"].update_state(
-                    config, clear_state(latest_state)
-                )
+                    # Clear state first to remove existing messages and summary
+                    st.session_state["conversation_chain"].update_state(
+                        config, clear_state(latest_state)
+                    )
 
-                # Next, import the new state
-                st.session_state["conversation_chain"].update_state(
-                    config,
-                    {
-                        "messages": imported_state.get("messages", []),
-                        "summary": imported_state.get("summary", ""),
-                    },
-                )
-                st.session_state["state_imported"] = True
-                st.rerun()
+                    # Next, import the new state
+                    st.session_state["conversation_chain"].update_state(
+                        config,
+                        {
+                            "messages": imported_state.get("messages", []),
+                            "summary": imported_state.get("summary", ""),
+                        },
+                    )
+                    st.session_state["state_imported"] = True
+                    st.rerun()
             elif "state_imported" in st.session_state:
                 st.success("Configuration imported successfully!")
 

--- a/bili/streamlit_ui/ui/configuration_panels.py
+++ b/bili/streamlit_ui/ui/configuration_panels.py
@@ -479,6 +479,15 @@ def display_configuration_panels():
                         st.session_state["custom_response_schema"] = preset_schemas[
                             preset
                         ]
+                        # Also drive the textarea widget key so the box reflects
+                        # the preset. Streamlit ignores the value= argument once
+                        # the widget is keyed, so without this the box keeps the
+                        # old text and the next keystroke would undo the switch.
+                        # Safe here: on_change callbacks run before the widget is
+                        # re-instantiated.
+                        st.session_state["custom_response_schema_input"] = (
+                            preset_schemas[preset]
+                        )
 
                 # Preset selector
                 schema_preset = st.selectbox(

--- a/bili/streamlit_ui/ui/configuration_panels.py
+++ b/bili/streamlit_ui/ui/configuration_panels.py
@@ -561,20 +561,45 @@ def display_configuration_panels():
                     "[📚 Learn about Vertex AI JSON schemas](https://ai.google.dev/gemini-api/docs/structured-output)"
                 )
 
-                # Clear/Reset buttons
+                def reset_to_default_schema():
+                    """Reset the response schema to the default object preset.
+
+                    Run as the button's on_click callback (not in the main body)
+                    so it can set the schema_preset widget key. Callbacks run
+                    before widgets are instantiated, so this is allowed; setting
+                    a widget key after instantiation raises StreamlitAPIException.
+                    """
+                    st.session_state["custom_response_schema"] = (
+                        '{"type": "object", "properties": {"response": '
+                        '{"type": "string"}}, "required": ["response"]}'
+                    )
+                    st.session_state["schema_preset"] = "Object Response"
+
+                def clear_schema():
+                    """Clear the response schema back to an empty object.
+
+                    Run as the button's on_click callback so it may set the
+                    schema_preset widget key (see reset_to_default_schema).
+                    """
+                    st.session_state["custom_response_schema"] = "{}"
+                    st.session_state["schema_preset"] = "Custom"
+
+                # Clear/Reset buttons. The state mutations live in on_click
+                # callbacks (which auto-rerun) so they never write to the
+                # schema_preset widget key after the selectbox is instantiated.
                 col1, col2 = st.columns(2)
                 with col1:
-                    if st.button("Reset to Default Schema", use_container_width=True):
-                        st.session_state["custom_response_schema"] = (
-                            '{"type": "object", "properties": {"response": {"type": "string"}}, "required": ["response"]}'
-                        )
-                        st.session_state["schema_preset"] = "Object Response"
-                        st.rerun()
+                    st.button(
+                        "Reset to Default Schema",
+                        use_container_width=True,
+                        on_click=reset_to_default_schema,
+                    )
                 with col2:
-                    if st.button("Clear Schema", use_container_width=True):
-                        st.session_state["custom_response_schema"] = "{}"
-                        st.session_state["schema_preset"] = "Custom"
-                        st.rerun()
+                    st.button(
+                        "Clear Schema",
+                        use_container_width=True,
+                        on_click=clear_schema,
+                    )
 
             else:
                 # Clear custom schema and related settings for non-JSON MIME types

--- a/bili/streamlit_ui/ui/configuration_panels.py
+++ b/bili/streamlit_ui/ui/configuration_panels.py
@@ -565,23 +565,31 @@ def display_configuration_panels():
                     """Reset the response schema to the default object preset.
 
                     Run as the button's on_click callback (not in the main body)
-                    so it can set the schema_preset widget key. Callbacks run
-                    before widgets are instantiated, so this is allowed; setting
-                    a widget key after instantiation raises StreamlitAPIException.
+                    so it can set the schema_preset and textarea widget keys.
+                    Callbacks run before widgets are instantiated, so this is
+                    allowed; setting a widget key after instantiation raises
+                    StreamlitAPIException. Both the data key
+                    (custom_response_schema) and the textarea widget key
+                    (custom_response_schema_input) are set so the box shows the
+                    reset value rather than the user's stale text.
                     """
-                    st.session_state["custom_response_schema"] = (
+                    default_schema = (
                         '{"type": "object", "properties": {"response": '
                         '{"type": "string"}}, "required": ["response"]}'
                     )
+                    st.session_state["custom_response_schema"] = default_schema
+                    st.session_state["custom_response_schema_input"] = default_schema
                     st.session_state["schema_preset"] = "Object Response"
 
                 def clear_schema():
                     """Clear the response schema back to an empty object.
 
                     Run as the button's on_click callback so it may set the
-                    schema_preset widget key (see reset_to_default_schema).
+                    schema_preset and textarea widget keys (see
+                    reset_to_default_schema).
                     """
                     st.session_state["custom_response_schema"] = "{}"
+                    st.session_state["custom_response_schema_input"] = "{}"
                     st.session_state["schema_preset"] = "Custom"
 
                 # Clear/Reset buttons. The state mutations live in on_click

--- a/bili/tests/__init__.py
+++ b/bili/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the top-level bili package."""

--- a/bili/tests/test_package_init.py
+++ b/bili/tests/test_package_init.py
@@ -43,3 +43,16 @@ class TestLazySubmoduleLoader:
         for name in bili._LAZY_SUBMODULES:
             module = importlib.import_module(f"bili.{name}")
             assert isinstance(module, types.ModuleType)
+
+    def test_all_matches_lazy_submodules(self):
+        """__all__ must equal _LAZY_SUBMODULES so `from bili import *` works.
+
+        A name in __all__ that is not in _LAZY_SUBMODULES would raise
+        AttributeError from __getattr__ during a star import.
+        """
+        assert set(bili.__all__) == set(bili._LAZY_SUBMODULES)
+
+    def test_star_import_resolves_every_name(self):
+        """Every name in __all__ resolves via __getattr__ (star-import safe)."""
+        for name in bili.__all__:
+            assert isinstance(getattr(bili, name), types.ModuleType)

--- a/bili/tests/test_package_init.py
+++ b/bili/tests/test_package_init.py
@@ -1,0 +1,45 @@
+"""Tests for the bili package lazy-submodule loader (PEP 562)."""
+
+import importlib
+import types
+
+import pytest
+
+import bili
+
+
+class TestLazySubmoduleLoader:
+    """bili.__getattr__ lazily imports declared subpackages."""
+
+    def test_getattr_imports_known_submodule(self):
+        """Accessing a declared submodule returns the imported module."""
+        module = bili.__getattr__("utils")
+        assert isinstance(module, types.ModuleType)
+        assert module.__name__ == "bili.utils"
+
+    def test_getattr_caches_module_in_globals(self):
+        """A loaded submodule is cached so later access is a direct attribute."""
+        bili.__getattr__("utils")
+        assert isinstance(vars(bili).get("utils"), types.ModuleType)
+
+    def test_getattr_unknown_name_raises_attribute_error(self):
+        """An undeclared attribute name raises AttributeError."""
+        with pytest.raises(AttributeError):
+            bili.__getattr__("definitely_not_a_submodule")
+
+    def test_dir_lists_exactly_the_lazy_submodules(self):
+        """dir(bili) advertises exactly the lazily loadable submodules."""
+        assert set(bili.__dir__()) == set(bili._LAZY_SUBMODULES)
+
+    def test_every_declared_submodule_actually_imports(self):
+        """Every name in _LAZY_SUBMODULES must resolve to a real package.
+
+        Regression guard for stale entries: the v5.0.0 refactor moved several
+        former top-level packages (config, checkpointers, loaders, nodes,
+        tools, graph_builder) under bili/iris/, leaving the lazy list pointing
+        at modules that no longer exist. This asserts each declared submodule
+        imports cleanly, so a stale entry fails loudly here.
+        """
+        for name in bili._LAZY_SUBMODULES:
+            module = importlib.import_module(f"bili.{name}")
+            assert isinstance(module, types.ModuleType)

--- a/bili/utils/logging_utils.py
+++ b/bili/utils/logging_utils.py
@@ -94,13 +94,16 @@ log_level_str = os.getenv("LOG_LEVEL", "INFO").upper()
 # using the custom function that supports TRACE
 log_level = get_log_level(log_level_str)
 
-# Perform the root logger configuration once when the module is loaded
-if len(logging.getLogger().handlers) > 0:
-    # If running in an environment like AWS Lambda, the root logger is already configured
-    logging.getLogger().setLevel(log_level)
-else:
-    # Configure the logger with a basic console handler for local usage
+# Perform the root logger configuration once when the module is loaded.
+if len(logging.getLogger().handlers) == 0:
+    # No handlers yet: configure a basic console handler for local usage.
     logging.basicConfig(level=log_level)
+elif "LOG_LEVEL" in os.environ:
+    # The root logger is already configured (e.g. Gunicorn, uvicorn, AWS
+    # Lambda, pytest --log-cli-level). Only override its level when LOG_LEVEL
+    # was set explicitly, so importing bili does not silently stomp on the
+    # host application's logging configuration.
+    logging.getLogger().setLevel(log_level)
 
 
 def get_logger(name: str):

--- a/bili/utils/logging_utils.py
+++ b/bili/utils/logging_utils.py
@@ -95,13 +95,12 @@ log_level_str = os.getenv("LOG_LEVEL", "INFO").upper()
 log_level = get_log_level(log_level_str)
 
 # Perform the root logger configuration once when the module is loaded
-if len(logging.getLogger().handlers) == 0:
-    if len(logging.getLogger().handlers) > 0:
-        # If running in an environment like AWS Lambda, the root logger is already configured
-        logging.getLogger().setLevel(log_level)
-    else:
-        # Configure the logger with a basic console handler for local usage
-        logging.basicConfig(level=log_level)
+if len(logging.getLogger().handlers) > 0:
+    # If running in an environment like AWS Lambda, the root logger is already configured
+    logging.getLogger().setLevel(log_level)
+else:
+    # Configure the logger with a basic console handler for local usage
+    logging.basicConfig(level=log_level)
 
 
 def get_logger(name: str):

--- a/bili/utils/tests/test_file_utils.py
+++ b/bili/utils/tests/test_file_utils.py
@@ -7,7 +7,7 @@ are tested only via mocking or skipped.
 """
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from langchain_core.documents import Document
 
@@ -18,9 +18,19 @@ from bili.utils.file_utils import (
     load_from_json,
     preprocess_directory,
     preprocess_file,
+    process_excel_data,
+    process_html_data,
+    process_json_data,
+    process_markdown_data,
+    process_pdf_data,
     process_text,
     process_text_data,
+    process_unstructured_data,
+    process_word_data,
+    process_xml_data,
 )
+
+_MODULE = "bili.utils.file_utils"
 
 # ------------------------------------------------------------------
 # load_from_json
@@ -263,3 +273,82 @@ class TestDefaultConstants:
     def test_default_chunk_overlap(self):
         """DEFAULT_CHUNK_OVERLAP is 200."""
         assert DEFAULT_CHUNK_OVERLAP == 200
+
+
+# ------------------------------------------------------------------
+# Loader-wrapper processors (mocked LangChain loaders)
+# ------------------------------------------------------------------
+
+
+class TestLoaderWrappers:
+    """Each processor delegates to its LangChain loader and returns load()."""
+
+    def _assert_delegates(self, loader_name, func):
+        """Patch *loader_name* and assert *func* returns the loader's load()."""
+        with patch(f"{_MODULE}.{loader_name}") as loader_cls:
+            loader_cls.return_value.load.return_value = ["doc"]
+            result = func("some/file.path", ".ext")
+        assert result == ["doc"]
+        loader_cls.return_value.load.assert_called_once()
+
+    def test_process_excel_data(self):
+        """process_excel_data uses UnstructuredExcelLoader."""
+        self._assert_delegates("UnstructuredExcelLoader", process_excel_data)
+
+    def test_process_word_data(self):
+        """process_word_data uses UnstructuredWordDocumentLoader."""
+        self._assert_delegates("UnstructuredWordDocumentLoader", process_word_data)
+
+    def test_process_json_data(self):
+        """process_json_data uses JSONLoader."""
+        self._assert_delegates("JSONLoader", process_json_data)
+
+    def test_process_html_data(self):
+        """process_html_data uses BSHTMLLoader."""
+        self._assert_delegates("BSHTMLLoader", process_html_data)
+
+    def test_process_markdown_data(self):
+        """process_markdown_data uses UnstructuredMarkdownLoader."""
+        self._assert_delegates("UnstructuredMarkdownLoader", process_markdown_data)
+
+    def test_process_xml_data(self):
+        """process_xml_data uses UnstructuredXMLLoader."""
+        self._assert_delegates("UnstructuredXMLLoader", process_xml_data)
+
+    def test_process_unstructured_data(self):
+        """process_unstructured_data uses UnstructuredFileLoader."""
+        self._assert_delegates("UnstructuredFileLoader", process_unstructured_data)
+
+
+class TestProcessPdfData:
+    """process_pdf_data tries image extraction then retries without it."""
+
+    def test_success_with_image_extraction(self):
+        """The first attempt extracts images and returns its split content."""
+        with patch(f"{_MODULE}.PyPDFLoader") as loader_cls:
+            loader_cls.return_value.load_and_split.return_value = ["pdf"]
+            result = process_pdf_data("doc.pdf", ".pdf")
+        assert result == ["pdf"]
+        # First (and only) attempt requests image extraction.
+        assert loader_cls.call_args_list[0].kwargs["extract_images"] is True
+
+    def test_retries_without_images_on_error(self):
+        """A failure with images retries with extract_images disabled."""
+        first = MagicMock()
+        first.load_and_split.side_effect = ValueError("image boom")
+        second = MagicMock()
+        second.load_and_split.return_value = ["retried"]
+        with patch(f"{_MODULE}.PyPDFLoader", side_effect=[first, second]) as loader_cls:
+            result = process_pdf_data("doc.pdf", ".pdf")
+        assert result == ["retried"]
+        assert loader_cls.call_args_list[0].kwargs["extract_images"] is True
+        assert loader_cls.call_args_list[1].kwargs["extract_images"] is False
+
+
+class TestPreprocessFileErrorHandling:
+    """preprocess_file swallows loader IOError/ValueError and returns ''."""
+
+    def test_returns_empty_string_on_loader_error(self):
+        """A processor that raises a handled error yields an empty string."""
+        with patch(f"{_MODULE}.process_csv_data", side_effect=ValueError("bad csv")):
+            assert preprocess_file("data.csv") == ""

--- a/bili/utils/tests/test_logging_utils.py
+++ b/bili/utils/tests/test_logging_utils.py
@@ -1,11 +1,14 @@
 """Tests for bili.utils.logging_utils.
 
-Covers get_log_level, get_logger, and the custom TRACE level
-constant.
+Covers get_log_level, get_logger, the custom TRACE level constant, the
+trace() logger method, and the module-load root-logger configuration.
 """
 
+import importlib
 import logging
+from unittest.mock import MagicMock, patch
 
+import bili.utils.logging_utils as logging_utils
 from bili.utils.logging_utils import TRACE, get_log_level, get_logger
 
 # ------------------------------------------------------------------
@@ -85,3 +88,75 @@ class TestGetLogger:
         logger = get_logger("trace.check")
         assert hasattr(logger, "trace")
         assert callable(logger.trace)
+
+
+# ------------------------------------------------------------------
+# trace() logger method
+# ------------------------------------------------------------------
+
+
+class TestTraceMethod:
+    """The custom trace method emits a record only when TRACE is enabled."""
+
+    def test_trace_emits_record_when_enabled(self):
+        """A TRACE-level logger dispatches the record to its handler."""
+        logger = get_logger("trace.emit")
+        logger.setLevel(TRACE)
+        records = []
+        handler = logging.Handler()
+        handler.emit = records.append
+        logger.addHandler(handler)
+        try:
+            logger.trace("hello trace")
+        finally:
+            logger.removeHandler(handler)
+        assert any(r.getMessage() == "hello trace" for r in records)
+
+    def test_trace_suppressed_when_disabled(self):
+        """A logger above TRACE level emits no record for trace()."""
+        logger = get_logger("trace.suppressed")
+        logger.setLevel(logging.INFO)
+        records = []
+        handler = logging.Handler()
+        handler.emit = records.append
+        logger.addHandler(handler)
+        try:
+            logger.trace("should not appear")
+        finally:
+            logger.removeHandler(handler)
+        assert records == []
+
+
+# ------------------------------------------------------------------
+# Module-load root-logger configuration
+# ------------------------------------------------------------------
+
+
+class TestModuleRootConfiguration:
+    """Module import configures the root logger based on existing handlers."""
+
+    def teardown_method(self):
+        """Reload the module unpatched so later tests see normal state."""
+        importlib.reload(logging_utils)
+
+    def test_sets_level_when_root_has_handlers(self):
+        """An already-configured root logger only gets its level set."""
+        fake_root = MagicMock()
+        fake_root.handlers = [MagicMock()]
+        with patch("logging.getLogger", return_value=fake_root), patch(
+            "logging.basicConfig"
+        ) as mock_basic:
+            importlib.reload(logging_utils)
+        fake_root.setLevel.assert_called_once()
+        mock_basic.assert_not_called()
+
+    def test_basic_config_when_root_has_no_handlers(self):
+        """An unconfigured root logger is set up with basicConfig."""
+        fake_root = MagicMock()
+        fake_root.handlers = []
+        with patch("logging.getLogger", return_value=fake_root), patch(
+            "logging.basicConfig"
+        ) as mock_basic:
+            importlib.reload(logging_utils)
+        mock_basic.assert_called_once()
+        fake_root.setLevel.assert_not_called()

--- a/bili/utils/tests/test_logging_utils.py
+++ b/bili/utils/tests/test_logging_utils.py
@@ -6,6 +6,7 @@ trace() logger method, and the module-load root-logger configuration.
 
 import importlib
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 import bili.utils.logging_utils as logging_utils
@@ -139,15 +140,29 @@ class TestModuleRootConfiguration:
         """Reload the module unpatched so later tests see normal state."""
         importlib.reload(logging_utils)
 
-    def test_sets_level_when_root_has_handlers(self):
-        """An already-configured root logger only gets its level set."""
+    def test_sets_level_when_handlers_present_and_log_level_set(self):
+        """A configured root logger gets its level set only when LOG_LEVEL is set."""
         fake_root = MagicMock()
         fake_root.handlers = [MagicMock()]
         with patch("logging.getLogger", return_value=fake_root), patch(
             "logging.basicConfig"
-        ) as mock_basic:
+        ) as mock_basic, patch.dict("os.environ", {"LOG_LEVEL": "DEBUG"}):
             importlib.reload(logging_utils)
         fake_root.setLevel.assert_called_once()
+        mock_basic.assert_not_called()
+
+    def test_respects_host_config_when_log_level_unset(self):
+        """A configured root logger is left untouched when LOG_LEVEL is absent."""
+        fake_root = MagicMock()
+        fake_root.handlers = [MagicMock()]
+        env_without_log_level = {
+            k: v for k, v in os.environ.items() if k != "LOG_LEVEL"
+        }
+        with patch("logging.getLogger", return_value=fake_root), patch(
+            "logging.basicConfig"
+        ) as mock_basic, patch.dict("os.environ", env_without_log_level, clear=True):
+            importlib.reload(logging_utils)
+        fake_root.setLevel.assert_not_called()
         mock_basic.assert_not_called()
 
     def test_basic_config_when_root_has_no_handlers(self):

--- a/bili/utils/tests/test_opensearch_utils.py
+++ b/bili/utils/tests/test_opensearch_utils.py
@@ -1,0 +1,75 @@
+"""Tests for bili.utils.opensearch_utils.load_opensearch_vector_search."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bili.utils.opensearch_utils import load_opensearch_vector_search
+
+_MODULE = "bili.utils.opensearch_utils"
+
+
+def _patches():
+    """Return the standard set of external-dependency patchers as a context tuple."""
+    return (
+        patch(f"{_MODULE}.boto3"),
+        patch(f"{_MODULE}.AWS4Auth"),
+        patch(f"{_MODULE}.OpenSearchVectorSearch"),
+    )
+
+
+class TestLoadOpenSearchVectorSearch:
+    """The loader configures credentials and builds an OpenSearchVectorSearch."""
+
+    def test_local_environment_uses_test_credentials(self):
+        """LOCALSTACK_HOSTNAME triggers the localstack credential path without SSL."""
+        env = {
+            "LOCALSTACK_HOSTNAME": "localhost",
+            "OPENSEARCH_URL": "http://opensearch:9200",
+        }
+        p_boto, p_auth, p_oss = _patches()
+        with patch.dict(
+            "os.environ", env, clear=True
+        ), p_boto as boto3_mock, p_auth, p_oss as oss_mock:
+            embed = MagicMock()
+            result = load_opensearch_vector_search(embed, "my-index")
+
+        boto3_mock.Session.assert_called_once()
+        # Local path passes explicit test credentials to the session.
+        assert "aws_access_key_id" in boto3_mock.Session.call_args.kwargs
+        kwargs = oss_mock.call_args.kwargs
+        assert kwargs["use_ssl"] is False
+        assert kwargs["verify_certs"] is False
+        assert kwargs["index_name"] == "my-index"
+        assert kwargs["opensearch_url"] == "http://opensearch:9200"
+        assert result is oss_mock.return_value
+
+    def test_aws_environment_uses_default_credential_chain(self):
+        """Without LOCALSTACK the default boto3 session and SSL are used."""
+        env = {
+            "OPENSEARCH_URL": "https://opensearch.aws:443",
+            "AWS_REGION": "us-west-2",
+        }
+        p_boto, p_auth, p_oss = _patches()
+        with patch.dict(
+            "os.environ", env, clear=True
+        ), p_boto as boto3_mock, p_auth, p_oss as oss_mock:
+            load_opensearch_vector_search(MagicMock(), "idx")
+
+        # Default credential chain: Session() called with no keyword arguments.
+        boto3_mock.Session.assert_called_once_with()
+        assert oss_mock.call_args.kwargs["use_ssl"] is True
+        assert oss_mock.call_args.kwargs["verify_certs"] is True
+
+    def test_missing_opensearch_url_raises(self):
+        """A missing OPENSEARCH_URL raises a descriptive ValueError."""
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="OPENSEARCH_URL"):
+                load_opensearch_vector_search(MagicMock(), "idx")
+
+    def test_missing_aws_region_raises_in_aws_environment(self):
+        """A non-local environment without AWS_REGION raises a ValueError."""
+        env = {"OPENSEARCH_URL": "https://opensearch.aws:443"}
+        with patch.dict("os.environ", env, clear=True):
+            with pytest.raises(ValueError, match="AWS_REGION"):
+                load_opensearch_vector_search(MagicMock(), "idx")

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Per-file coverage gate for bili-core.
+
+Enforces the project goal that every runtime file has at least 90% line
+coverage. Reads coverage.json produced by
+``pytest --cov=bili --cov-report=json``.
+
+The .coveragerc already scopes measurement to runtime code (it omits the
+test tree), so every file in the report is shipping code. This gate fails
+the build (exit 1) and lists every offender if any runtime file is below the
+threshold. A global average gate would let a 50%-covered file hide behind a
+crowd of 99%-covered files; the project goal is per-file, so the gate is
+per-file.
+
+Usage:
+    pytest bili/ --cov=bili --cov-report=json:coverage.json -q
+    python scripts/check_coverage.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+THRESHOLD = 90.0
+COVERAGE_JSON = "coverage.json"
+
+
+def main() -> int:
+    path = Path(COVERAGE_JSON)
+    if not path.exists():
+        print(
+            f"ERROR: {COVERAGE_JSON} not found. Run pytest with "
+            f"--cov=bili --cov-report=json:{COVERAGE_JSON} first.",
+            file=sys.stderr,
+        )
+        return 2
+
+    data = json.loads(path.read_text())
+    files = data.get("files", {})
+
+    offenders = []
+    for file_path, fdata in sorted(files.items()):
+        summary = fdata["summary"]
+        if summary["num_statements"] == 0:
+            # No executable statements (e.g. an empty __init__). Nothing to cover.
+            continue
+        pct = summary["percent_covered"]
+        if pct < THRESHOLD:
+            offenders.append((file_path, pct, summary["missing_lines"]))
+
+    total = data["totals"]["percent_covered"]
+
+    if offenders:
+        print(
+            f"FAIL: {len(offenders)} runtime file(s) below {THRESHOLD:.0f}% "
+            f"line coverage (overall {total:.1f}%):\n"
+        )
+        for file_path, pct, missing in offenders:
+            print(f"  {pct:5.1f}%  ({missing:>4} lines uncovered)  {file_path}")
+        print(
+            f"\nEvery runtime file must reach >= {THRESHOLD:.0f}% line coverage. "
+            "Add tests for the uncovered lines (see the per-file --cov-report=term-missing "
+            "output for exact line numbers), or mark genuinely unreachable lines with "
+            "`# pragma: no cover` and a one-line reason."
+        )
+        return 1
+
+    print(
+        f"PASS: all {len(files)} runtime files >= {THRESHOLD:.0f}% line coverage "
+        f"(overall {total:.1f}%)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -40,6 +40,14 @@ def main() -> int:
     data = json.loads(path.read_text())
     files = data.get("files", {})
 
+    if not files:
+        print(
+            f"ERROR: {COVERAGE_JSON} has no measured files. Coverage did not run "
+            "correctly; re-run the test suite with coverage enabled.",
+            file=sys.stderr,
+        )
+        return 2
+
     offenders = []
     for file_path, fdata in sorted(files.items()):
         summary = fdata["summary"]
@@ -50,7 +58,7 @@ def main() -> int:
         if pct < THRESHOLD:
             offenders.append((file_path, pct, summary["missing_lines"]))
 
-    total = data["totals"]["percent_covered"]
+    total = data.get("totals", {}).get("percent_covered", 0.0)
 
     if offenders:
         print(


### PR DESCRIPTION
## Summary

Enforces per-file line coverage of **≥90% on every runtime file** and wires it into CI as a required gate. Closes the long-standing gap where coverage was never measured by a tool: CI ran `pytest bili/` with no `--cov`, the "90%" was aspirational, and the real runtime-only number was ~77%.

The branch raises every runtime file to the threshold, fixes the bugs surfaced along the way, and adds the gate so this can't silently regress.

## What changed

**Measurement + gate infrastructure**
- `.coveragerc` scopes coverage to runtime code (`source = bili`, the test tree is omitted so it cannot inflate the numbers).
- `scripts/check_coverage.py` enforces the threshold **per file**, not as an average: a single runtime file below 90% fails the build.
- CI `test-application` job now runs `pytest --cov` and a required `Enforce per-file coverage gate (>= 90%)` step.

**Coverage**
- Every one of the 187 runtime files reaches ≥90% (overall **98.4%**). Test waves covered checkpointers, AEGIS, IRIS tools/loaders, AETHER, auth, the Flask API, the Streamlit/AETHER UI pages, and the top-level entry points.

**Bug fixes** (each was first documented with an `xfail(strict)` test; those tests now assert correct behavior and pass)
1. **Async PG checkpointer skipped multi-tenant thread-ownership validation.** `AsyncPruningPostgresSaver` did not inherit `QueryableCheckpointerMixin` (where `_validate_thread_ownership` lives), so `aput`/`aget_tuple` raised `AttributeError` instead of rejecting cross-tenant access. Added the mixin (shared validation, not duplicated) and implemented all five query methods by delegating to a sync saver that shares the sync connection pool.
2. **`per_user_agent` crashed on every `/nova_per_user` request.** The graph-insertion branch called `dataclasses.replace()` on Node factory partials and compared a partial to the graph's Node instances. Now it matches the node by name, re-points the existing persona instance, and instantiates a fresh `per_user_state` node without mutating the shared graph definition.
3. **chat_interface Export/Import used a removed serializer API.** langgraph 1.0 dropped `JsonPlusSerializer.dumps`/`.loads` in favor of `dumps_typed`/`loads_typed`; both buttons crashed. Export now serializes the state values via `dumps_typed` in a JSON envelope and import reconstructs the `(type, bytes)` pair via `loads_typed`, so message objects round-trip.
4. **configuration_panels Reset/Clear schema buttons crashed the panel.** Their handlers wrote to the `schema_preset` widget key in the main body after the selectbox was instantiated (`StreamlitAPIException`). Moved the state mutations into `on_click` callbacks.

A bug found mid-pass in `attack_results_page._render_matrix` (the compliance matrix rendered empty whenever no Tier-3 score existed, hiding Tier-1/Tier-2 cells) was fixed inline during the coverage work.

## Verification

- Full suite: **3189 passed, 0 xfailed**.
- Per-file gate: `PASS: all 187 runtime files >= 90% line coverage (overall 98.4%)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
