### PR TITLE
ci: gate verdict via structured_output; bump claude-code-action v1.0.152

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        uses: anthropics/claude-code-action@51705da45eecce209d4700538bf8377d5b5fc695 # v1.0.152
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
@@ -224,11 +224,12 @@ jobs:
     # Only run when the review actually produced something to extract from.
     if: ${{ needs.claude-review.result == 'success' && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
-    # The verdict travels to the gate as a JOB OUTPUT parsed from the agent's
-    # execution log — NOT via a PR comment. claude-code-action's comment behavior
-    # is unreliable for a one-shot (track_progress on leaves an un-updated "I'll
-    # analyze this" placeholder; off posts no comment at all), but the agent's
-    # emitted line is always in the execution log, so we read it from there.
+    # The verdict travels to the gate as a JOB OUTPUT built from the action's
+    # STRUCTURED OUTPUT (claude-code-action's `--json-schema` feature, v1.0.152+):
+    # the agent returns schema-validated JSON in `structured_output`, which we read
+    # directly. This avoids both unreliable channels tried before — a PR comment
+    # (the one-shot's track_progress placeholder was flaky) and the execution-log
+    # file (its path is coupled to the action version and broke on a bump).
     outputs:
       verdict_line: ${{ steps.parse.outputs.verdict_line }}
     permissions:
@@ -263,63 +264,48 @@ jobs:
             exit 1
           fi
 
-      # SHA-pinned anthropics/claude-code-action v1.0.133 (same as the review).
-      # Cheap model (Haiku) — this is a one-line classification, not a review.
+      # SHA-pinned anthropics/claude-code-action v1.0.152. Cheap model (Haiku) —
+      # this is a one-shot classification, not a review. The verdict comes back as
+      # schema-validated STRUCTURED OUTPUT (the `--json-schema` claude_arg), exposed
+      # as steps.extract.outputs.structured_output — no comment, no log-file parse.
       - name: Extract the merge verdict
         id: extract
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        uses: anthropics/claude-code-action@51705da45eecce209d4700538bf8377d5b5fc695 # v1.0.152
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # track_progress off: we do NOT rely on the action posting a comment.
-          # The agent's one-line answer is read from its execution log by the
-          # parse step below. (With track_progress on, the action leaves an
-          # un-updated "I'll analyze this" placeholder on this tiny one-shot; with
-          # it off it posts no comment — either way the comment is not a reliable
-          # channel, so the execution log is the source of truth.)
+          # track_progress off: this is a data task, not a PR conversation; we read
+          # the result from structured_output, not a comment.
           track_progress: false
-          claude_args: '--model haiku'
-          # NOTE: the format example below uses <placeholders> ON PURPOSE — it must
-          # NOT contain a concrete `VERDICT=PASS COUNT=0`-style string, or the parse
-          # step's regex would false-match the prompt echoed in the execution log
-          # instead of the agent's real answer.
+          claude_args: |
+            --model haiku
+            --json-schema '{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","BLOCK"]},"count":{"type":"integer","minimum":0}},"required":["verdict","count"],"additionalProperties":false}'
           prompt: >-
             Read the file ./REVIEW.md in the repository — it is an automated code review of this
             pull request. Your ONLY task is to report its merge verdict. Count the findings the
             review itself rates HIGH or CRITICAL severity (a "CI Tests" FAILURE called out in the
             review also counts). Do NOT re-judge the diff, do NOT add findings of your own, and do
             NOT count MEDIUM/LOW findings, missing-test notes, or anything the review did not label
-            HIGH/CRITICAL. Respond with EXACTLY one line and NOTHING else — no preamble, no
-            acknowledgement, no "I'll analyze this". The line has this shape (substitute the
-            placeholders, do not emit them literally):
-            MERGE-VERDICT-GATE VERDICT=<PASS-or-BLOCK> COUNT=<integer>
-            Use VERDICT=PASS with the count as zero when the review has zero HIGH/CRITICAL
-            findings; otherwise VERDICT=BLOCK with the count set to the number of HIGH/CRITICAL
-            findings.
+            HIGH/CRITICAL. Return verdict="PASS" with count=0 when the review has zero HIGH/CRITICAL
+            findings; otherwise verdict="BLOCK" with count set to the number of HIGH/CRITICAL findings.
 
-      - name: Parse the verdict from the execution log
+      - name: Build the verdict line from the structured output
         id: parse
         env:
-          EXEC_FILE: ${{ steps.extract.outputs.execution_file }}
+          STRUCTURED: ${{ steps.extract.outputs.structured_output }}
         run: |
           set -uo pipefail
-          # The agent's emitted verdict line lives in claude-code-action's execution
-          # log (it does not post a usable comment for a one-shot). Read it from
-          # there — schema-tolerant: prefer the final result text via jq, fall back
-          # to a raw scan. The prompt above uses <placeholders>, so it contributes
-          # no concrete `VERDICT=... COUNT=N` string for the regex to false-match;
-          # only the agent's real answer matches, and tail -1 takes the last (the
-          # answer comes after any input context in the log).
-          f="${EXEC_FILE:-}"
-          [ -n "$f" ] && [ -f "$f" ] || f="$RUNNER_TEMP/claude-execution-output.json"
-          re='MERGE-VERDICT-GATE VERDICT=(PASS|BLOCK) COUNT=[0-9]+'
+          # structured_output is schema-validated JSON, e.g. {"verdict":"PASS","count":0}.
+          # Reconstruct the same MERGE-VERDICT-GATE line the gate already parses, so
+          # the gate logic is unchanged. Empty/garbled output -> empty line ->
+          # INCONCLUSIVE (never a silent PASS).
+          v=$(printf '%s' "${STRUCTURED:-}" | jq -r '.verdict // empty' 2>/dev/null || true)
+          c=$(printf '%s' "${STRUCTURED:-}" | jq -r '.count // empty'   2>/dev/null || true)
           line=""
-          if [ -f "$f" ]; then
-            final=$(jq -r 'if type=="array" then ([.[] | (.result? // (.message?.content[]? | select(.type=="text") | .text))] | map(select(.!=null)) | last // "") else (.result // "") end' "$f" 2>/dev/null || true)
-            line=$(printf '%s' "$final" | grep -oE "$re" | tail -1 || true)
-            [ -z "$line" ] && line=$(grep -oE "$re" "$f" | tail -1 || true)
-          else
-            echo "execution log not found at '$f'" >&2
+          if [ "$v" = "PASS" ] || [ "$v" = "BLOCK" ]; then
+            printf '%s' "$c" | grep -qE '^[0-9]+$' || c=0
+            line="MERGE-VERDICT-GATE VERDICT=$v COUNT=$c"
           fi
+          echo "structured_output: ${STRUCTURED:-<none>}"
           echo "Parsed verdict line: ${line:-<none>}"
           echo "verdict_line=$line" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Makes the gate robust across claude-code-action version bumps. The extractor now uses the action's **structured-output** feature (`--json-schema`) and reads the schema-validated result from `structured_output`, instead of parsing the execution-log file (whose path broke on the v1.0.133 -> v1.0.152 bump). No PR comment. Gate contract unchanged. Also bumps claude-code-action to v1.0.152. Ported from zenhub-cli (validated). Observe-only. Self-edit PR -> admin-merge via non-review checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)