### PR TITLE
ci: skip Semgrep and Claude review on dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,6 +9,7 @@ jobs:
   # findings comment so the Claude review job (which reads PR comments) folds the
   # results into its review. Replaces the metered claude-security-review.yml.
   semgrep:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -70,6 +71,7 @@ jobs:
           gh pr comment "$PR" --body-file semgrep-comment.md
 
   claude-review:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     needs: semgrep   # guarantees the Semgrep comment is posted before the review
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Dependabot PRs run with a read-only token and no Actions secrets, so claude-review errored on every dependabot PR. Guards both jobs with `if: github.actor != 'dependabot[bot]'`. Dependabot PRs still run test/build/lint/codeql.