### PR TITLE
chore: add CITATION.cff and bump to v5.3.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,91 @@
+cff-version: 1.2.0
+message: "If you use BiliCore in your research, please cite it using the metadata below."
+type: software
+title: "BiliCore: An Open-Source Framework for LLM-Powered Applications (IRIS / AETHER / AEGIS)"
+abstract: >
+  BiliCore is an open-source, MIT-licensed framework for building and testing
+  LLM-powered applications. It comprises three components: IRIS (Interactive
+  Reasoning and Integration Services) for single-agent orchestration across
+  60+ models from 6 providers; AETHER (Agent Ecosystems for Testing,
+  Hardening, Evaluation, and Research) for declarative multi-agent system
+  creation via YAML; and AEGIS (Adversarial Evaluation and Guarding of
+  Intelligent Systems) for security testing of multi-agent systems. Originally
+  developed for the Colorado Sustainability Hub at the Metropolitan State
+  University of Denver Community-Centered Computing (C3) Lab.
+# Authors are ordered by code contribution to the bili-core repository.
+# The list reflects software development; co-authors on papers that cite
+# BiliCore but did not contribute code are not included here.
+authors:
+  - given-names: Daniel
+    family-names: Pittman
+    email: dpittma8@msudenver.edu
+    affiliation: "Metropolitan State University of Denver, Department of Computer Sciences"
+    orcid: "https://orcid.org/0000-0002-0888-3587"
+  - given-names: Monica
+    family-names: Ball
+    email: mball14@msudenver.edu
+    affiliation: "Metropolitan State University of Denver, Department of Computer Sciences"
+  - given-names: Kade
+    family-names: Shockey
+    affiliation: "DreamFace Technologies LLC; alumnus, Metropolitan State University of Denver"
+  - given-names: Lombe
+    family-names: Chileshe
+    email: lombe.chileshe@du.edu
+    affiliation: "University of Denver"
+  - given-names: Jeremy
+    family-names: Dougherty
+    affiliation: "Metropolitan State University of Denver (alumnus)"
+  - given-names: Alyssa
+    family-names: Williams
+    email: awill157@msudenver.edu
+    affiliation: "Metropolitan State University of Denver, Community-Centered Computing (C3) Lab"
+version: 5.2.3
+date-released: 2026-06-11
+license: MIT
+repository-code: "https://github.com/msu-denver/bili-core"
+url: "https://github.com/msu-denver/bili-core"
+keywords:
+  - large language models
+  - multi-agent systems
+  - LLM evaluation
+  - AI security
+  - adversarial testing
+  - LangGraph
+  - research software
+  - sustainability
+  - open-source
+identifiers:
+  - type: url
+    value: "https://github.com/msu-denver/bili-core"
+    description: "BiliCore source repository"
+references:
+  - type: grant
+    title: "CISE-MSI:RPEP:III:Sustainability Hub - A Community Data Hub for Sustainable Regional Systems Research in Colorado"
+    institution:
+      name: "National Science Foundation"
+    number: "2318730"
+  - type: grant
+    title: "Advancing Colorado Sustainability: Leveraging AWS and Azure for Enhanced Data Accessibility and Retrieval"
+    institution:
+      name: "NSF NAIRR Pilot"
+    number: "NAIRR240197"
+preferred-citation:
+  type: software
+  title: "BiliCore: An Open-Source Framework for LLM-Powered Applications (IRIS / AETHER / AEGIS)"
+  authors:
+    - given-names: Daniel
+      family-names: Pittman
+      orcid: "https://orcid.org/0000-0002-0888-3587"
+    - given-names: Monica
+      family-names: Ball
+    - given-names: Kade
+      family-names: Shockey
+    - given-names: Lombe
+      family-names: Chileshe
+    - given-names: Jeremy
+      family-names: Dougherty
+    - given-names: Alyssa
+      family-names: Williams
+  year: 2026
+  version: 5.3.2
+  url: "https://github.com/msu-denver/bili-core"

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ def read_http_git_requirements():
 
 setup(
     name="bili-core",
-    version="5.3.1",
+    version="5.3.2",
     # Detect runtime packages while excluding every test subpackage. Without
     # the exclude, find_packages() bundles 200+ .py test modules (under
     # bili/<component>/tests/ and bili/<component>/<subcomponent>/tests/)


### PR DESCRIPTION
## Summary

- Adds a `CITATION.cff` describing bili-core as research software, ahead of enabling Zenodo's GitHub archive integration on the repo so that future releases mint a DOI for citation in papers, biosketches, and tenure files.
- Authors are listed as **software contributors only**, ordered by commit count: Pittman, Ball, Shockey, Chileshe, Dougherty, Williams. Paper co-authors who cite BiliCore but did not commit code (e.g. the Feb 2025 NAIRR poster's first author) are intentionally excluded — that's the distinction between a software citation and a paper citation.
- ORCID iDs are only filled in for Pittman in this revision. The other five iDs will be added in a follow-up PR once each contributor confirms theirs. CFF treats the field as optional, so the file is valid as-is.
- The `references:` block records NSF Award #2318730 and NAIRR Pilot Allocation NAIRR240197 so grant attribution travels with the citation.
- Bumps `setup.py` to **5.3.2** because this is a metadata-only release that mints the first Zenodo DOI.

## What happens after this merges

1. Tag and release `v5.3.2` from develop.
2. Zenodo's GitHub webhook fires, archives the source, and emits a concept DOI plus a version DOI.
3. The DOI gets added back to the bili-core entry in Pittman's ORCID, and the SciENcv biosketch then renders the bili-core citation with a proper \"Available from\" URL line (the issue that motivated this whole pass).

## Test plan

- [x] CITATION.cff lints as YAML
- [x] Black / Autoflake / Isort pre-commit hooks pass
- [ ] CI green
- [ ] After merge: tag, release, verify Zenodo archive lands