### PR TITLE
Release v5.3.1: gate honesty + per_user_agent conditional-routing fix

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -17,6 +17,10 @@ omit =
     */tests/*
     */test_*.py
     */conftest.py
+    # Illustrative demo scripts, not runtime logic. They exercise full
+    # end-to-end workflows (real MAS execution), so they are explicitly out of
+    # scope for the per-file 90% gate rather than left silently unmeasured.
+    */examples/*
 
 [report]
 exclude_lines =

--- a/bili/flask_api/flask_utils.py
+++ b/bili/flask_api/flask_utils.py
@@ -394,15 +394,24 @@ def per_user_agent(
                 # edges, conditional entry) so the rest of the pipeline, including
                 # any conditional branches, runs after the injection rather than
                 # bypassing it.
-                per_user_state_modified.edges = list(persona_node_modified.edges) or [
-                    "inject_current_datetime"
-                ]
-                per_user_state_modified.conditional_edges = (
-                    persona_node_modified.conditional_edges
+                inherited_edges = list(persona_node_modified.edges)
+                inherited_conditional = persona_node_modified.conditional_edges
+                inherited_entry = persona_node_modified.conditional_entry
+                # Only synthesize a fallback static edge when the persona had no
+                # routing at all (a caller that forgot to wire it). If it routed
+                # only conditionally, keep static edges empty so we do not add a
+                # spurious parallel branch alongside the inherited conditional
+                # decision.
+                has_no_routing = (
+                    not inherited_edges
+                    and not inherited_conditional
+                    and not inherited_entry
                 )
-                per_user_state_modified.conditional_entry = (
-                    persona_node_modified.conditional_entry
+                per_user_state_modified.edges = inherited_edges or (
+                    ["inject_current_datetime"] if has_no_routing else []
                 )
+                per_user_state_modified.conditional_edges = inherited_conditional
+                per_user_state_modified.conditional_entry = inherited_entry
                 # The persona now routes unconditionally to per_user_state only.
                 persona_node_modified.edges = ["per_user_state"]
                 persona_node_modified.conditional_edges = []

--- a/bili/flask_api/tests/test_flask_utils.py
+++ b/bili/flask_api/tests/test_flask_utils.py
@@ -680,6 +680,61 @@ class TestPerUserAgent:
             assert persona.edges == ["inject_current_datetime"]
             assert persona.conditional_edges == [("cond", "react_agent")]
 
+    def test_conditional_only_persona_gets_no_spurious_static_edge(self):
+        """A persona with only conditional routing keeps per_user_state static-edge-free."""
+        from bili.iris.nodes.add_persona_and_summary import (  # pylint: disable=import-outside-toplevel
+            persona_and_summary_node,
+        )
+
+        persona = persona_and_summary_node()
+        persona.edges = []  # no static routing
+        persona.conditional_edges = [("cond", "react_agent")]
+        persona.conditional_entry = None
+
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        decorated = per_user_agent(
+            checkpoint_saver=MagicMock(),
+            graph_definition=[persona],
+            node_kwargs={},
+        )(lambda: "ok")
+
+        with app.test_request_context():
+            g.user = {"uid": "u1"}
+            with patch("bili.flask_api.flask_utils.build_agent_graph") as mock_build:
+                decorated()
+            per_user_state_built = mock_build.call_args.kwargs["graph_definition"][1]
+            # No fallback static edge is synthesized; only the conditional route
+            # is inherited, preserving the original conditional-only semantics.
+            assert per_user_state_built.edges == []
+            assert per_user_state_built.conditional_edges == [("cond", "react_agent")]
+
+    def test_persona_with_no_routing_gets_fallback_edge(self):
+        """A persona with no routing at all falls back to a default static edge."""
+        from bili.iris.nodes.add_persona_and_summary import (  # pylint: disable=import-outside-toplevel
+            persona_and_summary_node,
+        )
+
+        persona = persona_and_summary_node()
+        persona.edges = []
+        persona.conditional_edges = []
+        persona.conditional_entry = None
+
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        decorated = per_user_agent(
+            checkpoint_saver=MagicMock(),
+            graph_definition=[persona],
+            node_kwargs={},
+        )(lambda: "ok")
+
+        with app.test_request_context():
+            g.user = {"uid": "u1"}
+            with patch("bili.flask_api.flask_utils.build_agent_graph") as mock_build:
+                decorated()
+            per_user_state_built = mock_build.call_args.kwargs["graph_definition"][1]
+            assert per_user_state_built.edges == ["inject_current_datetime"]
+
 
 def _set_cookie_headers(resp):
     """Return all Set-Cookie header values from a Flask test response."""

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ def read_http_git_requirements():
 
 setup(
     name="bili-core",
-    version="5.3.0",
+    version="5.3.1",
     # Detect runtime packages while excluding every test subpackage. Without
     # the exclude, find_packages() bundles 200+ .py test modules (under
     # bili/<component>/tests/ and bili/<component>/<subcomponent>/tests/)


### PR DESCRIPTION
## Release v5.3.1

Small follow-up to v5.3.0 closing the two substantive items the round-3 review surfaced on #180.

- **Coverage gate honesty:** omit `*/examples/*` in `.coveragerc`. The gate only checks files some test imports, so the unimported example workflow script was in scope but silently unmeasured. Examples are illustrative demos, not runtime logic, so they are now explicitly out of scope and "every non-omitted runtime file is enforced" is literally true.
- **per_user_agent:** only synthesize the fallback static edge when the persona had no routing at all. A persona with conditional-only routing previously received a spurious parallel static edge; now its conditional routing is preserved exactly. New tests cover the conditional-only and no-routing cases.

The other two round-3 findings (sync query methods callable from async; minor import-toast UX) were consciously declined: the sync methods are required by the mixin contract, and the UX items are cosmetic.

Full suite: 3200 passed. Per-file gate: all 187 runtime files >= 90%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
