### PR TITLE
fix(citation): correct top-level CITATION.cff version to 5.3.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -39,8 +39,8 @@ authors:
     family-names: Williams
     email: awill157@msudenver.edu
     affiliation: "Metropolitan State University of Denver, Community-Centered Computing (C3) Lab"
-version: 5.2.3
-date-released: 2026-06-11
+version: 5.3.2
+date-released: 2026-06-12
 license: MIT
 repository-code: "https://github.com/msu-denver/bili-core"
 url: "https://github.com/msu-denver/bili-core"


### PR DESCRIPTION
## Summary

Follow-up to #195. The top-level \`CITATION.cff\` \`version:\` field was left at 5.2.3 while \`preferred-citation.version\` was correctly bumped to 5.3.2. Zenodo reads the **top-level** field for the version-DOI metadata it mints from a GitHub release, so the v5.3.2 archive would have been labeled 5.2.3.

Also bumps \`date-released\` to 2026-06-12 (the actual release date in UTC).

## Plan after merge

1. Delete the existing v5.3.2 tag + GitHub release (the Zenodo GitHub integration has not been enabled yet, so no DOI was minted from the original v5.3.2 — the tag rewrite is safe).
2. Re-tag v5.3.2 against this fix commit.
3. Re-create the v5.3.2 release.

## Test plan

- [x] Top-level \`version\` now reads 5.3.2 (matches \`preferred-citation.version\` and \`setup.py\`)
- [x] Pre-commit hooks pass
- [ ] CI green
- [ ] After merge: delete + re-cut v5.3.2 tag and release