### PR TITLE
feat(iris): LLMProvider abstraction interface and ProviderRegistry

### DIFF
--- a/bili/iris/__init__.py
+++ b/bili/iris/__init__.py
@@ -4,4 +4,11 @@ Single-agent orchestration framework. Provides LLM configuration for 60+
 models across 6 providers (AWS Bedrock, Google Vertex AI, Azure OpenAI,
 OpenAI, Ollama, local), a node-based workflow pipeline, extensible tool
 system, middleware framework, and state persistence via checkpointers.
+
+Provider abstraction
+--------------------
+``bili.iris.providers`` exposes the ``LLMProvider`` abstract base class and
+``ProviderRegistry`` that unify all provider shapes behind a single
+``.invoke()`` contract.  Third-party providers can be registered at
+application startup via :func:`bili.iris.providers.register_provider`.
 """

--- a/bili/iris/loaders/llm_loader.py
+++ b/bili/iris/loaders/llm_loader.py
@@ -133,6 +133,16 @@ def load_model(
     # This if/elif block is intentionally preserved for backward compatibility;
     # the individual loader functions are part of the public API and may be
     # imported and called directly by consumers (e.g. sustainability-hub-engine).
+    #
+    # Follow-up (delegation refactor): each branch below duplicates logic that
+    # also lives in the corresponding LLMProvider class in bili.iris.providers.
+    # The clean fix is to delegate these branches to provider_class().load(**kwargs)
+    # so there is one implementation per backend. The blocker is the
+    # @conditional_cache_resource() decorator on each load_* function — removing
+    # it would silently change caching behavior for existing callers. Once a
+    # cache-aware delegation path exists (or caching is lifted into the caller),
+    # replace this block with: provider_class = PROVIDER_REGISTRY.get(model_type);
+    # llm_model = provider_class().load(**kwargs).
     if model_type == "local_llamacpp":
         llm_model = load_llamacpp_model(**kwargs)
     elif model_type == "local_huggingface":

--- a/bili/iris/loaders/llm_loader.py
+++ b/bili/iris/loaders/llm_loader.py
@@ -3,8 +3,14 @@ Module: llm_loader
 
 This module provides functions to load and initialize various language models for LangChain.
 It supports local models (LlamaCpp, HuggingFace) and remote models
-(Google Vertex AI, AWS Bedrock, Azure OpenAI).
-The functions are conditionally cached to optimize resource usage in Streamlit applications.
+(Google Vertex AI, AWS Bedrock, Azure OpenAI, OpenAI direct).
+
+The six built-in provider types are dispatched directly by ``load_model()``.
+Additional provider types — registered at application startup via
+``bili.iris.providers.register_provider()`` — are discovered through the
+``bili.iris.providers.PROVIDER_REGISTRY`` when the built-in dispatch does not
+match.  This allows third-party provider implementations to integrate without
+modifying this module.
 
 Functions:
     - load_model(model_type, **kwargs):
@@ -54,6 +60,12 @@ Example:
         max_tokens=100,
         temperature=0.7
     )
+
+    # Load a provider registered at startup via register_provider()
+    from bili.iris.providers import register_provider
+    from mypackage import MyProvider
+    register_provider("remote_my_api", MyProvider)
+    model = load_model("remote_my_api", model_name="my-model")
 """
 
 import gc
@@ -100,22 +112,27 @@ def load_model(
     routes to the appropriate loader function depending on whether the model type
     is local or hosted remotely on cloud services.
 
-    :param model_type: Specifies the type of the model to be loaded. The value determines
-        which loader function will be called. Supported types are "local_llamacpp",
-        "local_huggingface", "remote_google_vertex", "remote_aws_bedrock", and
-        "remote_azure_openai".
+    :param model_type: Specifies the type of the model to be loaded. Built-in
+        supported types are ``"local_llamacpp"``, ``"local_huggingface"``,
+        ``"remote_google_vertex"``, ``"remote_aws_bedrock"``,
+        ``"remote_azure_openai"``, and ``"remote_openai"``.  Additional types
+        registered via ``bili.iris.providers.register_provider()`` are also
+        supported through the provider registry.
     :type model_type: str
     :param kwargs: Additional keyword arguments specific to the loader function for
         the chosen model type. These arguments differ depending on the model type.
     :type kwargs: dict
     :return: The loaded model object as returned by the appropriate model loader
         function. The return value may differ in format depending on the chosen
-        model type.
+        model type, but always exposes an ``.invoke(messages)`` method.
     :rtype: object
-    :raises ValueError: If the specified model_type is not one of the supported
-        values, this exception will be raised.
+    :raises ValueError: If the specified model_type is not one of the built-in
+        types and is not registered in the provider registry.
     """
-    # Based on model_type, call the appropriate loader function
+    # Built-in provider dispatch — handles the six types shipped with bili-core.
+    # This if/elif block is intentionally preserved for backward compatibility;
+    # the individual loader functions are part of the public API and may be
+    # imported and called directly by consumers (e.g. sustainability-hub-engine).
     if model_type == "local_llamacpp":
         llm_model = load_llamacpp_model(**kwargs)
     elif model_type == "local_huggingface":
@@ -129,7 +146,22 @@ def load_model(
     elif model_type == "remote_openai":
         llm_model = load_remote_openai(**kwargs)
     else:
-        raise ValueError(f"Invalid model type: {model_type}")
+        # Fall through to the provider registry for third-party / extended
+        # provider types registered at startup via register_provider().
+        # Lazy import to avoid circular dependency and module-level overhead.
+        from bili.iris.providers.registry import (  # pylint: disable=import-outside-toplevel
+            PROVIDER_REGISTRY,
+        )
+
+        provider_class = PROVIDER_REGISTRY.get(model_type)
+        if provider_class is None:
+            raise ValueError(f"Invalid model type: {model_type}")
+        LOGGER.info(
+            "Delegating model_type '%s' to registered provider: %s",
+            model_type,
+            provider_class.__name__,
+        )
+        llm_model = provider_class().load(**kwargs)
 
     return llm_model
 

--- a/bili/iris/providers/__init__.py
+++ b/bili/iris/providers/__init__.py
@@ -28,6 +28,17 @@ Heavy dependencies (cloud SDKs, torch, etc.) MUST be imported inside the
 subpackage import without installing optional dependencies.
 """
 
+# Import builtin after the public API is defined so the side-effect
+# (populating PROVIDER_REGISTRY with the six built-in providers) runs after
+# the registry singleton exists.  Any code that does
+# `from bili.iris.providers import ...` — including the lazy import in
+# llm_loader.py's else branch — triggers this registration automatically, so
+# the registry is always populated on the production path without a separate
+# explicit call.  The isort: skip comment keeps isort from hoisting this above
+# the functional imports.
+from . import (  # noqa: F401  pylint: disable=wrong-import-position  # isort: skip
+    builtin as _builtin,
+)
 from .base import LLMProvider
 from .registry import (
     PROVIDER_REGISTRY,

--- a/bili/iris/providers/__init__.py
+++ b/bili/iris/providers/__init__.py
@@ -1,0 +1,45 @@
+"""LLM provider abstraction layer for bili-core IRIS.
+
+This subpackage defines the ``LLMProvider`` abstract base class and the
+``ProviderRegistry`` that maps provider-type strings to their concrete
+implementations.  It establishes the seam through which all provider
+shapes — LangChain-native API chat models, subprocess/CLI providers, and
+MCP-backed providers — are reached from a single ``load_model()`` call.
+
+Public API
+----------
+- :class:`LLMProvider`  — abstract base all providers implement
+- :class:`ProviderRegistry` — maps type strings to ``LLMProvider`` classes
+- :data:`PROVIDER_REGISTRY` — the module-level singleton registry instance
+- :func:`register_provider` — convenience for runtime provider registration
+- :func:`get_provider` — look up a registered provider class
+
+Design contract
+---------------
+Every concrete provider MUST override ``load(**kwargs)`` and return any
+object with a ``.invoke(messages)`` method.  Providers need not be
+LangChain ``BaseChatModel`` subclasses; the only required interface is the
+``.invoke()`` method (plus optional ``.stream()`` / ``.astream()``).
+
+Lazy imports
+------------
+Heavy dependencies (cloud SDKs, torch, etc.) MUST be imported inside the
+``load()`` method body, never at module scope.  This lets the providers
+subpackage import without installing optional dependencies.
+"""
+
+from .base import LLMProvider
+from .registry import (
+    PROVIDER_REGISTRY,
+    ProviderRegistry,
+    get_provider,
+    register_provider,
+)
+
+__all__ = [
+    "LLMProvider",
+    "ProviderRegistry",
+    "PROVIDER_REGISTRY",
+    "register_provider",
+    "get_provider",
+]

--- a/bili/iris/providers/azure_openai_provider.py
+++ b/bili/iris/providers/azure_openai_provider.py
@@ -31,7 +31,10 @@ class AzureOpenAIProvider(LLMProvider):
     model_name : str
         Azure deployment name (e.g. ``"gpt-41"``).
     api_version : str
-        Azure OpenAI REST API version (e.g. ``"2024-08-01-preview"``).
+        Azure OpenAI REST API version string (e.g. ``"2025-01-01-preview"``).
+        Required. No default is provided here to match the contract of
+        ``load_remote_azure_openai``; the caller must supply the version
+        explicitly so it cannot silently drift.
     max_tokens : int, optional
         Maximum completion tokens (mapped to ``max_completion_tokens``).
     temperature : float, optional
@@ -47,7 +50,7 @@ class AzureOpenAIProvider(LLMProvider):
     def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments
         self,
         model_name: str,
-        api_version: str = "2024-08-01-preview",
+        api_version: str,
         max_tokens: Optional[int] = None,
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
@@ -58,7 +61,8 @@ class AzureOpenAIProvider(LLMProvider):
         """Create and return an ``AzureChatOpenAI`` instance.
 
         :param model_name: Azure deployment name.
-        :param api_version: REST API version string.
+        :param api_version: REST API version string. Required; no default is
+            provided so the caller cannot silently use a stale version.
         :returns: An ``AzureChatOpenAI`` instance.
         :raises ImportError: If ``langchain_openai`` is not installed.
         """

--- a/bili/iris/providers/azure_openai_provider.py
+++ b/bili/iris/providers/azure_openai_provider.py
@@ -1,0 +1,92 @@
+"""Azure OpenAI provider for bili-core IRIS.
+
+Wraps ``langchain_openai.AzureChatOpenAI`` behind the :class:`LLMProvider`
+interface.  Supports GPT-4.x, GPT-3.5, and reasoning (o1/o3/o4) model
+families available through Azure OpenAI Service.
+
+Authentication reads ``AZURE_OPENAI_API_KEY`` and ``AZURE_OPENAI_ENDPOINT``
+from the environment (LangChain OpenAI defaults).
+
+Heavy dependencies
+------------------
+``langchain_openai`` is imported inside :meth:`AzureOpenAIProvider.load` to
+avoid module-level import cost when this provider is not in use.
+"""
+
+# pylint: disable=duplicate-code
+import logging
+from typing import Any, Optional
+
+from .base import LLMProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=too-few-public-methods
+class AzureOpenAIProvider(LLMProvider):
+    """LangChain-native Azure OpenAI Service provider.
+
+    Accepted kwargs
+    ---------------
+    model_name : str
+        Azure deployment name (e.g. ``"gpt-41"``).
+    api_version : str
+        Azure OpenAI REST API version (e.g. ``"2024-08-01-preview"``).
+    max_tokens : int, optional
+        Maximum completion tokens (mapped to ``max_completion_tokens``).
+    temperature : float, optional
+        Sampling temperature.
+    top_p : float, optional
+        Nucleus sampling probability.
+    top_k : int, optional
+        Top-k sampling limit (forwarded; provider may ignore).
+    seed : int, optional
+        Random seed for reproducibility.
+    """
+
+    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments
+        self,
+        model_name: str,
+        api_version: str = "2024-08-01-preview",
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        top_k: Optional[int] = None,
+        seed: Optional[int] = None,
+        **_extra: Any,
+    ) -> Any:
+        """Create and return an ``AzureChatOpenAI`` instance.
+
+        :param model_name: Azure deployment name.
+        :param api_version: REST API version string.
+        :returns: An ``AzureChatOpenAI`` instance.
+        :raises ImportError: If ``langchain_openai`` is not installed.
+        """
+        from langchain_openai import (  # pylint: disable=import-outside-toplevel
+            AzureChatOpenAI,
+        )
+
+        LOGGER.info(
+            "Initializing Azure OpenAI model: %s, API version: %s",
+            model_name,
+            api_version,
+        )
+
+        config: dict = {
+            "azure_deployment": model_name,
+            "api_version": api_version,
+        }
+        if temperature:
+            config["temperature"] = temperature
+        if max_tokens:
+            config["max_completion_tokens"] = max_tokens
+        if top_p:
+            config["top_p"] = top_p
+        if top_k:
+            config["top_k"] = top_k
+        if seed:
+            config["seed"] = seed
+
+        llm = AzureChatOpenAI(**config)
+        LOGGER.debug(llm)
+        return llm

--- a/bili/iris/providers/base.py
+++ b/bili/iris/providers/base.py
@@ -1,0 +1,112 @@
+"""Abstract base class for bili-core LLM providers.
+
+All provider implementations — LangChain-native API chat models,
+subprocess/CLI providers, and MCP-backed providers — inherit from
+``LLMProvider`` and implement :meth:`load`.
+
+The returned object from :meth:`load` must expose an ``.invoke(messages)``
+method that accepts a list of ``langchain_core.messages.BaseMessage`` objects
+and returns a response with a ``.content`` attribute.  Concrete providers
+need not subclass any LangChain base class; the duck-typed ``.invoke()``
+contract is sufficient for compatibility with both IRIS node pipelines and
+AETHER agent nodes.
+
+Provider type strings
+---------------------
+Each concrete subclass is identified by a *provider type string* — a plain
+str used as the key in :class:`~bili.iris.providers.registry.ProviderRegistry`
+and in ``LLM_MODELS`` catalog entries.  Established values are listed in
+:data:`KNOWN_PROVIDER_TYPES` for reference; implementations are not
+constrained to that list.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+# ProviderRegistry uses these strings as keys.  The list is informational;
+# the registry itself is the authoritative source of which types are active.
+KNOWN_PROVIDER_TYPES = frozenset(
+    {
+        # LangChain-native remote API providers
+        "remote_aws_bedrock",
+        "remote_google_vertex",
+        "remote_azure_openai",
+        "remote_openai",
+        # Local in-process providers
+        "local_llamacpp",
+        "local_huggingface",
+        # Future provider shapes (not yet implemented)
+        # "cli"   — subprocess / stdin-stdout transport
+        # "mcp"   — Model Context Protocol server transport
+    }
+)
+
+
+# pylint: disable=too-few-public-methods
+class LLMProvider(ABC):
+    """Abstract base class for all bili-core LLM providers.
+
+    Subclasses represent a single *provider shape* — a transport mechanism
+    and credential strategy for obtaining LLM completions.  Concrete
+    examples: an AWS Bedrock chat model, a local LlamaCpp model, a future
+    subprocess-based CLI provider, or a future MCP-server-backed provider.
+
+    Each concrete provider intentionally exposes only the single ``load()``
+    method; providers are lightweight factory objects, not service classes.
+
+    Usage
+    -----
+    Subclasses are not instantiated per-call.  Instead the registry maps a
+    provider-type string to the *class*, and :meth:`load` is called via
+    ``ProviderClass().load(**kwargs)``::
+
+        from bili.iris.providers import get_provider
+
+        ProviderClass = get_provider("remote_aws_bedrock")
+        llm = ProviderClass().load(model_name="...", max_tokens=4096)
+
+    For typical usage prefer :func:`bili.iris.loaders.llm_loader.load_model`,
+    which handles provider lookup and delegation automatically.
+
+    Implementing a new provider
+    ---------------------------
+    1. Create a module under ``bili/iris/providers/`` (e.g.
+       ``anthropic_provider.py``).
+    2. Subclass ``LLMProvider`` and implement :meth:`load`.
+    3. Import any heavy SDK *inside* :meth:`load` (never at module scope).
+    4. Register the provider at startup::
+
+           from bili.iris.providers import register_provider
+           from bili.iris.providers.my_provider import MyProvider
+
+           register_provider("remote_my_api", MyProvider)
+
+    Parameter signature
+    -------------------
+    Concrete overrides of :meth:`load` SHOULD declare explicit keyword
+    parameters rather than relying solely on ``**kwargs``.  This makes
+    accepted parameters discoverable via introspection and IDE tooling.
+    Pylint ``arguments-differ`` warnings are suppressed on concrete
+    subclasses because the abstract signature intentionally uses only
+    ``**kwargs`` as the lowest-common-denominator contract.
+    """
+
+    @abstractmethod
+    def load(self, **kwargs: Any) -> Any:
+        """Instantiate and return an LLM client object.
+
+        Implementations MUST import any heavy dependencies (cloud SDKs,
+        ``torch``, etc.) inside this method body rather than at module scope.
+
+        :param kwargs: Provider-specific keyword arguments (e.g.
+            ``model_name``, ``max_tokens``, ``temperature``).  Each provider
+            documents its accepted kwargs in its own docstring.
+        :returns: An object with an ``.invoke(messages)`` method that accepts
+            a list of ``langchain_core.messages.BaseMessage`` objects and
+            returns a response with a ``.content`` attribute.  The object
+            may additionally expose ``.stream()`` and ``.astream()`` for
+            streaming support.
+        :raises ValueError: For invalid or missing required kwargs.
+        :raises ImportError: If a required optional dependency is not
+            installed.
+        """

--- a/bili/iris/providers/bedrock_provider.py
+++ b/bili/iris/providers/bedrock_provider.py
@@ -1,0 +1,88 @@
+"""AWS Bedrock provider for bili-core IRIS.
+
+Wraps ``langchain_aws.ChatBedrockConverse`` behind the :class:`LLMProvider`
+interface.  Supports all models available through the AWS Bedrock Converse API
+(Amazon Nova, Anthropic Claude, Meta Llama, Mistral, Cohere, DeepSeek, and
+others catalogued in ``bili.iris.config.llm_config.LLM_MODELS``).
+
+Authentication uses the standard AWS credential chain (environment variables,
+``~/.aws/credentials``, IAM instance profiles, etc.).
+
+Heavy dependencies
+------------------
+``langchain_aws`` and its underlying ``boto3`` SDK are imported inside
+:meth:`BedrockProvider.load` to avoid module-level import cost when the
+AWS provider is not in use.
+"""
+
+# pylint: disable=duplicate-code
+import logging
+from typing import Any, Optional
+
+from .base import LLMProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=too-few-public-methods
+class BedrockProvider(LLMProvider):
+    """LangChain-native AWS Bedrock Converse API provider.
+
+    Accepted kwargs
+    ---------------
+    model_name : str
+        The Bedrock model ID (e.g. ``"us.anthropic.claude-opus-4-20250514-v1:0"``).
+    max_tokens : int, optional
+        Maximum tokens in the model response.
+    temperature : float, optional
+        Sampling temperature (0.0 = deterministic, 1.0 = creative).
+    top_p : float, optional
+        Nucleus sampling probability threshold.
+    top_k : int, optional
+        Top-k sampling limit.
+    seed : int, optional
+        Random seed for reproducibility.
+    """
+
+    def load(  # pylint: disable=arguments-differ
+        self,
+        model_name: str,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        top_k: Optional[int] = None,
+        seed: Optional[int] = None,
+        **_extra: Any,
+    ) -> Any:
+        """Create and return a ``ChatBedrockConverse`` instance.
+
+        :param model_name: Bedrock model ID.
+        :param max_tokens: Maximum response tokens.
+        :param temperature: Sampling temperature.
+        :param top_p: Nucleus sampling probability.
+        :param top_k: Top-k token limit.
+        :param seed: Random seed.
+        :returns: A ``ChatBedrockConverse`` instance.
+        :raises ImportError: If ``langchain_aws`` is not installed.
+        """
+        from langchain_aws import (  # pylint: disable=import-outside-toplevel
+            ChatBedrockConverse,
+        )
+
+        LOGGER.info("Initializing AWS Bedrock model: %s", model_name)
+
+        config: dict = {"model_id": model_name}
+        if max_tokens:
+            config["max_tokens"] = max_tokens
+        if temperature:
+            config["temperature"] = temperature
+        if top_p:
+            config["top_p"] = top_p
+        if top_k:
+            config["top_k"] = top_k
+        if seed:
+            config["seed"] = seed
+
+        llm = ChatBedrockConverse(**config)
+        LOGGER.debug(llm)
+        return llm

--- a/bili/iris/providers/builtin.py
+++ b/bili/iris/providers/builtin.py
@@ -1,0 +1,62 @@
+"""Register all built-in providers in the global ``PROVIDER_REGISTRY``.
+
+Importing this module has the side effect of populating
+:data:`~bili.iris.providers.registry.PROVIDER_REGISTRY` with the six
+provider types shipped with bili-core.  It is imported once inside
+:func:`bili.iris.loaders.llm_loader.load_model` at first call.
+
+External provider authors do NOT import this module; they call
+:func:`~bili.iris.providers.registry.register_provider` directly from their
+own code at application startup.
+
+Built-in provider types
+-----------------------
+=========================  ============================================
+Provider type string        Implementation class
+=========================  ============================================
+``remote_aws_bedrock``      :class:`~.bedrock_provider.BedrockProvider`
+``remote_google_vertex``    :class:`~.vertex_provider.VertexAIProvider`
+``remote_azure_openai``     :class:`~.azure_openai_provider.AzureOpenAIProvider`
+``remote_openai``           :class:`~.openai_provider.OpenAIProvider`
+``local_llamacpp``          :class:`~.llamacpp_provider.LlamaCppProvider`
+``local_huggingface``       :class:`~.huggingface_provider.HuggingFaceProvider`
+=========================  ============================================
+"""
+
+import logging
+
+from .azure_openai_provider import AzureOpenAIProvider
+from .bedrock_provider import BedrockProvider
+from .huggingface_provider import HuggingFaceProvider
+from .llamacpp_provider import LlamaCppProvider
+from .openai_provider import OpenAIProvider
+from .registry import PROVIDER_REGISTRY
+from .vertex_provider import VertexAIProvider
+
+LOGGER = logging.getLogger(__name__)
+
+_BUILTIN_PROVIDERS = {
+    "remote_aws_bedrock": BedrockProvider,
+    "remote_google_vertex": VertexAIProvider,
+    "remote_azure_openai": AzureOpenAIProvider,
+    "remote_openai": OpenAIProvider,
+    "local_llamacpp": LlamaCppProvider,
+    "local_huggingface": HuggingFaceProvider,
+}
+
+
+def _register_builtins() -> None:
+    """Populate ``PROVIDER_REGISTRY`` with built-in providers (idempotent).
+
+    Safe to call multiple times; already-registered types are skipped
+    so repeated imports (e.g. in tests) do not raise ``ValueError``.
+    """
+    for provider_type, provider_class in _BUILTIN_PROVIDERS.items():
+        if provider_type not in PROVIDER_REGISTRY:
+            PROVIDER_REGISTRY.register(provider_type, provider_class)
+            LOGGER.debug("Built-in provider registered: '%s'", provider_type)
+        else:
+            LOGGER.debug("Built-in provider already registered: '%s'", provider_type)
+
+
+_register_builtins()

--- a/bili/iris/providers/huggingface_provider.py
+++ b/bili/iris/providers/huggingface_provider.py
@@ -1,0 +1,128 @@
+"""Local HuggingFace provider for bili-core IRIS.
+
+Wraps ``langchain_huggingface.ChatHuggingFace`` behind the
+:class:`LLMProvider` interface for loading models from the HuggingFace Hub or
+a local directory.
+
+Note: ``ChatHuggingFace`` does not currently support automatic tool calling.
+See ``bili.iris.config.llm_config.LLM_MODELS`` for the ``supports_tools: False``
+flag on this provider's entries.
+
+Heavy dependencies
+------------------
+``torch``, ``transformers``, and ``langchain_huggingface`` are imported inside
+:meth:`HuggingFaceProvider.load` to avoid loading heavy ML frameworks when
+this provider is not in use.
+"""
+
+import gc
+import logging
+from typing import Any, Optional
+
+from .base import LLMProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=too-few-public-methods
+class HuggingFaceProvider(LLMProvider):
+    """Local HuggingFace in-process model provider.
+
+    Accepted kwargs
+    ---------------
+    model_name : str
+        HuggingFace model name or local directory path.
+    max_tokens : int, optional
+        Maximum tokens to generate (``max_new_tokens``).
+    temperature : float, optional
+        Sampling temperature.
+    top_p : float, optional
+        Nucleus sampling probability.
+    top_k : int, optional
+        Top-k sampling limit.
+    seed : int, optional
+        Random seed for reproducibility.
+    """
+
+    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments,too-many-locals
+        self,
+        model_name: str,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        top_k: Optional[int] = None,
+        seed: Optional[int] = None,
+        **_extra: Any,
+    ) -> Any:
+        """Load and return a ``ChatHuggingFace`` instance.
+
+        Loads the model into memory using ``AutoModelForCausalLM`` with
+        ``device_map="auto"`` so the framework selects the best available
+        device (CUDA, Apple MPS, or CPU).
+
+        :param model_name: HuggingFace model ID or local path.
+        :returns: A ``ChatHuggingFace`` instance wrapping a text-generation
+            pipeline.
+        :raises ImportError: If ``torch``, ``transformers``, or
+            ``langchain_huggingface`` are not installed.
+        """
+        # pylint: disable=import-outside-toplevel
+        import torch
+        from langchain_huggingface.chat_models.huggingface import (
+            ChatHuggingFace,
+            HuggingFacePipeline,
+        )
+        from transformers import AutoModelForCausalLM, pipeline
+
+        from bili.iris.loaders.tokenizer_loader import load_huggingface_tokenizer
+
+        LOGGER.info("Loading HuggingFace model from %s", model_name)
+
+        tokenizer = load_huggingface_tokenizer(model_name)
+
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+        model = AutoModelForCausalLM.from_pretrained(
+            model_name,
+            torch_dtype=torch.float16,
+            trust_remote_code=True,
+            device_map="auto",
+            offload_folder="/tmp/model_offload",
+        )
+
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
+        model.config.pad_token_id = model.config.eos_token_id
+
+        generation_config: dict = {
+            "do_sample": True,
+            "repetition_penalty": 1.176,
+        }
+        if top_p is not None:
+            generation_config["top_p"] = top_p
+        if top_k is not None:
+            generation_config["top_k"] = top_k
+        if seed is not None:
+            generation_config["seed"] = seed
+        if max_tokens is not None:
+            generation_config["max_new_tokens"] = max_tokens
+        if temperature is not None:
+            generation_config["temperature"] = temperature
+
+        text_pipeline = pipeline(
+            device_map="auto",
+            trust_remote_code=True,
+            torch_dtype=torch.float16,
+            task="text-generation",
+            return_full_text=False,
+            model=model,
+            tokenizer=tokenizer,
+            **generation_config,
+        )
+
+        hf_pipeline = HuggingFacePipeline(pipeline=text_pipeline)
+        chat_hf = ChatHuggingFace(llm=hf_pipeline)
+        LOGGER.debug(chat_hf)
+        return chat_hf

--- a/bili/iris/providers/llamacpp_provider.py
+++ b/bili/iris/providers/llamacpp_provider.py
@@ -1,0 +1,88 @@
+"""Local LlamaCpp provider for bili-core IRIS.
+
+Wraps ``langchain_community.chat_models.ChatLlamaCpp`` behind the
+:class:`LLMProvider` interface for loading GGUF-format models from disk.
+
+Note: LlamaCpp does not currently support automatic tool calling.  See
+``bili.iris.config.llm_config.LLM_MODELS`` for the ``supports_tools: False``
+flag on this provider's entries.
+
+Heavy dependencies
+------------------
+``langchain_community`` is imported inside :meth:`LlamaCppProvider.load` to
+avoid loading the large community package when this provider is not in use.
+"""
+
+import logging
+from typing import Any, Optional
+
+from .base import LLMProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=too-few-public-methods
+class LlamaCppProvider(LLMProvider):
+    """Local LlamaCpp in-process model provider.
+
+    Accepted kwargs
+    ---------------
+    model_name : str
+        Absolute path to the GGUF model file.
+    max_tokens : int, optional
+        Maximum tokens to generate.
+    temperature : float, optional
+        Sampling temperature.
+    top_p : float, optional
+        Nucleus sampling probability.
+    top_k : int, optional
+        Top-k sampling limit.
+    seed : int, optional
+        Random seed for reproducibility.
+    """
+
+    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments
+        self,
+        model_name: str,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        top_k: Optional[int] = None,
+        seed: Optional[int] = None,
+        **_extra: Any,
+    ) -> Any:
+        """Load and return a ``ChatLlamaCpp`` instance.
+
+        :param model_name: Path to the GGUF model file.
+        :returns: A ``ChatLlamaCpp`` instance.
+        :raises ImportError: If ``langchain_community`` is not installed.
+        """
+        from langchain_community.chat_models import (  # pylint: disable=import-outside-toplevel
+            ChatLlamaCpp,
+        )
+
+        LOGGER.info("Loading LlamaCpp model from %s", model_name)
+
+        params: dict = {
+            "model_path": model_name,
+            "n_ctx": 4096,
+            "n_gpu_layers": 512,
+            "n_batch": 30,
+            "n_parts": 1,
+            "repeat_penalty": 1.176,
+            "f16_kv": True,
+        }
+        if seed:
+            params["seed"] = seed
+        if top_p:
+            params["top_p"] = top_p
+        if top_k:
+            params["top_k"] = top_k
+        if temperature:
+            params["temperature"] = temperature
+        if max_tokens:
+            params["max_tokens"] = max_tokens
+
+        llm = ChatLlamaCpp(**params)  # pylint: disable=E1102
+        LOGGER.debug(llm)
+        return llm

--- a/bili/iris/providers/openai_provider.py
+++ b/bili/iris/providers/openai_provider.py
@@ -1,0 +1,85 @@
+"""OpenAI provider for bili-core IRIS.
+
+Wraps ``langchain_openai.ChatOpenAI`` behind the :class:`LLMProvider`
+interface.  Supports GPT-4.x, GPT-3.5, and reasoning model families
+available through the OpenAI API.
+
+Authentication reads ``OPENAI_API_KEY`` from the environment.
+
+Heavy dependencies
+------------------
+``langchain_openai`` is imported inside :meth:`OpenAIProvider.load` to
+avoid module-level import cost when this provider is not in use.
+"""
+
+# pylint: disable=duplicate-code
+import logging
+from typing import Any, Optional
+
+from .base import LLMProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=too-few-public-methods
+class OpenAIProvider(LLMProvider):
+    """LangChain-native OpenAI API provider.
+
+    Accepted kwargs
+    ---------------
+    model_name : str
+        OpenAI model identifier (e.g. ``"gpt-4o"``, ``"o3-mini"``).
+    max_tokens : int, optional
+        Maximum completion tokens (mapped to ``max_completion_tokens``).
+    temperature : float, optional
+        Sampling temperature.
+    top_p : float, optional
+        Nucleus sampling probability.
+    top_k : int, optional
+        Top-k sampling limit (forwarded; provider may ignore).
+    seed : int, optional
+        Random seed for reproducibility.
+    max_retries : int, optional
+        Maximum number of automatic retries on transient errors.
+    """
+
+    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments
+        self,
+        model_name: str,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        top_k: Optional[int] = None,
+        seed: Optional[int] = None,
+        max_retries: Optional[int] = None,
+        **_extra: Any,
+    ) -> Any:
+        """Create and return a ``ChatOpenAI`` instance.
+
+        :param model_name: OpenAI model identifier.
+        :returns: A ``ChatOpenAI`` instance.
+        :raises ImportError: If ``langchain_openai`` is not installed.
+        """
+        from langchain_openai import (  # pylint: disable=import-outside-toplevel
+            ChatOpenAI,
+        )
+
+        LOGGER.info("Initializing OpenAI model: %s", model_name)
+
+        config: dict = {"model": model_name}
+        if temperature:
+            config["temperature"] = temperature
+        if max_tokens:
+            config["max_completion_tokens"] = max_tokens
+        if top_p:
+            config["top_p"] = top_p
+        if top_k:
+            config["top_k"] = top_k
+        if seed:
+            config["seed"] = seed
+        if max_retries:
+            config["max_retries"] = max_retries
+
+        llm = ChatOpenAI(**config)
+        LOGGER.debug(llm)
+        return llm

--- a/bili/iris/providers/registry.py
+++ b/bili/iris/providers/registry.py
@@ -1,0 +1,172 @@
+"""Provider registry — maps provider-type strings to ``LLMProvider`` classes.
+
+The registry is the authoritative routing table for :func:`load_model`.
+Registration of built-in providers happens in
+:mod:`bili.iris.providers.builtin` at module import time; external code can
+register additional providers at application startup via
+:func:`register_provider`.
+
+Thread-safety
+-------------
+The registry is not thread-safe for concurrent mutation.  All registrations
+must happen at application startup before the application begins serving
+requests.  This mirrors the same constraint documented for
+``GRAPH_NODE_REGISTRY`` in ``bili/iris/loaders/langchain_loader.py``.
+"""
+
+import logging
+from typing import Dict, Optional, Type
+
+from .base import LLMProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ProviderRegistry:
+    """Maps provider-type strings to :class:`~bili.iris.providers.base.LLMProvider` classes.
+
+    The registry stores the *class*, not an instance.  Callers instantiate
+    and invoke :meth:`~bili.iris.providers.base.LLMProvider.load` themselves
+    (or via the convenience :func:`load_model` function in
+    :mod:`bili.iris.loaders.llm_loader`).
+
+    Example::
+
+        registry = ProviderRegistry()
+        registry.register("remote_openai", OpenAIProvider)
+        ProviderClass = registry.get("remote_openai")
+        llm = ProviderClass().load(model_name="gpt-4o", max_tokens=1024)
+    """
+
+    def __init__(self) -> None:
+        self._providers: Dict[str, Type[LLMProvider]] = {}
+
+    def register(self, provider_type: str, provider_class: Type[LLMProvider]) -> None:
+        """Register a provider class for a given provider-type string.
+
+        :param provider_type: The provider-type key used in ``LLM_MODELS``
+            and passed to :func:`~bili.iris.loaders.llm_loader.load_model`
+            (e.g. ``"remote_aws_bedrock"``).
+        :param provider_class: A concrete subclass of :class:`LLMProvider`.
+        :raises TypeError: If ``provider_class`` is not a subclass of
+            :class:`LLMProvider`.
+        :raises ValueError: If ``provider_type`` is already registered.
+            Call :meth:`unregister` first to replace a built-in.
+
+        Note:
+            Registration should happen at application startup, before the
+            application begins serving requests.  The registry is not
+            thread-safe for concurrent mutation.
+        """
+        if not (
+            isinstance(provider_class, type) and issubclass(provider_class, LLMProvider)
+        ):
+            raise TypeError(
+                f"provider_class must be a subclass of LLMProvider, got {provider_class!r}"
+            )
+        if provider_type in self._providers:
+            raise ValueError(
+                f"Provider type '{provider_type}' is already registered. "
+                "Call unregister() first to replace it."
+            )
+        self._providers[provider_type] = provider_class
+        LOGGER.debug(
+            "Registered provider '%s' → %s", provider_type, provider_class.__name__
+        )
+
+    def unregister(self, provider_type: str) -> None:
+        """Remove a provider registration.
+
+        Primarily useful for test teardown or intentional replacement of a
+        built-in provider.
+
+        :param provider_type: The provider-type key to remove.
+        :raises KeyError: If ``provider_type`` is not registered.
+        """
+        if provider_type not in self._providers:
+            raise KeyError(
+                f"Provider type '{provider_type}' is not registered. "
+                f"Available: {sorted(self._providers)}"
+            )
+        del self._providers[provider_type]
+        LOGGER.debug("Unregistered provider '%s'", provider_type)
+
+    def get(self, provider_type: str) -> Optional[Type[LLMProvider]]:
+        """Return the provider class for a type string, or ``None``.
+
+        :param provider_type: The provider-type key to look up.
+        :returns: The registered :class:`LLMProvider` subclass, or ``None``
+            if no provider is registered for that type.
+        """
+        return self._providers.get(provider_type)
+
+    def get_or_raise(self, provider_type: str) -> Type[LLMProvider]:
+        """Return the provider class, raising ``ValueError`` if not found.
+
+        :param provider_type: The provider-type key to look up.
+        :returns: The registered :class:`LLMProvider` subclass.
+        :raises ValueError: If ``provider_type`` is not registered.
+        """
+        provider = self._providers.get(provider_type)
+        if provider is None:
+            available = sorted(self._providers)
+            raise ValueError(
+                f"Invalid model type: '{provider_type}'. "
+                f"Registered types: {available}. "
+                "To add a new provider, call register_provider() at application startup."
+            )
+        return provider
+
+    def list_types(self) -> list:
+        """Return a sorted list of registered provider-type strings."""
+        return sorted(self._providers)
+
+    def __contains__(self, provider_type: str) -> bool:
+        return provider_type in self._providers
+
+    def __len__(self) -> int:
+        return len(self._providers)
+
+    def __repr__(self) -> str:
+        return f"ProviderRegistry({self.list_types()})"
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+#: The global provider registry instance.  Built-in providers are registered
+#: by importing :mod:`bili.iris.providers.builtin`.  External providers can
+#: be added at startup via :func:`register_provider`.
+PROVIDER_REGISTRY = ProviderRegistry()
+
+
+def register_provider(provider_type: str, provider_class: Type[LLMProvider]) -> None:
+    """Register a provider class in the global registry.
+
+    Convenience wrapper around :meth:`ProviderRegistry.register` targeting
+    the module-level :data:`PROVIDER_REGISTRY` singleton.
+
+    :param provider_type: Provider-type key (e.g. ``"remote_my_api"``).
+    :param provider_class: A concrete :class:`LLMProvider` subclass.
+
+    Example::
+
+        from bili.iris.providers import register_provider
+        from mypackage.my_provider import MyProvider
+
+        register_provider("remote_my_api", MyProvider)
+    """
+    PROVIDER_REGISTRY.register(provider_type, provider_class)
+
+
+def get_provider(provider_type: str) -> Optional[Type[LLMProvider]]:
+    """Look up a provider class in the global registry.
+
+    Returns ``None`` if the provider type is not registered.  Prefer
+    :func:`~bili.iris.loaders.llm_loader.load_model` for typical usage.
+
+    :param provider_type: Provider-type key to look up.
+    :returns: The :class:`LLMProvider` subclass or ``None``.
+    """
+    return PROVIDER_REGISTRY.get(provider_type)

--- a/bili/iris/providers/tests/test_provider_interface.py
+++ b/bili/iris/providers/tests/test_provider_interface.py
@@ -233,6 +233,84 @@ class TestBuiltinRegistration:
 
 
 # ---------------------------------------------------------------------------
+# Registry population on the production path (not just after test setup)
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryPopulatedOnProductionPath:
+    """Verify the registry is populated whenever the production code path runs.
+
+    The production path in load_model() does:
+        from bili.iris.providers.registry import PROVIDER_REGISTRY
+    Importing bili.iris.providers.registry does NOT by itself populate the
+    registry. The population happens via bili.iris.providers.__init__, which
+    now imports builtin as a side effect.
+
+    These tests confirm that:
+    1. Importing the providers PACKAGE (not just registry.py) populates
+       PROVIDER_REGISTRY with all six built-in types.
+    2. The registry object imported in the tests IS the same singleton
+       that the llm_loader else-branch would access, so tests and production
+       share state correctly.
+    """
+
+    def test_providers_package_import_populates_registry(self):
+        """Verify that importing bili.iris.providers populates PROVIDER_REGISTRY.
+
+        The test module imports from bili.iris.providers at the top level, which
+        triggers builtin registration via __init__.py. This test confirms that
+        state is present and not just an artifact of how the test file loaded.
+        """
+        # PROVIDER_REGISTRY is the same object imported at module top level.
+        # If __init__ correctly imports builtin, all six types must be present.
+        for provider_type in _EXPECTED_BUILTIN_TYPES:
+            assert provider_type in PROVIDER_REGISTRY, (
+                f"Production-path registry missing '{provider_type}'. "
+                "Check that bili/iris/providers/__init__.py imports builtin."
+            )
+
+    def test_registry_singleton_shared_with_loader_path(self):
+        """Verify registry imported via providers.registry is the same singleton."""
+        import importlib  # pylint: disable=import-outside-toplevel
+
+        registry_mod = importlib.import_module("bili.iris.providers.registry")
+        # PROVIDER_REGISTRY from the top-level import and from direct registry
+        # module access must be the same object (same id).
+        assert registry_mod.PROVIDER_REGISTRY is PROVIDER_REGISTRY, (
+            "PROVIDER_REGISTRY is not a singleton: "
+            "bili.iris.providers.PROVIDER_REGISTRY and "
+            "bili.iris.providers.registry.PROVIDER_REGISTRY differ."
+        )
+        # And the singleton must be populated.
+        for provider_type in _EXPECTED_BUILTIN_TYPES:
+            assert provider_type in registry_mod.PROVIDER_REGISTRY
+
+    def test_load_model_else_branch_reaches_populated_registry(self):
+        """Verify load_model() else branch finds a populated registry.
+
+        Simulates the production path: a third-party type is registered, then
+        load_model() is called with that type. If PROVIDER_REGISTRY were empty
+        the call would raise ValueError even for newly registered types.
+        """
+        from bili.iris.loaders.llm_loader import (  # pylint: disable=import-outside-toplevel
+            load_model,
+        )
+
+        mock_llm = MagicMock()
+
+        class _ProductionPathProvider(LLMProvider):
+            def load(self, **kwargs):
+                return mock_llm
+
+        register_provider("test_production_path_type", _ProductionPathProvider)
+        try:
+            result = load_model("test_production_path_type", model_name="test")
+            assert result is mock_llm
+        finally:
+            PROVIDER_REGISTRY.unregister("test_production_path_type")
+
+
+# ---------------------------------------------------------------------------
 # Convenience functions
 # ---------------------------------------------------------------------------
 
@@ -345,6 +423,19 @@ class TestVertexAIProvider:
 
 class TestAzureOpenAIProvider:
     """Verify AzureOpenAIProvider.load() constructs AzureChatOpenAI correctly."""
+
+    def test_api_version_is_required(self):
+        """Verify load() raises TypeError when api_version is omitted.
+
+        api_version has no default so the caller cannot silently use a stale
+        version string.  This test pins that contract.
+        """
+        mock_cls = MagicMock()
+        with patch("langchain_openai.AzureChatOpenAI", mock_cls):
+            with pytest.raises(TypeError):
+                AzureOpenAIProvider().load(  # pylint: disable=no-value-for-parameter
+                    model_name="gpt-4"
+                )
 
     def test_minimal_load(self):
         """Verify minimal config passes azure_deployment and api_version."""

--- a/bili/iris/providers/tests/test_provider_interface.py
+++ b/bili/iris/providers/tests/test_provider_interface.py
@@ -1,0 +1,566 @@
+"""Tests for the bili-core provider abstraction layer.
+
+Covers:
+- ``LLMProvider`` abstract base class contract
+- ``ProviderRegistry`` registration, lookup, error paths
+- ``builtin`` registration (idempotency and completeness)
+- Each concrete provider's ``load()`` method with mocked heavy dependencies
+- ``load_model()`` routing through the registry (backward-compat layer)
+- Module-level convenience functions (``register_provider``, ``get_provider``)
+"""
+
+# pylint: disable=too-few-public-methods,duplicate-code
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import bili.iris.providers.builtin  # noqa: F401  pylint: disable=unused-import
+from bili.iris.providers.azure_openai_provider import AzureOpenAIProvider
+from bili.iris.providers.base import KNOWN_PROVIDER_TYPES, LLMProvider
+from bili.iris.providers.bedrock_provider import BedrockProvider
+from bili.iris.providers.huggingface_provider import HuggingFaceProvider
+from bili.iris.providers.llamacpp_provider import LlamaCppProvider
+from bili.iris.providers.openai_provider import OpenAIProvider
+from bili.iris.providers.registry import (
+    PROVIDER_REGISTRY,
+    ProviderRegistry,
+    get_provider,
+    register_provider,
+)
+from bili.iris.providers.vertex_provider import VertexAIProvider
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_provider(name: str = "TestProvider") -> type:
+    """Return a minimal concrete LLMProvider subclass for test use."""
+
+    class _P(LLMProvider):
+        def load(self, **kwargs):
+            return MagicMock()
+
+    _P.__name__ = name
+    _P.__qualname__ = name
+    return _P
+
+
+# ---------------------------------------------------------------------------
+# LLMProvider — abstract base contract
+# ---------------------------------------------------------------------------
+
+
+class TestLLMProviderAbstractBase:
+    """Verify the abstract base cannot be instantiated and enforces load()."""
+
+    def test_cannot_instantiate_abstract_base(self):
+        """Verify direct instantiation of LLMProvider raises TypeError."""
+        with pytest.raises(TypeError):
+            LLMProvider()  # pylint: disable=abstract-class-instantiated
+
+    def test_concrete_subclass_without_load_raises(self):
+        """Verify a subclass missing load() cannot be instantiated."""
+
+        class IncompleteProvider(LLMProvider):
+            """Incomplete provider missing load()."""
+
+        with pytest.raises(TypeError):
+            IncompleteProvider()  # pylint: disable=abstract-class-instantiated
+
+    def test_concrete_subclass_with_load_instantiates(self):
+        """Verify a complete concrete subclass can be instantiated."""
+        provider = _minimal_provider()()
+        assert isinstance(provider, LLMProvider)
+
+    def test_load_returns_invokeable_object(self):
+        """Verify load() returns an object with .invoke()."""
+
+        class InvokeProvider(LLMProvider):
+            """Minimal provider whose load() returns an invokeable mock."""
+
+            def load(self, **kwargs):
+                mock_llm = MagicMock()
+                mock_llm.invoke = MagicMock(return_value=MagicMock(content="ok"))
+                return mock_llm
+
+        llm = InvokeProvider().load(model_name="test")
+        result = llm.invoke([])
+        assert result.content == "ok"
+
+    def test_known_provider_types_is_frozenset(self):
+        """Verify KNOWN_PROVIDER_TYPES is an immutable frozenset."""
+        assert isinstance(KNOWN_PROVIDER_TYPES, frozenset)
+        assert "remote_aws_bedrock" in KNOWN_PROVIDER_TYPES
+        assert "remote_google_vertex" in KNOWN_PROVIDER_TYPES
+        assert "remote_openai" in KNOWN_PROVIDER_TYPES
+        assert "local_llamacpp" in KNOWN_PROVIDER_TYPES
+        assert "local_huggingface" in KNOWN_PROVIDER_TYPES
+
+
+# ---------------------------------------------------------------------------
+# ProviderRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestProviderRegistry:
+    """Verify ProviderRegistry registration, lookup, and error paths."""
+
+    def test_register_and_get(self):
+        """Verify register() + get() round-trips correctly."""
+        registry = ProviderRegistry()
+        cls = _minimal_provider()
+        registry.register("test_type", cls)
+        assert registry.get("test_type") is cls
+
+    def test_get_unknown_returns_none(self):
+        """Verify get() returns None for unregistered types."""
+        registry = ProviderRegistry()
+        assert registry.get("nonexistent") is None
+
+    def test_get_or_raise_raises_for_unknown(self):
+        """Verify get_or_raise() raises ValueError for unknown types."""
+        registry = ProviderRegistry()
+        with pytest.raises(ValueError, match="Invalid model type"):
+            registry.get_or_raise("nonexistent")
+
+    def test_get_or_raise_returns_class_for_known(self):
+        """Verify get_or_raise() returns the class for known types."""
+        registry = ProviderRegistry()
+        cls = _minimal_provider()
+        registry.register("known_type", cls)
+        assert registry.get_or_raise("known_type") is cls
+
+    def test_duplicate_registration_raises(self):
+        """Verify registering the same type twice raises ValueError."""
+        registry = ProviderRegistry()
+        cls = _minimal_provider()
+        registry.register("dupe_type", cls)
+        with pytest.raises(ValueError, match="already registered"):
+            registry.register("dupe_type", cls)
+
+    def test_unregister_removes_entry(self):
+        """Verify unregister() removes the provider."""
+        registry = ProviderRegistry()
+        cls = _minimal_provider()
+        registry.register("to_remove", cls)
+        registry.unregister("to_remove")
+        assert registry.get("to_remove") is None
+
+    def test_unregister_unknown_raises_key_error(self):
+        """Verify unregistering a non-existent type raises KeyError."""
+        registry = ProviderRegistry()
+        with pytest.raises(KeyError):
+            registry.unregister("not_there")
+
+    def test_register_non_provider_raises_type_error(self):
+        """Verify registering a non-LLMProvider class raises TypeError."""
+        registry = ProviderRegistry()
+        with pytest.raises(TypeError, match="subclass of LLMProvider"):
+            registry.register("bad", str)
+
+    def test_contains_operator(self):
+        """Verify 'in' operator works on registry."""
+        registry = ProviderRegistry()
+        cls = _minimal_provider()
+        registry.register("check_type", cls)
+        assert "check_type" in registry
+        assert "other_type" not in registry
+
+    def test_len(self):
+        """Verify len() reflects number of registered providers."""
+        registry = ProviderRegistry()
+        assert len(registry) == 0
+        cls = _minimal_provider()
+        registry.register("t1", cls)
+        assert len(registry) == 1
+
+    def test_list_types_sorted(self):
+        """Verify list_types() returns sorted provider type strings."""
+        registry = ProviderRegistry()
+        registry.register("b_type", _minimal_provider("B"))
+        registry.register("a_type", _minimal_provider("A"))
+        assert registry.list_types() == ["a_type", "b_type"]
+
+    def test_repr(self):
+        """Verify repr includes the sorted type list."""
+        registry = ProviderRegistry()
+        registry.register("repr_type", _minimal_provider())
+        assert "repr_type" in repr(registry)
+
+
+# ---------------------------------------------------------------------------
+# Builtin registration
+# ---------------------------------------------------------------------------
+
+_EXPECTED_BUILTIN_TYPES = {
+    "remote_aws_bedrock",
+    "remote_google_vertex",
+    "remote_azure_openai",
+    "remote_openai",
+    "local_llamacpp",
+    "local_huggingface",
+}
+
+
+class TestBuiltinRegistration:
+    """Verify all six built-in providers are registered in PROVIDER_REGISTRY."""
+
+    def test_all_builtins_registered(self):
+        """Verify all six built-in provider types are in PROVIDER_REGISTRY."""
+        for provider_type in _EXPECTED_BUILTIN_TYPES:
+            assert (
+                provider_type in PROVIDER_REGISTRY
+            ), f"Expected '{provider_type}' in PROVIDER_REGISTRY"
+
+    def test_builtin_providers_are_llmprovider_subclasses(self):
+        """Verify every registered built-in is an LLMProvider subclass."""
+        for provider_type in _EXPECTED_BUILTIN_TYPES:
+            cls = PROVIDER_REGISTRY.get(provider_type)
+            assert cls is not None
+            assert issubclass(
+                cls, LLMProvider
+            ), f"Provider '{provider_type}' → {cls} is not an LLMProvider subclass"
+
+    def test_double_import_does_not_raise(self):
+        """Verify importing builtin twice does not raise ValueError."""
+        # The import at the top of this file already triggered registration.
+        # A second import must be idempotent.
+        import importlib  # pylint: disable=import-outside-toplevel
+
+        importlib.import_module("bili.iris.providers.builtin")
+
+
+# ---------------------------------------------------------------------------
+# Convenience functions
+# ---------------------------------------------------------------------------
+
+
+class TestConvenienceFunctions:
+    """Verify module-level register_provider() and get_provider()."""
+
+    def test_get_provider_returns_none_for_unknown(self):
+        """Verify get_provider() returns None for unregistered type."""
+        result = get_provider("__definitely_not_registered__")
+        assert result is None
+
+    def test_get_provider_returns_class_for_registered(self):
+        """Verify get_provider() returns the class for a registered type."""
+        cls = get_provider("remote_openai")
+        assert cls is not None
+        assert issubclass(cls, LLMProvider)
+
+    def test_register_provider_and_retrieve(self):
+        """Verify register_provider() adds to PROVIDER_REGISTRY."""
+        cls = _minimal_provider("ConvenienceProvider")
+        register_provider("test_convenience_type", cls)
+        try:
+            retrieved = get_provider("test_convenience_type")
+            assert retrieved is cls
+        finally:
+            PROVIDER_REGISTRY.unregister("test_convenience_type")
+
+
+# ---------------------------------------------------------------------------
+# Concrete providers — mocked load() calls
+# ---------------------------------------------------------------------------
+
+
+class TestBedrockProvider:
+    """Verify BedrockProvider.load() constructs ChatBedrockConverse correctly."""
+
+    def test_minimal_load(self):
+        """Verify minimal config calls ChatBedrockConverse with model_id only."""
+        mock_cls = MagicMock()
+        with patch("langchain_aws.ChatBedrockConverse", mock_cls):
+            BedrockProvider().load(model_name="test-model")
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model_id"] == "test-model"
+
+    def test_full_config(self):
+        """Verify all optional params are forwarded to ChatBedrockConverse."""
+        mock_cls = MagicMock()
+        with patch("langchain_aws.ChatBedrockConverse", mock_cls):
+            BedrockProvider().load(
+                model_name="claude-v2",
+                max_tokens=100,
+                temperature=0.5,
+                top_p=0.9,
+                top_k=40,
+                seed=42,
+            )
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model_id"] == "claude-v2"
+        assert kwargs["max_tokens"] == 100
+        assert kwargs["temperature"] == 0.5
+        assert kwargs["top_p"] == 0.9
+        assert kwargs["top_k"] == 40
+        assert kwargs["seed"] == 42
+
+    def test_extra_kwargs_ignored(self):
+        """Verify unexpected kwargs do not raise errors."""
+        mock_cls = MagicMock()
+        with patch("langchain_aws.ChatBedrockConverse", mock_cls):
+            BedrockProvider().load(model_name="m", unknown_extra="ignored")
+        assert mock_cls.called
+
+
+class TestVertexAIProvider:
+    """Verify VertexAIProvider.load() constructs ChatVertexAI correctly."""
+
+    def test_minimal_load(self):
+        """Verify minimal config passes model_name to ChatVertexAI."""
+        mock_cls = MagicMock()
+        with patch("langchain_google_vertexai.ChatVertexAI", mock_cls):
+            VertexAIProvider().load(model_name="gemini-pro")
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model_name"] == "gemini-pro"
+
+    def test_all_optional_params(self):
+        """Verify every optional param is forwarded to ChatVertexAI."""
+        mock_cls = MagicMock()
+        schema = {"type": "object"}
+        with patch("langchain_google_vertexai.ChatVertexAI", mock_cls):
+            VertexAIProvider().load(
+                model_name="gemini-pro",
+                max_tokens=100,
+                temperature=0.5,
+                top_p=0.9,
+                top_k=20,
+                seed=3,
+                response_mime_type="application/json",
+                response_schema=schema,
+                additional_headers={"X-Test": "1"},
+                location="global",
+            )
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["max_output_tokens"] == 100
+        assert kwargs["temperature"] == 0.5
+        assert kwargs["response_mime_type"] == "application/json"
+        assert kwargs["response_schema"] == schema
+        assert kwargs["additional_headers"] == {"X-Test": "1"}
+        assert kwargs["location"] == "global"
+
+
+class TestAzureOpenAIProvider:
+    """Verify AzureOpenAIProvider.load() constructs AzureChatOpenAI correctly."""
+
+    def test_minimal_load(self):
+        """Verify minimal config passes azure_deployment and api_version."""
+        mock_cls = MagicMock()
+        with patch("langchain_openai.AzureChatOpenAI", mock_cls):
+            AzureOpenAIProvider().load(model_name="gpt-4", api_version="2024-01")
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["azure_deployment"] == "gpt-4"
+        assert kwargs["api_version"] == "2024-01"
+
+    def test_full_config(self):
+        """Verify all optional params are forwarded to AzureChatOpenAI."""
+        mock_cls = MagicMock()
+        with patch("langchain_openai.AzureChatOpenAI", mock_cls):
+            AzureOpenAIProvider().load(
+                model_name="gpt-4",
+                api_version="2024-01",
+                max_tokens=200,
+                temperature=0.7,
+                top_p=0.95,
+                seed=123,
+            )
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["max_completion_tokens"] == 200
+        assert kwargs["temperature"] == 0.7
+        assert kwargs["top_p"] == 0.95
+        assert kwargs["seed"] == 123
+
+
+class TestOpenAIProvider:
+    """Verify OpenAIProvider.load() constructs ChatOpenAI correctly."""
+
+    def test_minimal_load(self):
+        """Verify minimal config passes model to ChatOpenAI."""
+        mock_cls = MagicMock()
+        with patch("langchain_openai.ChatOpenAI", mock_cls):
+            OpenAIProvider().load(model_name="gpt-4o")
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model"] == "gpt-4o"
+
+    def test_full_config(self):
+        """Verify all optional params are forwarded to ChatOpenAI."""
+        mock_cls = MagicMock()
+        with patch("langchain_openai.ChatOpenAI", mock_cls):
+            OpenAIProvider().load(
+                model_name="gpt-4o",
+                max_tokens=500,
+                temperature=0.3,
+                top_p=0.8,
+                seed=7,
+                max_retries=3,
+            )
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model"] == "gpt-4o"
+        assert kwargs["max_completion_tokens"] == 500
+        assert kwargs["temperature"] == 0.3
+        assert kwargs["max_retries"] == 3
+
+
+class TestLlamaCppProvider:
+    """Verify LlamaCppProvider.load() constructs ChatLlamaCpp correctly."""
+
+    def test_full_config(self):
+        """Verify all optional params are merged into the LlamaCpp config."""
+        mock_cls = MagicMock()
+        with patch("langchain_community.chat_models.ChatLlamaCpp", mock_cls):
+            LlamaCppProvider().load(
+                model_name="model.gguf",
+                max_tokens=256,
+                temperature=0.8,
+                top_p=0.95,
+                top_k=50,
+                seed=11,
+            )
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model_path"] == "model.gguf"
+        assert kwargs["n_ctx"] == 4096
+        assert kwargs["max_tokens"] == 256
+        assert kwargs["temperature"] == 0.8
+        assert kwargs["top_p"] == 0.95
+        assert kwargs["top_k"] == 50
+        assert kwargs["seed"] == 11
+
+    def test_minimal_config_omits_optional(self):
+        """Verify optional params are absent when not provided."""
+        mock_cls = MagicMock()
+        with patch("langchain_community.chat_models.ChatLlamaCpp", mock_cls):
+            LlamaCppProvider().load(model_name="model.gguf")
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model_path"] == "model.gguf"
+        for absent in ("max_tokens", "temperature", "top_p", "top_k", "seed"):
+            assert absent not in kwargs
+
+
+class TestHuggingFaceProvider:
+    """Verify HuggingFaceProvider.load() assembles the pipeline correctly."""
+
+    @patch("bili.iris.loaders.tokenizer_loader.load_huggingface_tokenizer")
+    @patch("torch.cuda.is_available", return_value=True)
+    @patch("torch.cuda.empty_cache")
+    @patch("transformers.AutoModelForCausalLM")
+    @patch("transformers.pipeline")
+    @patch(
+        "langchain_huggingface.chat_models.huggingface.HuggingFacePipeline",
+        create=True,
+    )
+    @patch(
+        "langchain_huggingface.chat_models.huggingface.ChatHuggingFace",
+        create=True,
+    )
+    def test_full_config(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        mock_chat,
+        mock_hf_pipe,  # pylint: disable=unused-argument
+        mock_pipe,
+        mock_auto,
+        mock_empty_cache,  # pylint: disable=unused-argument
+        mock_cuda_avail,  # pylint: disable=unused-argument
+        mock_tok,
+    ):
+        """Verify all optional params flow into the HuggingFace pipeline."""
+        tokenizer = MagicMock()
+        tokenizer.pad_token = None
+        tokenizer.eos_token = "</s>"
+        mock_tok.return_value = tokenizer
+        mock_auto.from_pretrained.return_value = MagicMock()
+        mock_chat.return_value = "chat_model"
+
+        result = HuggingFaceProvider().load(
+            model_name="gpt2",
+            max_tokens=128,
+            temperature=0.6,
+            top_p=0.9,
+            top_k=40,
+            seed=7,
+        )
+
+        assert result == "chat_model"
+        assert tokenizer.pad_token == "</s>"
+        pipe_kwargs = mock_pipe.call_args[1]
+        assert pipe_kwargs["task"] == "text-generation"
+        assert pipe_kwargs["max_new_tokens"] == 128
+        assert pipe_kwargs["temperature"] == 0.6
+
+
+# ---------------------------------------------------------------------------
+# load_model() backward-compat integration
+# ---------------------------------------------------------------------------
+
+
+class TestLoadModelBackwardCompat:
+    """Verify load_model() still works correctly after the refactor.
+
+    These tests confirm the existing public API is unchanged for all callers.
+    """
+
+    @patch("bili.iris.loaders.llm_loader.load_llamacpp_model")
+    def test_routes_llamacpp_unchanged(self, mock_loader):
+        """load_model('local_llamacpp') still routes to load_llamacpp_model."""
+        from bili.iris.loaders.llm_loader import (  # pylint: disable=import-outside-toplevel
+            load_model,
+        )
+
+        mock_loader.return_value = MagicMock()
+        result = load_model("local_llamacpp", model_name="m.gguf", max_tokens=50)
+        mock_loader.assert_called_once_with(model_name="m.gguf", max_tokens=50)
+        assert result is mock_loader.return_value
+
+    @patch("bili.iris.loaders.llm_loader.load_remote_bedrock_model")
+    def test_routes_bedrock_unchanged(self, mock_loader):
+        """load_model('remote_aws_bedrock') still routes to load_remote_bedrock_model."""
+        from bili.iris.loaders.llm_loader import (  # pylint: disable=import-outside-toplevel
+            load_model,
+        )
+
+        mock_loader.return_value = MagicMock()
+        result = load_model("remote_aws_bedrock", model_name="anthropic.claude-v2")
+        mock_loader.assert_called_once_with(model_name="anthropic.claude-v2")
+        assert result is mock_loader.return_value
+
+    @patch("bili.iris.loaders.llm_loader.load_remote_openai")
+    def test_routes_openai_unchanged(self, mock_loader):
+        """load_model('remote_openai') still routes to load_remote_openai."""
+        from bili.iris.loaders.llm_loader import (  # pylint: disable=import-outside-toplevel
+            load_model,
+        )
+
+        mock_loader.return_value = MagicMock()
+        result = load_model("remote_openai", model_name="gpt-4o")
+        mock_loader.assert_called_once_with(model_name="gpt-4o")
+        assert result is mock_loader.return_value
+
+    def test_invalid_type_still_raises_value_error(self):
+        """load_model() with unknown type still raises ValueError."""
+        from bili.iris.loaders.llm_loader import (  # pylint: disable=import-outside-toplevel
+            load_model,
+        )
+
+        with pytest.raises(ValueError, match="Invalid model type"):
+            load_model("__unknown_provider__", model_name="x")
+
+    def test_registered_provider_routes_through_registry(self):
+        """load_model() with a registered type delegates to the provider class."""
+        from bili.iris.loaders.llm_loader import (  # pylint: disable=import-outside-toplevel
+            load_model,
+        )
+
+        mock_llm = MagicMock()
+
+        class _RegistryProvider(LLMProvider):
+            def load(self, **kwargs):
+                return mock_llm
+
+        register_provider("test_registry_route", _RegistryProvider)
+        try:
+            result = load_model("test_registry_route", model_name="test")
+            assert result is mock_llm
+        finally:
+            PROVIDER_REGISTRY.unregister("test_registry_route")

--- a/bili/iris/providers/vertex_provider.py
+++ b/bili/iris/providers/vertex_provider.py
@@ -1,0 +1,101 @@
+"""Google Vertex AI provider for bili-core IRIS.
+
+Wraps ``langchain_google_vertexai.ChatVertexAI`` behind the
+:class:`LLMProvider` interface.  Supports all Gemini model generations
+catalogued in ``bili.iris.config.llm_config.LLM_MODELS``.
+
+Authentication uses Google Application Default Credentials (ADC):
+``gcloud auth application-default login`` or a service-account key pointed
+to by ``GOOGLE_APPLICATION_CREDENTIALS``.
+
+Heavy dependencies
+------------------
+``langchain_google_vertexai`` is imported inside :meth:`VertexAIProvider.load`
+to avoid module-level import cost when this provider is not in use.
+"""
+
+# pylint: disable=duplicate-code
+import logging
+from typing import Any, Optional
+
+from .base import LLMProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=too-few-public-methods
+class VertexAIProvider(LLMProvider):
+    """LangChain-native Google Vertex AI provider.
+
+    Accepted kwargs
+    ---------------
+    model_name : str
+        Vertex AI model name (e.g. ``"gemini-2.5-pro"``).
+    max_tokens : int, optional
+        Maximum output tokens (mapped to ``max_output_tokens``).
+    temperature : float, optional
+        Sampling temperature.
+    top_p : float, optional
+        Nucleus sampling probability.
+    top_k : int, optional
+        Top-k sampling limit.
+    seed : int, optional
+        Random seed for reproducibility.
+    response_mime_type : str, optional
+        MIME type for structured output (e.g. ``"application/json"``).
+    response_schema : dict, optional
+        JSON schema for structured output.
+    additional_headers : dict, optional
+        Extra HTTP headers (Priority PayGo, Provisioned Throughput, etc.).
+    location : str, optional
+        GCP region override (e.g. ``"us-central1"``, ``"global"``).
+    """
+
+    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments
+        self,
+        model_name: str,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        top_k: Optional[int] = None,
+        seed: Optional[int] = None,
+        response_schema: Optional[dict] = None,
+        response_mime_type: Optional[str] = None,
+        additional_headers: Optional[dict] = None,
+        location: Optional[str] = None,
+        **_extra: Any,
+    ) -> Any:
+        """Create and return a ``ChatVertexAI`` instance.
+
+        :returns: A ``ChatVertexAI`` instance.
+        :raises ImportError: If ``langchain_google_vertexai`` is not installed.
+        """
+        from langchain_google_vertexai import (  # pylint: disable=import-outside-toplevel
+            ChatVertexAI,
+        )
+
+        LOGGER.info("Initializing Google Vertex AI model: %s", model_name)
+
+        config: dict = {"model_name": model_name}
+        if max_tokens:
+            config["max_output_tokens"] = max_tokens
+        if temperature:
+            config["temperature"] = temperature
+        if top_p:
+            config["top_p"] = top_p
+        if top_k:
+            config["top_k"] = top_k
+        if seed:
+            config["seed"] = seed
+        if response_mime_type:
+            config["response_mime_type"] = response_mime_type
+        if response_schema:
+            config["response_schema"] = response_schema
+        if additional_headers:
+            config["additional_headers"] = additional_headers
+        if location:
+            config["location"] = location
+
+        llm = ChatVertexAI(**config)
+        LOGGER.debug(llm)
+        return llm


### PR DESCRIPTION
## Summary

Adds a formal provider interface layer in `bili/iris/providers/` that gives third-party code a stable extension point for registering new LLM backends — without forking, patching, or modifying the built-in dispatch in `load_model()`.

**New: `bili.iris.providers` subpackage**

- `LLMProvider` (ABC, `base.py`) — single abstract method `load(**kwargs) -> Any`, returning any object with a `.invoke()` method (LangChain chat-model protocol). The single-method design is intentional: it's the minimal contract every backend must satisfy, whether it's a remote API call, a local subprocess, or a future MCP server.
- `ProviderRegistry` (`registry.py`) — maps provider-type strings to `LLMProvider` subclasses. Supports `register` / `unregister` / `get` / `get_or_raise` / `list_types` plus `__contains__` / `__len__` / `__repr__`. Raises typed errors (TypeError for wrong base class, ValueError for duplicates/unknown types, KeyError for missing unregister target).
- `PROVIDER_REGISTRY` — module-level singleton. `register_provider()` and `get_provider()` convenience wrappers for the common case.
- Six built-in concrete providers — `BedrockProvider`, `VertexAIProvider`, `AzureOpenAIProvider`, `OpenAIProvider`, `LlamaCppProvider`, `HuggingFaceProvider` — each lifts the existing `load_*` logic behind the `LLMProvider` interface with all lazy imports preserved.
- `builtin.py` — idempotent registration of the six built-ins into `PROVIDER_REGISTRY` at import time.

**Backward-compatible `load_model()` hook (`bili/iris/loaders/llm_loader.py`)**

The existing six-branch `if/elif` dispatch is untouched. The `else` branch now falls through to `PROVIDER_REGISTRY.get(model_type)` before raising `ValueError`. Third-party providers registered at startup via `register_provider()` resolve transparently through the same public `load_model()` API. No existing call sites change.

**No signature changes** to `AgentSpec`, `MASExecutor`, `initialize_tools`, or `build_agent_graph`.

## Tests

40 new tests in `bili/iris/providers/tests/test_provider_interface.py`:

- `LLMProvider` abstract-base contract (can't instantiate, subclass without `load()` fails, invokeable return type)
- `ProviderRegistry` full CRUD — register, unregister, get, get_or_raise, duplicate detection, type-check on register, `__contains__`, `__len__`, `list_types` sort order, `__repr__`
- Built-in registration — all six types present, all are `LLMProvider` subclasses, double-import is idempotent
- Convenience functions — `get_provider` / `register_provider` round-trip
- Concrete provider `load()` — each of the six providers tested with mocked heavy dependencies (lazy imports patched at the package-string level)
- `load_model()` backward-compat routing — three built-in types verified unchanged, invalid type still raises `ValueError`, and a registered provider correctly routes through the registry

**Existing tests:** `bili/iris/loaders/tests/test_llm_loader.py` — 35 tests, all passing.

## Test plan

- [x] `pytest bili/iris/providers/tests/test_provider_interface.py` — 40/40 passed
- [x] `pytest bili/iris/loaders/tests/test_llm_loader.py` — 35/35 passed
- [x] `pylint bili/iris/providers/ --score=yes` — 10.00/10
- [x] Black / isort / autoflake — clean (pre-commit hook passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpXRrbE4UhL22Usj6UdEVQ