### PR TITLE
feat(iris): provider fallback-policy engine

### DIFF
--- a/bili/aether/compiler/llm_resolver.py
+++ b/bili/aether/compiler/llm_resolver.py
@@ -124,24 +124,38 @@ def resolve_provider(model_name: str) -> str:
 
 
 def create_llm(agent: AgentSpec) -> Any:
-    """Create a LangChain chat model instance from an ``AgentSpec``.
+    """Create a LangChain-compatible chat model from an ``AgentSpec``.
 
-    Lazy-imports ``bili.loaders.llm_loader.load_model`` and
-    ``bili.config.llm_config.LLM_MODELS`` so the compiler module can be
-    loaded without heavy dependencies.
+    Lazy-imports ``bili.iris.loaders.llm_loader.load_model`` and
+    ``bili.iris.config.llm_config.LLM_MODELS`` so the compiler module can
+    be loaded without heavy provider dependencies.
 
     The function resolves the display ``model_name`` to the actual
-    ``model_id`` expected by the provider, then delegates to
-    ``load_model`` with the correct parameter name for each provider.
+    ``model_id`` expected by the provider, then delegates to ``load_model``.
+
+    When ``agent.fallback_models`` is non-empty, the returned object is a
+    :class:`~bili.iris.providers.fallback.FallbackLLM` that transparently
+    tries each fallback provider on retryable errors (rate limits, transient
+    API failures).  The same ``temperature`` and ``max_tokens`` values are
+    applied to each fallback.  Callers see no difference — the returned
+    object always exposes ``.invoke()`` / ``.stream()`` / ``.astream()``.
+
+    When ``agent.fallback_models`` is empty (the default), this function
+    returns the primary LLM object directly — behaviour is identical to
+    before the fallback engine was introduced.
 
     Args:
         agent: An ``AgentSpec`` with ``model_name`` set.
 
     Returns:
-        A LangChain-compatible chat model ready for ``.invoke()``.
+        A chat model ready for ``.invoke()``.  Will be a plain LLM object
+        when no fallbacks are configured, or a
+        :class:`~bili.iris.providers.fallback.FallbackLLM` proxy when
+        ``agent.fallback_models`` is populated.
 
     Raises:
-        ValueError: If ``agent.model_name`` is ``None`` or unresolvable.
+        ValueError: If ``agent.model_name`` is ``None`` or unresolvable,
+            or if any fallback model name cannot be resolved.
     """
     if not agent.model_name:
         raise ValueError(
@@ -170,7 +184,43 @@ def create_llm(agent: AgentSpec) -> Any:
         load_model,
     )
 
-    return load_model(provider, **kwargs)
+    primary_llm = load_model(provider, **kwargs)
+
+    # --- Fallback engine (opt-in) -------------------------------------------
+    # If AgentSpec.fallback_models is empty, return the primary LLM directly.
+    # No change in behaviour for callers that do not configure fallbacks.
+    if not agent.fallback_models:
+        return primary_llm
+
+    # Build the ordered fallback chain from the AgentSpec's fallback_models
+    # list.  Each model name is resolved exactly like the primary model_name.
+    fallback_chain: List[Tuple[str, Dict[str, Any]]] = []
+    for fb_model_name in agent.fallback_models:
+        fb_provider, fb_model_id, fb_extra = _resolve_model_full(fb_model_name)
+        fb_kwargs: Dict[str, Any] = {**fb_extra, "model_name": fb_model_id}
+        if agent.temperature is not None:
+            fb_kwargs["temperature"] = agent.temperature
+        if agent.max_tokens is not None:
+            fb_kwargs["max_tokens"] = agent.max_tokens
+        fallback_chain.append((fb_provider, fb_kwargs))
+        LOGGER.debug(
+            "Agent '%s': registered fallback provider=%s, model_id=%s",
+            agent.agent_id,
+            fb_provider,
+            fb_model_id,
+        )
+
+    from bili.iris.providers.fallback import (  # noqa: E402  pylint: disable=import-outside-toplevel
+        build_fallback_llm,
+    )
+
+    LOGGER.info(
+        "Agent '%s': wrapping primary LLM with %d fallback(s): %s",
+        agent.agent_id,
+        len(fallback_chain),
+        [entry[0] for entry in fallback_chain],
+    )
+    return build_fallback_llm(primary_llm=primary_llm, fallback_chain=fallback_chain)
 
 
 def resolve_tools(agent: AgentSpec) -> list:

--- a/bili/aether/schema/agent_spec.py
+++ b/bili/aether/schema/agent_spec.py
@@ -106,6 +106,20 @@ class AgentSpec(BaseModel):
         None, ge=1, description="Maximum tokens in LLM response"
     )
 
+    fallback_models: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Ordered list of fallback model names to try when the primary "
+            "model fails with a transient error (rate limit, provider "
+            "unavailable, API timeout).  Each entry is resolved exactly like "
+            "``model_name`` — display name or model_id, looked up in "
+            "``LLM_MODELS`` then by heuristic.  The same ``temperature`` and "
+            "``max_tokens`` values from this AgentSpec are applied to each "
+            "fallback.  Leave empty (the default) to disable fallback "
+            "behaviour entirely."
+        ),
+    )
+
     # =========================================================================
     # CAPABILITIES & TOOLS
     # =========================================================================

--- a/bili/iris/providers/__init__.py
+++ b/bili/iris/providers/__init__.py
@@ -13,6 +13,12 @@ Public API
 - :data:`PROVIDER_REGISTRY` — the module-level singleton registry instance
 - :func:`register_provider` — convenience for runtime provider registration
 - :func:`get_provider` — look up a registered provider class
+- :class:`FallbackLLM` — transparent proxy that falls through an ordered
+  provider chain on retryable errors
+- :class:`FallbackPolicy` — classifies exceptions as retryable vs fatal
+- :class:`ProviderChain` — ordered ``(provider_type, kwargs)`` sequence
+- :func:`build_fallback_llm` — wrap an existing LLM with a fallback chain
+- :data:`DEFAULT_POLICY` — default name-based exception classification policy
 
 Design contract
 ---------------
@@ -40,6 +46,13 @@ from . import (  # noqa: F401  pylint: disable=wrong-import-position  # isort: s
     builtin as _builtin,
 )
 from .base import LLMProvider
+from .fallback import (
+    DEFAULT_POLICY,
+    FallbackLLM,
+    FallbackPolicy,
+    ProviderChain,
+    build_fallback_llm,
+)
 from .registry import (
     PROVIDER_REGISTRY,
     ProviderRegistry,
@@ -53,4 +66,9 @@ __all__ = [
     "PROVIDER_REGISTRY",
     "register_provider",
     "get_provider",
+    "FallbackLLM",
+    "FallbackPolicy",
+    "ProviderChain",
+    "build_fallback_llm",
+    "DEFAULT_POLICY",
 ]

--- a/bili/iris/providers/fallback.py
+++ b/bili/iris/providers/fallback.py
@@ -71,19 +71,28 @@ LOGGER = logging.getLogger(__name__)
 # hard imports of provider SDKs — providers that are not installed produce no
 # ImportError here.
 #
+# Only genuinely *transient* failures belong here: rate limits, timeouts,
+# connection drops, and provider-unavailable (HTTP 5xx).  Do NOT add base
+# exception classes that cover 4xx responses (auth failure, bad request,
+# not found, validation error); those are fatal and must not silently trigger
+# fallback, as that would mask misconfiguration and waste quota against every
+# fallback provider.
+#
+# In particular, ``APIStatusError`` (openai/anthropic) is the base class for
+# *all* status-coded errors including 401/403/400/422, so it must not be
+# listed here.  The specific subclasses below are the safe subset.
+#
 # Consumers can override the classification entirely via FallbackPolicy.
 _DEFAULT_RETRYABLE_NAMES: Tuple[str, ...] = (
-    # LangChain / LangChain-community base classes
-    "OutputParserException",  # transient parsing glitch
-    # openai SDK
+    # openai SDK — transient only
     "RateLimitError",
     "APIConnectionError",
     "APITimeoutError",
     "InternalServerError",
     "ServiceUnavailableError",
-    # anthropic SDK
+    # anthropic SDK — transient only
+    # "OverloadedError" is the Anthropic analogue of RateLimitError (HTTP 529)
     "OverloadedError",
-    "APIStatusError",
     # google-cloud / vertexai SDK
     "ResourceExhausted",
     "ServiceUnavailable",
@@ -92,8 +101,7 @@ _DEFAULT_RETRYABLE_NAMES: Tuple[str, ...] = (
     "ThrottlingException",
     "ServiceUnavailableException",
     "ModelTimeoutException",
-    "ModelErrorException",
-    # generic Python
+    # generic Python network/IO
     "TimeoutError",
     "ConnectionError",
     "ConnectionResetError",
@@ -102,12 +110,16 @@ _DEFAULT_RETRYABLE_NAMES: Tuple[str, ...] = (
 
 
 def _is_retryable_by_name(exc: BaseException) -> bool:
-    """Return True if the exception's class name is in the default retryable set."""
-    exc_type_name = type(exc).__name__
+    """Return True if the exception's class name (or any base class name) is in
+    the default retryable set.
+
+    The MRO check lets named subclasses inherit retryability (e.g. a
+    ``GoogleRateLimitError`` subclassing ``ResourceExhausted`` is also
+    treated as retryable).  The direct name check is subsumed by the MRO
+    set intersection — listed separately only for clarity.
+    """
     exc_base_names = {c.__name__ for c in type(exc).__mro__}
-    return bool(exc_base_names & set(_DEFAULT_RETRYABLE_NAMES)) or (
-        exc_type_name in _DEFAULT_RETRYABLE_NAMES
-    )
+    return bool(exc_base_names & set(_DEFAULT_RETRYABLE_NAMES))
 
 
 # ---------------------------------------------------------------------------
@@ -264,31 +276,61 @@ class FallbackLLM:
     ``.invoke()`` / ``.stream()`` / ``.astream()`` interface as any
     LangChain chat model.
 
+    Fallback providers are loaded **lazily** — on first use, not at
+    construction time.  This means a misconfigured fallback (missing
+    credentials, wrong region) only surfaces as an error when the chain
+    actually reaches it after the primary fails.  A healthy primary will
+    never trigger loading of any fallback provider.
+
     Parameters
     ----------
     primary : object
         The first LLM to try (must have ``.invoke()``).
-    fallbacks : list of objects
-        Subsequent LLMs to try, in priority order.
+    fallbacks : list of objects, optional
+        Pre-loaded subsequent LLMs, in priority order.  Use this when you
+        have already-instantiated LLM objects.
+    fallback_specs : list of (str, dict), optional
+        Lazy-loaded fallback specs as ``(provider_type, load_kwargs)`` pairs.
+        Each entry is loaded via :data:`~bili.iris.providers.registry.PROVIDER_REGISTRY`
+        on first use.  Mutually exclusive with *fallbacks*.
     policy : FallbackPolicy, optional
         Exception classification policy.  Defaults to
         :data:`DEFAULT_POLICY`.
 
     Class methods
     -------------
-    :meth:`from_chain` — convenience constructor that loads all providers
-    from a :class:`ProviderChain` at construction time.
+    :meth:`from_chain` — convenience constructor that loads the primary from
+    a :class:`ProviderChain` and stores the rest as lazy specs.
     """
 
     def __init__(
         self,
         primary: Any,
         fallbacks: Optional[List[Any]] = None,
+        fallback_specs: Optional[List[Tuple[str, dict]]] = None,
         policy: Optional[FallbackPolicy] = None,
     ) -> None:
+        if fallbacks and fallback_specs:
+            raise ValueError(
+                "Provide either 'fallbacks' (pre-loaded LLMs) or "
+                "'fallback_specs' (lazy (provider_type, kwargs) pairs), not both."
+            )
         self._primary = primary
         self._fallbacks: List[Any] = list(fallbacks) if fallbacks else []
+        # Lazy-loading state: specs to load + cache of loaded objects
+        self._fallback_specs: List[Tuple[str, dict]] = (
+            list(fallback_specs) if fallback_specs else []
+        )
+        self._loaded_fallbacks: List[Optional[Any]] = [None] * len(self._fallback_specs)
         self._policy = policy if policy is not None else DEFAULT_POLICY
+
+    def _get_fallback(self, spec_index: int) -> Any:
+        """Return the fallback LLM at *spec_index*, loading it on first use."""
+        if self._loaded_fallbacks[spec_index] is None:
+            provider_type, kwargs = self._fallback_specs[spec_index]
+            provider_class = PROVIDER_REGISTRY.get_or_raise(provider_type)
+            self._loaded_fallbacks[spec_index] = provider_class().load(**kwargs)
+        return self._loaded_fallbacks[spec_index]
 
     @classmethod
     def from_chain(
@@ -298,27 +340,48 @@ class FallbackLLM:
     ) -> "FallbackLLM":
         """Construct a ``FallbackLLM`` from a :class:`ProviderChain`.
 
-        Loads all provider LLM objects immediately (at construction time, not
-        at call time).
+        The primary LLM is loaded immediately.  Fallback providers are stored
+        as lazy specs and loaded on first use.
 
-        :param chain: An ordered :class:`ProviderChain`.
+        :param chain: An ordered :class:`ProviderChain` with at least one
+            entry.  The first entry is the primary; the rest are fallbacks.
         :param policy: Optional :class:`FallbackPolicy`.  Defaults to
             :data:`DEFAULT_POLICY`.
         :returns: A ``FallbackLLM`` ready to use.
         :raises ValueError: If the chain is empty or a type is unregistered.
         """
-        llms = chain.load_all()
-        primary = llms[0]
-        fallbacks = llms[1:]
-        return cls(primary=primary, fallbacks=fallbacks, policy=policy)
+        entries = list(chain)
+        if not entries:
+            raise ValueError("ProviderChain must have at least one entry.")
+        primary_type, primary_kwargs = entries[0]
+        primary_class = PROVIDER_REGISTRY.get_or_raise(primary_type)
+        primary_llm = primary_class().load(**primary_kwargs)
+        return cls(
+            primary=primary_llm,
+            fallback_specs=entries[1:] if len(entries) > 1 else None,
+            policy=policy,
+        )
 
     # ------------------------------------------------------------------
     # Core invocation helpers
     # ------------------------------------------------------------------
 
     def _candidates(self) -> List[Any]:
-        """Return the full ordered list of LLM candidates."""
-        return [self._primary] + self._fallbacks
+        """Return the full ordered list of LLM candidates.
+
+        Pre-loaded fallbacks (from the ``fallbacks`` constructor parameter)
+        appear first, followed by lazy-spec fallbacks.  The primary is always
+        index 0.
+        """
+        return (
+            [self._primary] + self._fallbacks + list(range(len(self._fallback_specs)))
+        )
+
+    def _resolve_candidate(self, candidate: Any) -> Any:
+        """Resolve a candidate: load it lazily if it is a spec index."""
+        if isinstance(candidate, int):
+            return self._get_fallback(candidate)
+        return candidate
 
     def _log_fallback(
         self,
@@ -360,7 +423,8 @@ class FallbackLLM:
         max_attempts = self._policy.max_attempts or len(candidates)
         last_exc: Optional[BaseException] = None
 
-        for i, llm in enumerate(candidates[:max_attempts]):
+        for i, candidate in enumerate(candidates[:max_attempts]):
+            llm = self._resolve_candidate(candidate)
             try:
                 result = llm.invoke(input, **kwargs)
                 if i > 0:
@@ -411,7 +475,8 @@ class FallbackLLM:
         max_attempts = self._policy.max_attempts or len(candidates)
         last_exc: Optional[BaseException] = None
 
-        for i, llm in enumerate(candidates[:max_attempts]):
+        for i, candidate in enumerate(candidates[:max_attempts]):
+            llm = self._resolve_candidate(candidate)
             try:
                 yield from llm.stream(input, **kwargs)
                 return
@@ -443,7 +508,8 @@ class FallbackLLM:
         max_attempts = self._policy.max_attempts or len(candidates)
         last_exc: Optional[BaseException] = None
 
-        for i, llm in enumerate(candidates[:max_attempts]):
+        for i, candidate in enumerate(candidates[:max_attempts]):
+            llm = self._resolve_candidate(candidate)
             try:
                 async for chunk in llm.astream(input, **kwargs):
                     yield chunk
@@ -472,13 +538,17 @@ class FallbackLLM:
 
     @property
     def fallbacks(self) -> List[Any]:
-        """The fallback LLMs in priority order."""
+        """Pre-loaded fallback LLMs in priority order.
+
+        Does not include lazy-spec fallbacks that have not been loaded yet.
+        Use :attr:`chain_length` to get the total number of providers.
+        """
         return list(self._fallbacks)
 
     @property
     def chain_length(self) -> int:
-        """Total number of providers in the chain (primary + fallbacks)."""
-        return 1 + len(self._fallbacks)
+        """Total number of providers in the chain (primary + all fallbacks)."""
+        return 1 + len(self._fallbacks) + len(self._fallback_specs)
 
     def __repr__(self) -> str:
         return (
@@ -499,6 +569,11 @@ def build_fallback_llm(
 ) -> FallbackLLM:
     """Build a :class:`FallbackLLM` from a primary LLM and a fallback spec.
 
+    Fallback providers are stored as lazy specs and loaded on first use —
+    only when the chain actually reaches them after the primary fails.  This
+    means a misconfigured fallback (missing credentials, wrong region) will
+    not break agent construction while the primary provider is healthy.
+
     This is the low-level convenience function used by
     :func:`~bili.aether.compiler.llm_resolver.create_llm` when
     ``AgentSpec.fallback_models`` is populated.  It can also be used
@@ -507,12 +582,14 @@ def build_fallback_llm(
 
     :param primary_llm: An already-instantiated primary LLM object.
     :param fallback_chain: Ordered list of ``(provider_type, load_kwargs)``
-        pairs for the fallback providers.  Each entry is loaded via
-        :data:`~bili.iris.providers.registry.PROVIDER_REGISTRY`.
+        pairs for the fallback providers.  Each entry is validated (provider
+        type must be registered) and then stored; the provider's
+        :meth:`~bili.iris.providers.base.LLMProvider.load` is called only
+        on first use.
     :param policy: Optional :class:`FallbackPolicy`.  Defaults to
         :data:`DEFAULT_POLICY`.
-    :returns: A :class:`FallbackLLM` wrapping the primary and all
-        loaded fallback LLMs.
+    :returns: A :class:`FallbackLLM` wrapping the primary with lazy
+        fallback specs.
     :raises ValueError: If a provider type in *fallback_chain* is not
         registered.
 
@@ -528,10 +605,14 @@ def build_fallback_llm(
             ],
         )
     """
-    fallback_llms: List[Any] = []
+    specs: List[Tuple[str, dict]] = []
     for provider_type, kwargs in fallback_chain:
-        provider_class = PROVIDER_REGISTRY.get_or_raise(provider_type)
-        fallback_llm = provider_class().load(**kwargs)
-        fallback_llms.append(fallback_llm)
+        # Validate the type is registered now (fail fast at build time, not
+        # during a live request); load() is deferred until first use.
+        PROVIDER_REGISTRY.get_or_raise(provider_type)
+        specs.append((provider_type, dict(kwargs)))
 
-    return FallbackLLM(primary=primary_llm, fallbacks=fallback_llms, policy=policy)
+    if not specs:
+        return FallbackLLM(primary=primary_llm, policy=policy)
+
+    return FallbackLLM(primary=primary_llm, fallback_specs=specs, policy=policy)

--- a/bili/iris/providers/fallback.py
+++ b/bili/iris/providers/fallback.py
@@ -459,17 +459,23 @@ class FallbackLLM:
     def stream(
         self, input: Any, **kwargs: Any  # pylint: disable=redefined-builtin
     ) -> Iterator[Any]:
-        """Stream responses, falling back on retryable errors.
+        """Stream responses, falling back only on clean start-failures.
 
-        Falls back at stream-open time (before the first chunk).  Once a
-        provider starts streaming, errors mid-stream propagate normally.
+        Fallback is attempted **only** when the provider fails before yielding
+        any tokens (a "clean" failure at stream-open time).  Once a provider
+        has emitted one or more tokens, any subsequent failure is propagated
+        immediately — falling over at that point would produce a partially-
+        consumed stream followed by the fallback's full output, which
+        constitutes corrupted output from the caller's perspective.
 
         :param input: Messages or prompt to pass to the LLM.
         :param kwargs: Additional keyword arguments forwarded to each
             provider's ``.stream()`` call.
-        :returns: An iterator of response chunks from the first successful
-            provider.
-        :raises: The last provider's exception if all candidates fail.
+        :returns: An iterator of response chunks from the first provider that
+            successfully opens a stream.
+        :raises: The original exception immediately if the failure occurs
+            mid-stream (after >= 1 token was already yielded).  The last
+            provider's exception if all candidates fail before the first token.
         """
         candidates = self._candidates()
         max_attempts = self._policy.max_attempts or len(candidates)
@@ -477,10 +483,25 @@ class FallbackLLM:
 
         for i, candidate in enumerate(candidates[:max_attempts]):
             llm = self._resolve_candidate(candidate)
+            tokens_yielded = 0
             try:
-                yield from llm.stream(input, **kwargs)
+                for chunk in llm.stream(input, **kwargs):
+                    tokens_yielded += 1
+                    yield chunk
                 return
             except Exception as exc:  # pylint: disable=broad-exception-caught
+                if tokens_yielded > 0:
+                    # Mid-stream failure: propagate immediately.  Falling over
+                    # here would give the caller a partial primary response
+                    # followed by the fallback's complete response.
+                    LOGGER.debug(
+                        "Provider %d raised %s mid-stream after %d token(s); "
+                        "propagating — cannot fall back on partial output.",
+                        i + 1,
+                        type(exc).__name__,
+                        tokens_yielded,
+                    )
+                    raise
                 if not self._policy.should_fallback(exc):
                     raise
                 last_exc = exc
@@ -496,13 +517,21 @@ class FallbackLLM:
     async def astream(
         self, input: Any, **kwargs: Any  # pylint: disable=redefined-builtin
     ) -> AsyncIterator[Any]:
-        """Async-stream responses, falling back on retryable errors.
+        """Async-stream responses, falling back only on clean start-failures.
+
+        Fallback is attempted **only** when the provider fails before yielding
+        any tokens (a "clean" failure at stream-open time).  Once a provider
+        has emitted one or more tokens, any subsequent failure is propagated
+        immediately to avoid returning corrupted (partial + restart) output.
 
         :param input: Messages or prompt to pass to the LLM.
         :param kwargs: Additional keyword arguments forwarded to each
             provider's ``.astream()`` call.
-        :returns: An async iterator of response chunks.
-        :raises: The last provider's exception if all candidates fail.
+        :returns: An async iterator of response chunks from the first provider
+            that successfully opens a stream.
+        :raises: The original exception immediately if the failure occurs
+            mid-stream (after >= 1 token was already yielded).  The last
+            provider's exception if all candidates fail before the first token.
         """
         candidates = self._candidates()
         max_attempts = self._policy.max_attempts or len(candidates)
@@ -510,11 +539,23 @@ class FallbackLLM:
 
         for i, candidate in enumerate(candidates[:max_attempts]):
             llm = self._resolve_candidate(candidate)
+            tokens_yielded = 0
             try:
                 async for chunk in llm.astream(input, **kwargs):
+                    tokens_yielded += 1
                     yield chunk
                 return
             except Exception as exc:  # pylint: disable=broad-exception-caught
+                if tokens_yielded > 0:
+                    # Mid-stream failure: propagate immediately.
+                    LOGGER.debug(
+                        "Provider %d raised %s mid-stream after %d token(s); "
+                        "propagating — cannot fall back on partial output.",
+                        i + 1,
+                        type(exc).__name__,
+                        tokens_yielded,
+                    )
+                    raise
                 if not self._policy.should_fallback(exc):
                     raise
                 last_exc = exc

--- a/bili/iris/providers/fallback.py
+++ b/bili/iris/providers/fallback.py
@@ -1,0 +1,537 @@
+"""Fallback-policy engine for bili-core LLM providers.
+
+When a provider fails with a transient error (rate limit, API unavailable,
+network timeout) this module automatically falls through an ordered list of
+provider alternatives without propagating the error to the caller.  The
+mechanism is opt-in and backward-compatible: callers that do not configure a
+fallback chain see no change in behaviour.
+
+Core types
+----------
+- :class:`FallbackPolicy` — classifies exceptions as retryable vs fatal.
+- :class:`ProviderChain` — an ordered sequence of ``(provider_type, kwargs)``
+  pairs that represents the fallback priority list.
+- :class:`FallbackLLM` — a transparent proxy that tries each entry in the
+  chain on retryable failure and exposes ``.invoke()`` / ``.stream()`` /
+  ``.astream()`` to callers.
+
+Usage example
+-------------
+Typical usage via :func:`~bili.aether.compiler.llm_resolver.create_llm` when
+``AgentSpec.fallback_models`` is populated::
+
+    from bili.iris.providers.fallback import FallbackLLM, ProviderChain
+
+    chain = ProviderChain([
+        ("remote_aws_bedrock", {"model_name": "anthropic.claude-3-5-sonnet-20241022-v2:0"}),
+        ("remote_openai",      {"model_name": "gpt-4o"}),
+    ])
+    llm = FallbackLLM.from_chain(chain)
+
+    # Callers interact with the standard .invoke() / .stream() interface.
+    response = llm.invoke(messages)
+
+Standalone usage without AgentSpec::
+
+    from bili.iris.providers.fallback import FallbackLLM, FallbackPolicy
+
+    policy = FallbackPolicy(retryable_exceptions=(RateLimitError, TimeoutError))
+    primary_llm = load_model("remote_aws_bedrock", model_name="...")
+    fallback_llm = load_model("remote_openai", model_name="gpt-4o")
+    llm = FallbackLLM(primary=primary_llm, fallbacks=[fallback_llm], policy=policy)
+
+Design notes
+------------
+The fallback engine is *completely generic*.  It knows nothing about which
+providers exist or in what order they should be tried; that is the consumer's
+responsibility.  The engine only handles: exception classification, ordered
+retry, logging, and transparent proxy behaviour.
+
+``FallbackLLM`` implements the same duck-typed ``.invoke()`` / ``.stream()``
+/ ``.astream()`` interface as any LangChain chat model, so it is transparent
+to AETHER executor nodes, IRIS pipeline nodes, and any other caller that
+receives an LLM object.
+"""
+
+# pylint: disable=too-few-public-methods
+
+import logging
+from typing import Any, AsyncIterator, Iterator, List, Optional, Sequence, Tuple, Type
+
+from bili.iris.providers.registry import PROVIDER_REGISTRY
+
+LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Default retryable exception types
+# ---------------------------------------------------------------------------
+
+# These are the exception class *names* (as strings) that are treated as
+# retryable by default.  String matching is used so the engine does not need
+# hard imports of provider SDKs — providers that are not installed produce no
+# ImportError here.
+#
+# Consumers can override the classification entirely via FallbackPolicy.
+_DEFAULT_RETRYABLE_NAMES: Tuple[str, ...] = (
+    # LangChain / LangChain-community base classes
+    "OutputParserException",  # transient parsing glitch
+    # openai SDK
+    "RateLimitError",
+    "APIConnectionError",
+    "APITimeoutError",
+    "InternalServerError",
+    "ServiceUnavailableError",
+    # anthropic SDK
+    "OverloadedError",
+    "APIStatusError",
+    # google-cloud / vertexai SDK
+    "ResourceExhausted",
+    "ServiceUnavailable",
+    "DeadlineExceeded",
+    # boto3 / botocore (Bedrock)
+    "ThrottlingException",
+    "ServiceUnavailableException",
+    "ModelTimeoutException",
+    "ModelErrorException",
+    # generic Python
+    "TimeoutError",
+    "ConnectionError",
+    "ConnectionResetError",
+    "BrokenPipeError",
+)
+
+
+def _is_retryable_by_name(exc: BaseException) -> bool:
+    """Return True if the exception's class name is in the default retryable set."""
+    exc_type_name = type(exc).__name__
+    exc_base_names = {c.__name__ for c in type(exc).__mro__}
+    return bool(exc_base_names & set(_DEFAULT_RETRYABLE_NAMES)) or (
+        exc_type_name in _DEFAULT_RETRYABLE_NAMES
+    )
+
+
+# ---------------------------------------------------------------------------
+# FallbackPolicy
+# ---------------------------------------------------------------------------
+
+
+class FallbackPolicy:
+    """Classifies exceptions as retryable (trigger fallback) vs fatal (re-raise).
+
+    The policy is the only place where exception type decisions live.  Two
+    configuration modes:
+
+    1. **Type-based** — pass a tuple of exception classes to
+       ``retryable_exceptions``.  Any exception that is an instance of one of
+       those classes triggers the fallback.
+    2. **Callable** — pass a callable to ``is_retryable``.  The callable
+       receives the exception and returns ``True`` to trigger fallback.
+
+    If neither is supplied, the engine uses name-based matching against
+    :data:`_DEFAULT_RETRYABLE_NAMES`, which covers the most common transient
+    errors across the built-in providers without requiring hard imports of
+    their SDKs.
+
+    Parameters
+    ----------
+    retryable_exceptions : tuple of exception classes, optional
+        Hard-typed exception classes.  Checked with ``isinstance``.
+    is_retryable : callable, optional
+        ``(exc: BaseException) -> bool``.  Takes precedence over
+        ``retryable_exceptions`` when both are supplied.
+    max_attempts : int
+        Total number of providers to try (primary + fallbacks).  0 means
+        unlimited (try the whole chain).  Default: 0.
+
+    Examples
+    --------
+    Type-based::
+
+        from openai import RateLimitError
+        policy = FallbackPolicy(retryable_exceptions=(RateLimitError,))
+
+    Callable (covers any 429 / 503 HTTP status)::
+
+        def my_policy(exc):
+            return getattr(exc, "status_code", 0) in (429, 503)
+
+        policy = FallbackPolicy(is_retryable=my_policy)
+    """
+
+    def __init__(
+        self,
+        retryable_exceptions: Optional[Tuple[Type[BaseException], ...]] = None,
+        is_retryable: Optional[Any] = None,
+        max_attempts: int = 0,
+    ) -> None:
+        self._retryable_exceptions = retryable_exceptions
+        self._is_retryable_fn = is_retryable
+        self.max_attempts = max_attempts
+
+    def should_fallback(self, exc: BaseException) -> bool:
+        """Return ``True`` if *exc* should trigger a fallback attempt.
+
+        :param exc: The exception raised by the current provider.
+        :returns: ``True`` to try the next provider; ``False`` to re-raise.
+        """
+        if self._is_retryable_fn is not None:
+            return bool(self._is_retryable_fn(exc))
+        if self._retryable_exceptions is not None:
+            return isinstance(exc, self._retryable_exceptions)
+        # Default: name-based matching (no hard SDK imports required)
+        return _is_retryable_by_name(exc)
+
+
+#: The default policy used when no explicit policy is provided to FallbackLLM.
+DEFAULT_POLICY = FallbackPolicy()
+
+
+# ---------------------------------------------------------------------------
+# ProviderChain
+# ---------------------------------------------------------------------------
+
+
+class ProviderChain:
+    """An ordered list of ``(provider_type, load_kwargs)`` pairs.
+
+    Each entry describes one candidate LLM provider.  The engine tries them
+    in order, stopping at the first that succeeds.
+
+    Parameters
+    ----------
+    entries : list of (str, dict)
+        Ordered list of ``(provider_type_string, load_kwargs)`` pairs.
+        ``provider_type_string`` must be registered in
+        :data:`~bili.iris.providers.registry.PROVIDER_REGISTRY`.
+        ``load_kwargs`` are forwarded verbatim to the provider's
+        :meth:`~bili.iris.providers.base.LLMProvider.load` method.
+
+    Example
+    -------
+    ::
+
+        chain = ProviderChain([
+            ("remote_aws_bedrock", {"model_name": "anthropic.claude-3-5-sonnet..."}),
+            ("remote_openai",      {"model_name": "gpt-4o"}),
+            ("remote_google_vertex", {"model_name": "gemini-2.0-flash"}),
+        ])
+    """
+
+    def __init__(self, entries: List[Tuple[str, dict]]) -> None:
+        if not entries:
+            raise ValueError("ProviderChain requires at least one entry.")
+        self._entries: List[Tuple[str, dict]] = list(entries)
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def __iter__(self):
+        return iter(self._entries)
+
+    def __repr__(self) -> str:
+        types = [e[0] for e in self._entries]
+        return f"ProviderChain({types})"
+
+    def load_all(self) -> List[Any]:
+        """Instantiate all providers in the chain and return their LLM objects.
+
+        :returns: Ordered list of LLM objects, one per chain entry.
+        :raises ValueError: If a provider type is not registered.
+        :raises ImportError: If a provider's optional dependency is absent.
+        """
+        llms = []
+        for provider_type, kwargs in self._entries:
+            provider_class = PROVIDER_REGISTRY.get_or_raise(provider_type)
+            llm = provider_class().load(**kwargs)
+            llms.append(llm)
+        return llms
+
+
+# ---------------------------------------------------------------------------
+# FallbackLLM
+# ---------------------------------------------------------------------------
+
+
+class FallbackLLM:
+    """Transparent proxy that falls through an ordered list of LLM objects.
+
+    On a retryable error from the current LLM, ``FallbackLLM`` automatically
+    tries the next one in the chain.  If the chain is exhausted the last
+    exception is re-raised.  On a fatal (non-retryable) error the exception
+    propagates immediately without trying further providers.
+
+    ``FallbackLLM`` is transparent to callers — it exposes the same
+    ``.invoke()`` / ``.stream()`` / ``.astream()`` interface as any
+    LangChain chat model.
+
+    Parameters
+    ----------
+    primary : object
+        The first LLM to try (must have ``.invoke()``).
+    fallbacks : list of objects
+        Subsequent LLMs to try, in priority order.
+    policy : FallbackPolicy, optional
+        Exception classification policy.  Defaults to
+        :data:`DEFAULT_POLICY`.
+
+    Class methods
+    -------------
+    :meth:`from_chain` — convenience constructor that loads all providers
+    from a :class:`ProviderChain` at construction time.
+    """
+
+    def __init__(
+        self,
+        primary: Any,
+        fallbacks: Optional[List[Any]] = None,
+        policy: Optional[FallbackPolicy] = None,
+    ) -> None:
+        self._primary = primary
+        self._fallbacks: List[Any] = list(fallbacks) if fallbacks else []
+        self._policy = policy if policy is not None else DEFAULT_POLICY
+
+    @classmethod
+    def from_chain(
+        cls,
+        chain: ProviderChain,
+        policy: Optional[FallbackPolicy] = None,
+    ) -> "FallbackLLM":
+        """Construct a ``FallbackLLM`` from a :class:`ProviderChain`.
+
+        Loads all provider LLM objects immediately (at construction time, not
+        at call time).
+
+        :param chain: An ordered :class:`ProviderChain`.
+        :param policy: Optional :class:`FallbackPolicy`.  Defaults to
+            :data:`DEFAULT_POLICY`.
+        :returns: A ``FallbackLLM`` ready to use.
+        :raises ValueError: If the chain is empty or a type is unregistered.
+        """
+        llms = chain.load_all()
+        primary = llms[0]
+        fallbacks = llms[1:]
+        return cls(primary=primary, fallbacks=fallbacks, policy=policy)
+
+    # ------------------------------------------------------------------
+    # Core invocation helpers
+    # ------------------------------------------------------------------
+
+    def _candidates(self) -> List[Any]:
+        """Return the full ordered list of LLM candidates."""
+        return [self._primary] + self._fallbacks
+
+    def _log_fallback(
+        self,
+        exc: BaseException,
+        attempt_index: int,
+        next_index: int,
+        total: int,
+    ) -> None:
+        """Log a fallback transition."""
+        LOGGER.warning(
+            "Provider attempt %d/%d failed with %s: %s. "
+            "Falling through to candidate %d/%d.",
+            attempt_index + 1,
+            total,
+            type(exc).__name__,
+            exc,
+            next_index + 1,
+            total,
+        )
+
+    # ------------------------------------------------------------------
+    # Public interface — mirrors LangChain chat model protocol
+    # ------------------------------------------------------------------
+
+    def invoke(  # pylint: disable=redefined-builtin
+        self, input: Any, **kwargs: Any
+    ) -> Any:
+        """Invoke the LLM chain, falling back on retryable errors.
+
+        :param input: Messages or prompt to pass to the LLM.
+        :param kwargs: Additional keyword arguments forwarded to each
+            provider's ``.invoke()`` call.
+        :returns: The first successful response.
+        :raises: The last provider's exception if all candidates fail,
+            or the original exception immediately if it is classified as
+            fatal.
+        """
+        candidates = self._candidates()
+        max_attempts = self._policy.max_attempts or len(candidates)
+        last_exc: Optional[BaseException] = None
+
+        for i, llm in enumerate(candidates[:max_attempts]):
+            try:
+                result = llm.invoke(input, **kwargs)
+                if i > 0:
+                    LOGGER.info(
+                        "Fallback to candidate %d/%d succeeded.", i + 1, len(candidates)
+                    )
+                return result
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                if not self._policy.should_fallback(exc):
+                    LOGGER.debug(
+                        "Provider %d raised fatal exception %s; not falling back.",
+                        i + 1,
+                        type(exc).__name__,
+                    )
+                    raise
+                last_exc = exc
+                if i < max_attempts - 1:
+                    self._log_fallback(
+                        exc, i, i + 1, min(max_attempts, len(candidates))
+                    )
+
+        # All candidates exhausted
+        LOGGER.error(
+            "All %d provider candidates failed. Last error: %s",
+            min(max_attempts, len(candidates)),
+            last_exc,
+        )
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError("FallbackLLM: no candidates available.")  # pragma: no cover
+
+    def stream(
+        self, input: Any, **kwargs: Any  # pylint: disable=redefined-builtin
+    ) -> Iterator[Any]:
+        """Stream responses, falling back on retryable errors.
+
+        Falls back at stream-open time (before the first chunk).  Once a
+        provider starts streaming, errors mid-stream propagate normally.
+
+        :param input: Messages or prompt to pass to the LLM.
+        :param kwargs: Additional keyword arguments forwarded to each
+            provider's ``.stream()`` call.
+        :returns: An iterator of response chunks from the first successful
+            provider.
+        :raises: The last provider's exception if all candidates fail.
+        """
+        candidates = self._candidates()
+        max_attempts = self._policy.max_attempts or len(candidates)
+        last_exc: Optional[BaseException] = None
+
+        for i, llm in enumerate(candidates[:max_attempts]):
+            try:
+                yield from llm.stream(input, **kwargs)
+                return
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                if not self._policy.should_fallback(exc):
+                    raise
+                last_exc = exc
+                if i < max_attempts - 1:
+                    self._log_fallback(
+                        exc, i, i + 1, min(max_attempts, len(candidates))
+                    )
+
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError("FallbackLLM: no candidates available.")  # pragma: no cover
+
+    async def astream(
+        self, input: Any, **kwargs: Any  # pylint: disable=redefined-builtin
+    ) -> AsyncIterator[Any]:
+        """Async-stream responses, falling back on retryable errors.
+
+        :param input: Messages or prompt to pass to the LLM.
+        :param kwargs: Additional keyword arguments forwarded to each
+            provider's ``.astream()`` call.
+        :returns: An async iterator of response chunks.
+        :raises: The last provider's exception if all candidates fail.
+        """
+        candidates = self._candidates()
+        max_attempts = self._policy.max_attempts or len(candidates)
+        last_exc: Optional[BaseException] = None
+
+        for i, llm in enumerate(candidates[:max_attempts]):
+            try:
+                async for chunk in llm.astream(input, **kwargs):
+                    yield chunk
+                return
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                if not self._policy.should_fallback(exc):
+                    raise
+                last_exc = exc
+                if i < max_attempts - 1:
+                    self._log_fallback(
+                        exc, i, i + 1, min(max_attempts, len(candidates))
+                    )
+
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError("FallbackLLM: no candidates available.")  # pragma: no cover
+
+    # ------------------------------------------------------------------
+    # Inspection helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def primary(self) -> Any:
+        """The primary (first) LLM in the chain."""
+        return self._primary
+
+    @property
+    def fallbacks(self) -> List[Any]:
+        """The fallback LLMs in priority order."""
+        return list(self._fallbacks)
+
+    @property
+    def chain_length(self) -> int:
+        """Total number of providers in the chain (primary + fallbacks)."""
+        return 1 + len(self._fallbacks)
+
+    def __repr__(self) -> str:
+        return (
+            f"FallbackLLM(chain_length={self.chain_length}, "
+            f"policy={self._policy!r})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Convenience function
+# ---------------------------------------------------------------------------
+
+
+def build_fallback_llm(
+    primary_llm: Any,
+    fallback_chain: Sequence[Tuple[str, dict]],
+    policy: Optional[FallbackPolicy] = None,
+) -> FallbackLLM:
+    """Build a :class:`FallbackLLM` from a primary LLM and a fallback spec.
+
+    This is the low-level convenience function used by
+    :func:`~bili.aether.compiler.llm_resolver.create_llm` when
+    ``AgentSpec.fallback_models`` is populated.  It can also be used
+    directly when callers have an existing LLM object and want to wrap it
+    with fallback behaviour without going through AgentSpec.
+
+    :param primary_llm: An already-instantiated primary LLM object.
+    :param fallback_chain: Ordered list of ``(provider_type, load_kwargs)``
+        pairs for the fallback providers.  Each entry is loaded via
+        :data:`~bili.iris.providers.registry.PROVIDER_REGISTRY`.
+    :param policy: Optional :class:`FallbackPolicy`.  Defaults to
+        :data:`DEFAULT_POLICY`.
+    :returns: A :class:`FallbackLLM` wrapping the primary and all
+        loaded fallback LLMs.
+    :raises ValueError: If a provider type in *fallback_chain* is not
+        registered.
+
+    Example
+    -------
+    ::
+
+        primary = load_model("remote_aws_bedrock", model_name="...")
+        llm = build_fallback_llm(
+            primary_llm=primary,
+            fallback_chain=[
+                ("remote_openai", {"model_name": "gpt-4o"}),
+            ],
+        )
+    """
+    fallback_llms: List[Any] = []
+    for provider_type, kwargs in fallback_chain:
+        provider_class = PROVIDER_REGISTRY.get_or_raise(provider_type)
+        fallback_llm = provider_class().load(**kwargs)
+        fallback_llms.append(fallback_llm)
+
+    return FallbackLLM(primary=primary_llm, fallbacks=fallback_llms, policy=policy)

--- a/bili/iris/providers/tests/test_fallback.py
+++ b/bili/iris/providers/tests/test_fallback.py
@@ -33,7 +33,7 @@ from bili.iris.providers.fallback import (
     _is_retryable_by_name,
     build_fallback_llm,
 )
-from bili.iris.providers.registry import PROVIDER_REGISTRY, ProviderRegistry
+from bili.iris.providers.registry import PROVIDER_REGISTRY
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
@@ -154,6 +154,51 @@ class TestIsRetryableByName:
 
         assert _is_retryable_by_name(SpecificTimeoutError()) is True
 
+    def test_api_status_error_base_class_is_fatal(self):
+        """APIStatusError itself is NOT in the retryable set.
+
+        APIStatusError is the base class for all openai/anthropic status-coded
+        errors including auth (401), bad request (400), and permission (403).
+        It must NOT be treated as retryable — doing so would silently fall
+        through to other providers on auth failures, masking misconfiguration.
+        """
+
+        class APIStatusError(Exception):
+            """Simulated openai/anthropic base status error."""
+
+        assert _is_retryable_by_name(APIStatusError()) is False
+
+    def test_api_status_error_subclass_auth_failure_is_fatal(self):
+        """AuthenticationError (subclass of APIStatusError) is classified fatal.
+
+        Because APIStatusError is not in the retryable set, any subclass
+        (AuthenticationError, BadRequestError, PermissionDeniedError, etc.)
+        is also fatal unless its own class name is explicitly listed.
+        """
+
+        class APIStatusError(Exception):
+            """Simulated base."""
+
+        class AuthenticationError(APIStatusError):
+            """Simulated 401 auth failure."""
+
+        assert _is_retryable_by_name(AuthenticationError()) is False
+
+    def test_rate_limit_error_subclass_of_api_status_is_retryable(self):
+        """RateLimitError is retryable even though it inherits APIStatusError.
+
+        RateLimitError is listed explicitly in the retryable set.  The MRO
+        check finds it by the direct class name.
+        """
+
+        class APIStatusError(Exception):
+            """Simulated base."""
+
+        class RateLimitError(APIStatusError):
+            """Simulated 429 rate limit."""
+
+        assert _is_retryable_by_name(RateLimitError()) is True
+
 
 # ---------------------------------------------------------------------------
 # ProviderChain
@@ -186,19 +231,18 @@ class TestProviderChain:
 
     def test_load_all_calls_registry(self):
         """load_all() calls get_or_raise and each provider's load()."""
-        import bili.iris.providers.fallback as _fallback_mod  # pylint: disable=import-outside-toplevel
-
         mock_llm = MagicMock()
 
-        registry = ProviderRegistry()
-        registry.register(
-            "test_chain_type",
+        type_key = "_test_chain_load_type"
+        PROVIDER_REGISTRY.register(
+            type_key,
             type("P", (LLMProvider,), {"load": lambda self, **kw: mock_llm}),
         )
-
-        with patch.object(_fallback_mod, "PROVIDER_REGISTRY", registry):
-            chain = ProviderChain([("test_chain_type", {"model_name": "m"})])
+        try:
+            chain = ProviderChain([(type_key, {"model_name": "m"})])
             llms = chain.load_all()
+        finally:
+            PROVIDER_REGISTRY.unregister(type_key)
 
         assert len(llms) == 1
         assert llms[0] is mock_llm
@@ -394,9 +438,13 @@ class TestFallbackLLMFromChain:
     """Verify FallbackLLM.from_chain() end-to-end construction."""
 
     def test_from_chain_loads_providers(self):
-        """from_chain() loads all providers and builds FallbackLLM correctly."""
-        import bili.iris.providers.fallback as _fallback_mod  # pylint: disable=import-outside-toplevel
+        """from_chain() loads the primary eagerly and stores fallbacks lazily.
 
+        The primary LLM is loaded at construction time.  Fallback providers
+        are stored as specs (chain_length reflects them) but not loaded until
+        actually needed.  Invoking the FallbackLLM triggers lazy loading of
+        the fallback when the primary fails.
+        """
         mock_llm_a = MagicMock(name="llm_a")
         mock_llm_b = MagicMock(name="llm_b")
 
@@ -408,22 +456,28 @@ class TestFallbackLLMFromChain:
             def load(self, **kwargs):
                 return mock_llm_b
 
-        registry = ProviderRegistry()
-        registry.register("test_chain_a", _ProvA)
-        registry.register("test_chain_b", _ProvB)
-
-        with patch.object(_fallback_mod, "PROVIDER_REGISTRY", registry):
+        type_a = "_test_from_chain_a"
+        type_b = "_test_from_chain_b"
+        PROVIDER_REGISTRY.register(type_a, _ProvA)
+        PROVIDER_REGISTRY.register(type_b, _ProvB)
+        try:
             chain = ProviderChain(
                 [
-                    ("test_chain_a", {"model_name": "m1"}),
-                    ("test_chain_b", {"model_name": "m2"}),
+                    (type_a, {"model_name": "m1"}),
+                    (type_b, {"model_name": "m2"}),
                 ]
             )
             fb_llm = FallbackLLM.from_chain(chain)
+        finally:
+            PROVIDER_REGISTRY.unregister(type_a)
+            PROVIDER_REGISTRY.unregister(type_b)
 
+        # Primary was loaded eagerly.
         assert fb_llm.primary is mock_llm_a
-        assert fb_llm.fallbacks == [mock_llm_b]
+        # chain_length counts both primary and the lazy fallback spec.
         assert fb_llm.chain_length == 2
+        # fallbacks property returns only pre-loaded LLMs, not lazy specs.
+        assert not fb_llm.fallbacks
 
 
 # ---------------------------------------------------------------------------
@@ -435,31 +489,45 @@ class TestBuildFallbackLLM:
     """Verify the build_fallback_llm() convenience function."""
 
     def test_wraps_primary_with_fallback(self):
-        """build_fallback_llm() wraps primary with loaded fallback providers."""
-        import bili.iris.providers.fallback as _fallback_mod  # pylint: disable=import-outside-toplevel
+        """build_fallback_llm() wraps primary with a lazy fallback spec.
 
-        primary = _mock_llm("primary")
-        fallback_llm_obj = _mock_llm("fallback")
+        The returned FallbackLLM has the correct chain_length and is
+        functional: when the primary fails, the fallback is loaded and used.
+        """
+        primary = _mock_llm(side_effect=_RetryableError("rate limited"))
+        fallback_llm_obj = _mock_llm("fallback-result")
 
         class _FallbackProv(LLMProvider):
             def load(self, **kwargs):
                 return fallback_llm_obj
 
-        registry = ProviderRegistry()
-        registry.register("test_build_type", _FallbackProv)
-
-        with patch.object(_fallback_mod, "PROVIDER_REGISTRY", registry):
+        type_key = "_test_build_fb_type"
+        PROVIDER_REGISTRY.register(type_key, _FallbackProv)
+        try:
             result = build_fallback_llm(
                 primary_llm=primary,
-                fallback_chain=[("test_build_type", {"model_name": "m"})],
+                fallback_chain=[(type_key, {"model_name": "m"})],
+                policy=FallbackPolicy(retryable_exceptions=(_RetryableError,)),
             )
+        finally:
+            PROVIDER_REGISTRY.unregister(type_key)
 
         assert isinstance(result, FallbackLLM)
         assert result.primary is primary
-        assert result.fallbacks == [fallback_llm_obj]
+        # chain_length = 1 (primary) + 1 (lazy spec) = 2
+        assert result.chain_length == 2
+        # fallbacks property returns only pre-loaded LLMs; lazy specs are not listed.
+        assert not result.fallbacks
+        # Re-register so invoke() can load the lazy spec.
+        PROVIDER_REGISTRY.register(type_key, _FallbackProv)
+        try:
+            response = result.invoke(["hello"])
+        finally:
+            PROVIDER_REGISTRY.unregister(type_key)
+        assert response.content == "fallback-result"
 
     def test_unknown_fallback_type_raises(self):
-        """Unknown provider type in fallback_chain raises ValueError."""
+        """Unknown provider type in fallback_chain raises ValueError at build time."""
         primary = _mock_llm("primary")
         with pytest.raises(ValueError, match="Invalid model type"):
             build_fallback_llm(
@@ -473,6 +541,36 @@ class TestBuildFallbackLLM:
         result = build_fallback_llm(primary_llm=primary, fallback_chain=[])
         assert isinstance(result, FallbackLLM)
         assert not result.fallbacks
+
+    def test_misconfigured_fallback_does_not_break_construction(self):
+        """A fallback whose load() would fail does not break agent construction.
+
+        The fallback spec is validated (type must be registered) at build time,
+        but load() is deferred.  When the primary succeeds, the fallback is
+        never loaded and the broken configuration is never surfaced.
+        """
+
+        class _BrokenProv(LLMProvider):
+            def load(self, **kwargs):
+                raise RuntimeError("missing credentials — misconfigured fallback")
+
+        type_key = "_test_broken_fb_type"
+        PROVIDER_REGISTRY.register(type_key, _BrokenProv)
+        try:
+            primary = _mock_llm("primary-ok")
+            # Construction must succeed even though the fallback's load() would fail.
+            result = build_fallback_llm(
+                primary_llm=primary,
+                fallback_chain=[(type_key, {"model_name": "broken"})],
+            )
+            assert isinstance(result, FallbackLLM)
+            assert result.chain_length == 2
+
+            # Invoking with a healthy primary must succeed without touching the fallback.
+            response = result.invoke(["hello"])
+            assert response.content == "primary-ok"
+        finally:
+            PROVIDER_REGISTRY.unregister(type_key)
 
 
 # ---------------------------------------------------------------------------
@@ -628,11 +726,18 @@ class TestCreateLLMIntegration:
 
         assert isinstance(result, FallbackLLM)
         assert result.primary is primary_llm
-        assert result.fallbacks == [fallback_llm_obj]
+        # Fallbacks are now lazy specs; chain_length counts them.
+        assert result.chain_length == 2
 
     def test_fallback_resolution_propagates_temperature(self):
-        """Temperature from AgentSpec is forwarded to each fallback's load kwargs."""
+        """Temperature from AgentSpec is forwarded to each fallback's load kwargs.
+
+        Because fallbacks are lazy, load() is only called when the chain
+        actually reaches that fallback.  The test triggers a primary failure
+        so that the fallback provider is loaded and temperature is captured.
+        """
         primary_llm = MagicMock(name="primary")
+        primary_llm.invoke.side_effect = _RetryableError("rate limited")
         captured_kwargs: list = []
 
         class _CapturingProv(LLMProvider):
@@ -661,7 +766,14 @@ class TestCreateLLMIntegration:
                         temperature=0.3,
                         fallback_models=["test-fallback-id"],
                     )
-                    create_llm(spec)
+                    result_llm = create_llm(spec)
+                    # Trigger a primary failure so the lazy fallback is loaded.
+                    policy = FallbackPolicy(retryable_exceptions=(_RetryableError,))
+                    result_llm._policy = policy  # pylint: disable=protected-access
+                    try:
+                        result_llm.invoke(["msg"])
+                    except _RetryableError:
+                        pass  # all-fail path is fine; we just need load() called
         finally:
             PROVIDER_REGISTRY.unregister(type_key)
 
@@ -669,7 +781,11 @@ class TestCreateLLMIntegration:
         assert captured_kwargs[0].get("temperature") == 0.3
 
     def test_create_llm_fallback_invokes_correctly(self):
-        """FallbackLLM returned by create_llm() correctly falls back on failure."""
+        """FallbackLLM returned by create_llm() correctly falls back on failure.
+
+        The provider type must remain registered through the invoke() call
+        so the lazy fallback spec can be loaded when the primary fails.
+        """
         primary_llm = MagicMock(name="primary")
         primary_llm.invoke.side_effect = _RetryableError("rate limited")
         fallback_llm_obj = MagicMock(name="fallback")
@@ -684,6 +800,7 @@ class TestCreateLLMIntegration:
         import bili.iris.providers.fallback as _fallback_mod  # pylint: disable=import-outside-toplevel
 
         type_key = "_test_cllm_invoke_type"
+        # Keep the type registered through the full test (including invoke).
         PROVIDER_REGISTRY.register(type_key, _FbProv)
         try:
             with patch(
@@ -702,10 +819,13 @@ class TestCreateLLMIntegration:
                             fallback_models=["test-fallback-id"],
                         )
                         result_llm = create_llm(spec)
+
+            # invoke() is outside the load_model/resolve patches but
+            # inside the PROVIDER_REGISTRY registration.
+            response = result_llm.invoke(["hello"])
         finally:
             PROVIDER_REGISTRY.unregister(type_key)
 
-        response = result_llm.invoke(["hello"])
         assert response.content == "fallback-content"
 
 

--- a/bili/iris/providers/tests/test_fallback.py
+++ b/bili/iris/providers/tests/test_fallback.py
@@ -1,0 +1,765 @@
+"""Tests for the bili-core provider fallback engine.
+
+Covers:
+- ``FallbackPolicy`` exception classification (retryable vs fatal, all three
+  modes: type-based, callable, name-based default)
+- ``ProviderChain`` construction, iteration, and ``load_all()``
+- ``FallbackLLM.invoke()`` — first-fails-falls-to-second, all-fail-raises,
+  no-fallback-configured (plain passthrough), fatal-error-does-not-fallback,
+  max_attempts cap
+- ``FallbackLLM.stream()`` — same retryable vs fatal split
+- ``FallbackLLM.from_chain()`` — end-to-end construction via ProviderChain
+- ``build_fallback_llm()`` — convenience constructor
+- ``AgentSpec.fallback_models`` field — default empty, round-trips, accepted
+- ``create_llm()`` integration — no fallback → plain LLM; with fallback →
+  FallbackLLM; resolver propagation
+"""
+
+# pylint: disable=too-few-public-methods,duplicate-code
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bili.aether.compiler.llm_resolver import create_llm
+from bili.aether.schema import AgentSpec
+from bili.iris.providers.base import LLMProvider
+from bili.iris.providers.fallback import (
+    DEFAULT_POLICY,
+    FallbackLLM,
+    FallbackPolicy,
+    ProviderChain,
+    _is_retryable_by_name,
+    build_fallback_llm,
+)
+from bili.iris.providers.registry import PROVIDER_REGISTRY, ProviderRegistry
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_llm(response="ok", side_effect=None):
+    """Return a minimal mock LLM with .invoke(), .stream(), .astream()."""
+    llm = MagicMock()
+    if side_effect is not None:
+        llm.invoke.side_effect = side_effect
+        llm.stream.side_effect = side_effect
+    else:
+        llm.invoke.return_value = MagicMock(content=response)
+        llm.stream.return_value = iter([MagicMock(content=response)])
+    return llm
+
+
+class _RetryableError(Exception):
+    """An exception whose name is in _DEFAULT_RETRYABLE_NAMES."""
+
+
+class _FatalError(Exception):
+    """An exception whose name is NOT in _DEFAULT_RETRYABLE_NAMES."""
+
+
+# Patch the name so the default policy sees it correctly.
+_RetryableError.__name__ = "RateLimitError"
+
+
+# ---------------------------------------------------------------------------
+# FallbackPolicy
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackPolicy:
+    """Verify FallbackPolicy exception classification in all three modes."""
+
+    def test_default_policy_retryable_by_name(self):
+        """Default policy classifies known retryable names as retryable."""
+        exc = _RetryableError("too many requests")
+        assert DEFAULT_POLICY.should_fallback(exc) is True
+
+    def test_default_policy_fatal_by_name(self):
+        """Default policy classifies unknown exception names as fatal."""
+        exc = _FatalError("auth error")
+        assert DEFAULT_POLICY.should_fallback(exc) is False
+
+    def test_type_based_policy_retryable(self):
+        """Type-based policy classifies instance-of as retryable."""
+        policy = FallbackPolicy(retryable_exceptions=(ValueError, TimeoutError))
+        assert policy.should_fallback(ValueError("bad")) is True
+        assert policy.should_fallback(TimeoutError()) is True
+
+    def test_type_based_policy_fatal(self):
+        """Type-based policy classifies non-matching types as fatal."""
+        policy = FallbackPolicy(retryable_exceptions=(ValueError,))
+        assert policy.should_fallback(TypeError("wrong type")) is False
+
+    def test_callable_policy_overrides_type(self):
+        """Callable policy takes precedence over retryable_exceptions."""
+
+        def my_fn(exc):
+            return "retry" in str(exc)
+
+        policy = FallbackPolicy(
+            retryable_exceptions=(TypeError,),  # would say TypeError is retryable
+            is_retryable=my_fn,  # callable overrides
+        )
+        # callable says yes for ValueError if message contains "retry"
+        assert policy.should_fallback(ValueError("please retry")) is True
+        # callable says no for TypeError even though it's in retryable_exceptions
+        assert policy.should_fallback(TypeError("wrong")) is False
+
+    def test_callable_policy_fatal(self):
+        """Callable policy returning False means fatal."""
+        policy = FallbackPolicy(is_retryable=lambda _: False)
+        assert policy.should_fallback(Exception("anything")) is False
+
+    def test_max_attempts_stored(self):
+        """max_attempts is stored on the policy."""
+        policy = FallbackPolicy(max_attempts=3)
+        assert policy.max_attempts == 3
+
+    def test_default_max_attempts_is_zero(self):
+        """Default max_attempts is 0 (unlimited)."""
+        policy = FallbackPolicy()
+        assert policy.max_attempts == 0
+
+
+class TestIsRetryableByName:
+    """Unit tests for the name-based helper used by the default policy."""
+
+    def test_known_name_is_retryable(self):
+        """Known retryable name resolves to True."""
+
+        class RateLimitError(Exception):
+            """Fake rate limit error."""
+
+        assert _is_retryable_by_name(RateLimitError()) is True
+
+    def test_unknown_name_is_not_retryable(self):
+        """Unknown name resolves to False."""
+
+        class FooBarBazError(Exception):
+            """Completely unknown error."""
+
+        assert _is_retryable_by_name(FooBarBazError()) is False
+
+    def test_subclass_of_known_name(self):
+        """Subclass of a known name is retryable via MRO check."""
+
+        class TimeoutError(Exception):  # pylint: disable=redefined-builtin
+            """Timeout."""
+
+        class SpecificTimeoutError(TimeoutError):
+            """More specific timeout."""
+
+        assert _is_retryable_by_name(SpecificTimeoutError()) is True
+
+
+# ---------------------------------------------------------------------------
+# ProviderChain
+# ---------------------------------------------------------------------------
+
+
+class TestProviderChain:
+    """Verify ProviderChain construction and load_all()."""
+
+    def test_empty_raises(self):
+        """Empty entries list raises ValueError."""
+        with pytest.raises(ValueError, match="at least one"):
+            ProviderChain([])
+
+    def test_len(self):
+        """len() returns number of entries."""
+        chain = ProviderChain([("a", {}), ("b", {})])
+        assert len(chain) == 2
+
+    def test_iter(self):
+        """Iteration yields (provider_type, kwargs) tuples."""
+        entries = [("a", {"x": 1}), ("b", {"y": 2})]
+        chain = ProviderChain(entries)
+        assert list(chain) == entries
+
+    def test_repr(self):
+        """repr includes provider type strings."""
+        chain = ProviderChain([("remote_openai", {})])
+        assert "remote_openai" in repr(chain)
+
+    def test_load_all_calls_registry(self):
+        """load_all() calls get_or_raise and each provider's load()."""
+        import bili.iris.providers.fallback as _fallback_mod  # pylint: disable=import-outside-toplevel
+
+        mock_llm = MagicMock()
+
+        registry = ProviderRegistry()
+        registry.register(
+            "test_chain_type",
+            type("P", (LLMProvider,), {"load": lambda self, **kw: mock_llm}),
+        )
+
+        with patch.object(_fallback_mod, "PROVIDER_REGISTRY", registry):
+            chain = ProviderChain([("test_chain_type", {"model_name": "m"})])
+            llms = chain.load_all()
+
+        assert len(llms) == 1
+        assert llms[0] is mock_llm
+
+    def test_load_all_raises_for_unknown_type(self):
+        """load_all() raises ValueError for unregistered provider type."""
+        chain = ProviderChain([("__nonexistent_provider__", {})])
+        with pytest.raises(ValueError, match="Invalid model type"):
+            chain.load_all()
+
+
+# ---------------------------------------------------------------------------
+# FallbackLLM.invoke()
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackLLMInvoke:
+    """Verify FallbackLLM.invoke() fallback semantics."""
+
+    def test_primary_success_no_fallback_called(self):
+        """When primary succeeds, fallback is never called."""
+        primary = _mock_llm("primary-response")
+        fallback = _mock_llm("fallback-response")
+        llm = FallbackLLM(primary=primary, fallbacks=[fallback])
+
+        result = llm.invoke(["msg"])
+
+        assert result.content == "primary-response"
+        fallback.invoke.assert_not_called()
+
+    def test_first_fails_falls_to_second(self):
+        """Retryable failure on primary → fallback is tried and succeeds."""
+        primary = _mock_llm(side_effect=_RetryableError("rate limited"))
+        fallback = _mock_llm("fallback-ok")
+        policy = FallbackPolicy(retryable_exceptions=(_RetryableError,))
+        llm = FallbackLLM(primary=primary, fallbacks=[fallback], policy=policy)
+
+        result = llm.invoke(["msg"])
+
+        assert result.content == "fallback-ok"
+        primary.invoke.assert_called_once()
+        fallback.invoke.assert_called_once()
+
+    def test_all_fail_raises_last_exception(self):
+        """When all providers fail, the last exception is re-raised."""
+        err1 = _RetryableError("provider 1 down")
+        err2 = _RetryableError("provider 2 down")
+        primary = _mock_llm(side_effect=err1)
+        fallback = _mock_llm(side_effect=err2)
+        policy = FallbackPolicy(retryable_exceptions=(_RetryableError,))
+        llm = FallbackLLM(primary=primary, fallbacks=[fallback], policy=policy)
+
+        with pytest.raises(_RetryableError) as exc_info:
+            llm.invoke(["msg"])
+
+        assert exc_info.value is err2
+
+    def test_no_fallback_configured_passes_through(self):
+        """FallbackLLM with no fallbacks behaves identically to a plain LLM."""
+        primary = _mock_llm("sole-response")
+        llm = FallbackLLM(primary=primary, fallbacks=[])
+
+        result = llm.invoke(["msg"])
+
+        assert result.content == "sole-response"
+
+    def test_fatal_error_does_not_fallback(self):
+        """Fatal (non-retryable) exceptions are re-raised immediately."""
+        fatal_err = _FatalError("auth failed")
+        primary = _mock_llm(side_effect=fatal_err)
+        fallback = _mock_llm("fallback-ok")
+        policy = FallbackPolicy(retryable_exceptions=(_RetryableError,))
+        llm = FallbackLLM(primary=primary, fallbacks=[fallback], policy=policy)
+
+        with pytest.raises(_FatalError):
+            llm.invoke(["msg"])
+
+        fallback.invoke.assert_not_called()
+
+    def test_max_attempts_caps_chain(self):
+        """Policy max_attempts limits how many providers are tried."""
+        err = _RetryableError("down")
+        p1 = _mock_llm(side_effect=err)
+        p2 = _mock_llm(side_effect=err)
+        p3 = _mock_llm("p3-ok")
+        policy = FallbackPolicy(retryable_exceptions=(_RetryableError,), max_attempts=2)
+        llm = FallbackLLM(primary=p1, fallbacks=[p2, p3], policy=policy)
+
+        with pytest.raises(_RetryableError):
+            llm.invoke(["msg"])
+
+        # Only p1 and p2 were attempted; p3 was NOT reached.
+        p1.invoke.assert_called_once()
+        p2.invoke.assert_called_once()
+        p3.invoke.assert_not_called()
+
+    def test_kwargs_forwarded_to_provider(self):
+        """Extra kwargs are forwarded to each provider's .invoke()."""
+        primary = _mock_llm("ok")
+        llm = FallbackLLM(primary=primary)
+
+        llm.invoke(["msg"], config={"run_name": "test"})
+
+        primary.invoke.assert_called_once_with(["msg"], config={"run_name": "test"})
+
+    def test_second_fallback_tried_after_first_fallback_fails(self):
+        """Chain of 3: primary fails, first fallback fails, second succeeds."""
+        err = _RetryableError("down")
+        p1 = _mock_llm(side_effect=err)
+        p2 = _mock_llm(side_effect=err)
+        p3 = _mock_llm("p3-ok")
+        policy = FallbackPolicy(retryable_exceptions=(_RetryableError,))
+        llm = FallbackLLM(primary=p1, fallbacks=[p2, p3], policy=policy)
+
+        result = llm.invoke(["msg"])
+
+        assert result.content == "p3-ok"
+        p1.invoke.assert_called_once()
+        p2.invoke.assert_called_once()
+        p3.invoke.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# FallbackLLM.stream()
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackLLMStream:
+    """Verify FallbackLLM.stream() fallback semantics."""
+
+    def test_primary_stream_success(self):
+        """When primary stream succeeds, fallback is not tried."""
+        chunk = MagicMock(content="chunk1")
+        primary = MagicMock()
+        primary.stream.return_value = iter([chunk])
+        fallback = _mock_llm("fallback")
+        llm = FallbackLLM(primary=primary, fallbacks=[fallback])
+
+        chunks = list(llm.stream(["msg"]))
+
+        assert len(chunks) == 1
+        assert chunks[0].content == "chunk1"
+        fallback.stream.assert_not_called()
+
+    def test_stream_retryable_falls_to_fallback(self):
+        """Retryable error on stream open triggers fallback."""
+        chunk = MagicMock(content="fb-chunk")
+        primary = MagicMock()
+        primary.stream.side_effect = _RetryableError("stream down")
+        fallback = MagicMock()
+        fallback.stream.return_value = iter([chunk])
+        policy = FallbackPolicy(retryable_exceptions=(_RetryableError,))
+        llm = FallbackLLM(primary=primary, fallbacks=[fallback], policy=policy)
+
+        chunks = list(llm.stream(["msg"]))
+
+        assert len(chunks) == 1
+        assert chunks[0].content == "fb-chunk"
+
+    def test_stream_fatal_does_not_fallback(self):
+        """Fatal error on stream propagates immediately."""
+        primary = MagicMock()
+        primary.stream.side_effect = _FatalError("auth")
+        fallback = _mock_llm("ok")
+        policy = FallbackPolicy(retryable_exceptions=(_RetryableError,))
+        llm = FallbackLLM(primary=primary, fallbacks=[fallback], policy=policy)
+
+        with pytest.raises(_FatalError):
+            list(llm.stream(["msg"]))
+
+        fallback.stream.assert_not_called()
+
+    def test_all_stream_fail_raises(self):
+        """All stream providers fail → last exception raised."""
+        err = _RetryableError("all down")
+        primary = MagicMock()
+        primary.stream.side_effect = err
+        fallback = MagicMock()
+        fallback.stream.side_effect = err
+        policy = FallbackPolicy(retryable_exceptions=(_RetryableError,))
+        llm = FallbackLLM(primary=primary, fallbacks=[fallback], policy=policy)
+
+        with pytest.raises(_RetryableError):
+            list(llm.stream(["msg"]))
+
+
+# ---------------------------------------------------------------------------
+# FallbackLLM.from_chain()
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackLLMFromChain:
+    """Verify FallbackLLM.from_chain() end-to-end construction."""
+
+    def test_from_chain_loads_providers(self):
+        """from_chain() loads all providers and builds FallbackLLM correctly."""
+        import bili.iris.providers.fallback as _fallback_mod  # pylint: disable=import-outside-toplevel
+
+        mock_llm_a = MagicMock(name="llm_a")
+        mock_llm_b = MagicMock(name="llm_b")
+
+        class _ProvA(LLMProvider):
+            def load(self, **kwargs):
+                return mock_llm_a
+
+        class _ProvB(LLMProvider):
+            def load(self, **kwargs):
+                return mock_llm_b
+
+        registry = ProviderRegistry()
+        registry.register("test_chain_a", _ProvA)
+        registry.register("test_chain_b", _ProvB)
+
+        with patch.object(_fallback_mod, "PROVIDER_REGISTRY", registry):
+            chain = ProviderChain(
+                [
+                    ("test_chain_a", {"model_name": "m1"}),
+                    ("test_chain_b", {"model_name": "m2"}),
+                ]
+            )
+            fb_llm = FallbackLLM.from_chain(chain)
+
+        assert fb_llm.primary is mock_llm_a
+        assert fb_llm.fallbacks == [mock_llm_b]
+        assert fb_llm.chain_length == 2
+
+
+# ---------------------------------------------------------------------------
+# build_fallback_llm()
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFallbackLLM:
+    """Verify the build_fallback_llm() convenience function."""
+
+    def test_wraps_primary_with_fallback(self):
+        """build_fallback_llm() wraps primary with loaded fallback providers."""
+        import bili.iris.providers.fallback as _fallback_mod  # pylint: disable=import-outside-toplevel
+
+        primary = _mock_llm("primary")
+        fallback_llm_obj = _mock_llm("fallback")
+
+        class _FallbackProv(LLMProvider):
+            def load(self, **kwargs):
+                return fallback_llm_obj
+
+        registry = ProviderRegistry()
+        registry.register("test_build_type", _FallbackProv)
+
+        with patch.object(_fallback_mod, "PROVIDER_REGISTRY", registry):
+            result = build_fallback_llm(
+                primary_llm=primary,
+                fallback_chain=[("test_build_type", {"model_name": "m"})],
+            )
+
+        assert isinstance(result, FallbackLLM)
+        assert result.primary is primary
+        assert result.fallbacks == [fallback_llm_obj]
+
+    def test_unknown_fallback_type_raises(self):
+        """Unknown provider type in fallback_chain raises ValueError."""
+        primary = _mock_llm("primary")
+        with pytest.raises(ValueError, match="Invalid model type"):
+            build_fallback_llm(
+                primary_llm=primary,
+                fallback_chain=[("__nonexistent__", {"model_name": "x"})],
+            )
+
+    def test_empty_fallback_chain_returns_no_fallback_llm(self):
+        """Empty fallback_chain produces a FallbackLLM with no fallbacks."""
+        primary = _mock_llm("primary")
+        result = build_fallback_llm(primary_llm=primary, fallback_chain=[])
+        assert isinstance(result, FallbackLLM)
+        assert not result.fallbacks
+
+
+# ---------------------------------------------------------------------------
+# FallbackLLM introspection
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackLLMIntrospection:
+    """Verify FallbackLLM property accessors and repr."""
+
+    def test_primary_property(self):
+        """primary property returns the primary LLM."""
+        p = _mock_llm()
+        llm = FallbackLLM(primary=p)
+        assert llm.primary is p
+
+    def test_fallbacks_property_copy(self):
+        """fallbacks property returns a copy; mutating it does not affect chain."""
+        p = _mock_llm()
+        f1 = _mock_llm()
+        llm = FallbackLLM(primary=p, fallbacks=[f1])
+        copy = llm.fallbacks
+        copy.append(_mock_llm())
+        assert len(llm.fallbacks) == 1
+
+    def test_chain_length(self):
+        """chain_length counts primary + fallbacks."""
+        llm = FallbackLLM(primary=_mock_llm(), fallbacks=[_mock_llm(), _mock_llm()])
+        assert llm.chain_length == 3
+
+    def test_repr_includes_chain_length(self):
+        """repr mentions chain_length."""
+        llm = FallbackLLM(primary=_mock_llm(), fallbacks=[_mock_llm()])
+        assert "chain_length=2" in repr(llm)
+
+
+# ---------------------------------------------------------------------------
+# AgentSpec.fallback_models field
+# ---------------------------------------------------------------------------
+
+
+class TestAgentSpecFallbackModels:
+    """Verify the new fallback_models field on AgentSpec."""
+
+    def _make_spec(self, **kwargs) -> AgentSpec:
+        return AgentSpec(
+            agent_id="test-agent",
+            role="tester",
+            objective="Test the fallback field behaviour end to end.",
+            **kwargs,
+        )
+
+    def test_default_is_empty_list(self):
+        """fallback_models defaults to an empty list."""
+        spec = self._make_spec()
+        assert spec.fallback_models == []
+
+    def test_fallback_models_round_trips(self):
+        """fallback_models survives Pydantic round-trip."""
+        spec = self._make_spec(
+            model_name="gpt-4o",
+            fallback_models=["gpt-4-turbo", "gemini-pro"],
+        )
+        assert spec.fallback_models == ["gpt-4-turbo", "gemini-pro"]
+
+    def test_fallback_models_accepted_in_yaml_dict(self):
+        """AgentSpec can be constructed from a dict (as AETHER YAML does)."""
+        spec = AgentSpec(
+            **{
+                "agent_id": "yaml-agent",
+                "role": "tester",
+                "objective": "Test YAML-dict construction with fallback_models.",
+                "model_name": "gpt-4o",
+                "fallback_models": ["gpt-4-turbo"],
+            }
+        )
+        assert spec.fallback_models == ["gpt-4-turbo"]
+
+    def test_existing_agentspec_fields_unchanged(self):
+        """Adding fallback_models does not change any other field default."""
+        spec = self._make_spec(model_name="gpt-4o")
+        # These fields must still carry their original defaults.
+        assert spec.temperature is None
+        assert spec.max_tokens is None
+        assert spec.tools == []
+        assert spec.capabilities == []
+
+
+# ---------------------------------------------------------------------------
+# create_llm() integration
+# ---------------------------------------------------------------------------
+
+
+class TestCreateLLMIntegration:
+    """Verify create_llm() wires the fallback engine correctly."""
+
+    def _make_spec(self, model_name="gpt-4o", fallback_models=None) -> AgentSpec:
+        return AgentSpec(
+            agent_id="integration-agent",
+            role="tester",
+            objective="Integration test for create_llm fallback wiring.",
+            model_name=model_name,
+            fallback_models=fallback_models or [],
+        )
+
+    def test_no_fallback_returns_plain_llm(self):
+        """create_llm() without fallbacks returns the raw LLM, not FallbackLLM."""
+        mock_llm = MagicMock()
+        with patch(
+            "bili.iris.loaders.llm_loader.load_model", return_value=mock_llm
+        ) as mock_load:
+            spec = self._make_spec()
+            result = create_llm(spec)
+
+        mock_load.assert_called_once()
+        assert result is mock_llm
+        assert not isinstance(result, FallbackLLM)
+
+    def test_with_fallback_returns_fallback_llm(self):
+        """create_llm() with fallback_models returns a FallbackLLM.
+
+        Registers a test provider type in the global PROVIDER_REGISTRY and
+        patches _resolve_model_full to route the fallback model name to it,
+        then cleans up the global registry on exit.
+        """
+        primary_llm = MagicMock(name="primary")
+        fallback_llm_obj = MagicMock(name="fallback")
+
+        class _FbProv(LLMProvider):
+            def load(self, **kwargs):
+                return fallback_llm_obj
+
+        type_key = "_test_cllm_fb_type"
+        PROVIDER_REGISTRY.register(type_key, _FbProv)
+        try:
+            with patch(
+                "bili.iris.loaders.llm_loader.load_model", return_value=primary_llm
+            ):
+                with patch(
+                    "bili.aether.compiler.llm_resolver._resolve_model_full",
+                    side_effect=[
+                        ("remote_aws_bedrock", "test-primary-id", {}),
+                        (type_key, "test-fallback-id", {}),
+                    ],
+                ):
+                    spec = self._make_spec(
+                        model_name="test-primary-id",
+                        fallback_models=["test-fallback-id"],
+                    )
+                    result = create_llm(spec)
+        finally:
+            PROVIDER_REGISTRY.unregister(type_key)
+
+        assert isinstance(result, FallbackLLM)
+        assert result.primary is primary_llm
+        assert result.fallbacks == [fallback_llm_obj]
+
+    def test_fallback_resolution_propagates_temperature(self):
+        """Temperature from AgentSpec is forwarded to each fallback's load kwargs."""
+        primary_llm = MagicMock(name="primary")
+        captured_kwargs: list = []
+
+        class _CapturingProv(LLMProvider):
+            def load(self, **kwargs):
+                captured_kwargs.append(dict(kwargs))
+                return MagicMock()
+
+        type_key = "_test_cllm_temp_type"
+        PROVIDER_REGISTRY.register(type_key, _CapturingProv)
+        try:
+            with patch(
+                "bili.iris.loaders.llm_loader.load_model", return_value=primary_llm
+            ):
+                with patch(
+                    "bili.aether.compiler.llm_resolver._resolve_model_full",
+                    side_effect=[
+                        ("remote_aws_bedrock", "test-primary-id", {}),
+                        (type_key, "test-fallback-id", {}),
+                    ],
+                ):
+                    spec = AgentSpec(
+                        agent_id="temp-agent",
+                        role="tester",
+                        objective="Verify temperature propagates to fallback providers.",
+                        model_name="test-primary-id",
+                        temperature=0.3,
+                        fallback_models=["test-fallback-id"],
+                    )
+                    create_llm(spec)
+        finally:
+            PROVIDER_REGISTRY.unregister(type_key)
+
+        assert len(captured_kwargs) == 1
+        assert captured_kwargs[0].get("temperature") == 0.3
+
+    def test_create_llm_fallback_invokes_correctly(self):
+        """FallbackLLM returned by create_llm() correctly falls back on failure."""
+        primary_llm = MagicMock(name="primary")
+        primary_llm.invoke.side_effect = _RetryableError("rate limited")
+        fallback_llm_obj = MagicMock(name="fallback")
+        fallback_llm_obj.invoke.return_value = MagicMock(content="fallback-content")
+
+        class _FbProv(LLMProvider):
+            def load(self, **kwargs):
+                return fallback_llm_obj
+
+        policy = FallbackPolicy(retryable_exceptions=(_RetryableError,))
+
+        import bili.iris.providers.fallback as _fallback_mod  # pylint: disable=import-outside-toplevel
+
+        type_key = "_test_cllm_invoke_type"
+        PROVIDER_REGISTRY.register(type_key, _FbProv)
+        try:
+            with patch(
+                "bili.iris.loaders.llm_loader.load_model", return_value=primary_llm
+            ):
+                with patch(
+                    "bili.aether.compiler.llm_resolver._resolve_model_full",
+                    side_effect=[
+                        ("remote_aws_bedrock", "test-primary-id", {}),
+                        (type_key, "test-fallback-id", {}),
+                    ],
+                ):
+                    with patch.object(_fallback_mod, "DEFAULT_POLICY", policy):
+                        spec = self._make_spec(
+                            model_name="test-primary-id",
+                            fallback_models=["test-fallback-id"],
+                        )
+                        result_llm = create_llm(spec)
+        finally:
+            PROVIDER_REGISTRY.unregister(type_key)
+
+        response = result_llm.invoke(["hello"])
+        assert response.content == "fallback-content"
+
+
+# ---------------------------------------------------------------------------
+# astream (async) smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackLLMAstream:
+    """Verify astream() basic retryable fallback."""
+
+    def test_astream_primary_success(self):
+        """astream() yields chunks from primary when primary succeeds."""
+
+        async def _run():
+            chunk = MagicMock(content="async-chunk")
+            primary = MagicMock()
+
+            async def _astream_ok(*_args, **_kwargs):
+                yield chunk
+
+            primary.astream = _astream_ok
+            fallback = _mock_llm("fb")
+            llm = FallbackLLM(primary=primary, fallbacks=[fallback])
+            chunks = [c async for c in llm.astream(["msg"])]
+            return chunks
+
+        chunks = asyncio.run(_run())
+        assert len(chunks) == 1
+        assert chunks[0].content == "async-chunk"
+
+    def test_astream_retryable_falls_to_fallback(self):
+        """astream() falls back when primary raises a retryable error."""
+
+        async def _run():
+            primary = MagicMock()
+
+            async def _astream_fail(*_args, **_kwargs):
+                raise _RetryableError("async down")
+                yield  # make it a generator  # pylint: disable=unreachable
+
+            chunk = MagicMock(content="fb-async")
+            fallback = MagicMock()
+
+            async def _astream_ok(*_args, **_kwargs):
+                yield chunk
+
+            primary.astream = _astream_fail
+            fallback.astream = _astream_ok
+            policy = FallbackPolicy(retryable_exceptions=(_RetryableError,))
+            llm = FallbackLLM(primary=primary, fallbacks=[fallback], policy=policy)
+            chunks = [c async for c in llm.astream(["msg"])]
+            return chunks
+
+        chunks = asyncio.run(_run())
+        assert len(chunks) == 1
+        assert chunks[0].content == "fb-async"

--- a/bili/iris/providers/tests/test_fallback.py
+++ b/bili/iris/providers/tests/test_fallback.py
@@ -15,7 +15,7 @@ Covers:
   FallbackLLM; resolver propagation
 """
 
-# pylint: disable=too-few-public-methods,duplicate-code
+# pylint: disable=too-few-public-methods,duplicate-code,no-member,too-many-lines
 
 import asyncio
 from unittest.mock import MagicMock, patch
@@ -427,6 +427,64 @@ class TestFallbackLLMStream:
 
         with pytest.raises(_RetryableError):
             list(llm.stream(["msg"]))
+
+    def test_stream_mid_stream_failure_propagates_no_fallback(self):
+        """A failure after >= 1 token propagates immediately; fallback NOT tried.
+
+        Once the primary has yielded tokens, falling over to a fallback would
+        produce the primary's partial output followed by the fallback's full
+        output — corrupted from the caller's perspective.  The exception must
+        propagate instead.
+        """
+        mid_err = _RetryableError("connection reset mid-stream")
+
+        def _partial_stream(*_args, **_kwargs):
+            yield MagicMock(content="tok1")
+            raise mid_err
+
+        primary = MagicMock()
+        primary.stream = _partial_stream
+        fallback = _mock_llm("fallback-ok")
+        policy = FallbackPolicy(retryable_exceptions=(_RetryableError,))
+        llm = FallbackLLM(primary=primary, fallbacks=[fallback], policy=policy)
+
+        collected = []
+        with pytest.raises(_RetryableError) as exc_info:
+            for chunk in llm.stream(["msg"]):
+                collected.append(chunk)
+
+        # The one token before the failure was already yielded to the caller.
+        assert len(collected) == 1
+        assert collected[0].content == "tok1"
+        # The raised exception is the original mid-stream error.
+        assert exc_info.value is mid_err
+        # Fallback was never called.
+        fallback.stream.assert_not_called()
+
+    def test_stream_pre_token_retryable_falls_to_fallback(self):
+        """A retryable failure before the first token triggers fallback.
+
+        This is the clean start-failure path: the primary raises before yielding
+        anything, so the fallback can safely re-stream from the beginning.
+        """
+
+        def _fail_before_first_token(*_args, **_kwargs):
+            raise _RetryableError("connect timeout")
+            yield  # make it a generator  # pylint: disable=unreachable
+
+        primary = MagicMock()
+        primary.stream = _fail_before_first_token
+        fb_chunk = MagicMock(content="fb-tok")
+        fallback = MagicMock()
+        fallback.stream.return_value = iter([fb_chunk])
+        policy = FallbackPolicy(retryable_exceptions=(_RetryableError,))
+        llm = FallbackLLM(primary=primary, fallbacks=[fallback], policy=policy)
+
+        chunks = list(llm.stream(["msg"]))
+
+        assert len(chunks) == 1
+        assert chunks[0].content == "fb-tok"
+        fallback.stream.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -883,3 +941,80 @@ class TestFallbackLLMAstream:
         chunks = asyncio.run(_run())
         assert len(chunks) == 1
         assert chunks[0].content == "fb-async"
+
+    def test_astream_mid_stream_failure_propagates_no_fallback(self):
+        """astream() mid-stream failure propagates; fallback NOT tried.
+
+        Once the primary has yielded >= 1 token via astream(), any subsequent
+        failure must propagate immediately.  Falling over would concatenate the
+        primary's partial output with the fallback's full output.
+        """
+        mid_err = _RetryableError("async connection reset mid-stream")
+
+        async def _run():
+            async def _astream_partial(*_args, **_kwargs):
+                yield MagicMock(content="async-tok1")
+                raise mid_err
+
+            fallback_call_count = [0]
+
+            async def _astream_fb(*_args, **_kwargs):
+                fallback_call_count[0] += 1
+                yield MagicMock(content="should-not-appear")
+
+            primary = MagicMock()
+            primary.astream = _astream_partial
+            fallback = MagicMock()
+            fallback.astream = _astream_fb
+            policy = FallbackPolicy(retryable_exceptions=(_RetryableError,))
+            llm = FallbackLLM(primary=primary, fallbacks=[fallback], policy=policy)
+
+            collected = []
+            raised = None
+            try:
+                async for chunk in llm.astream(["msg"]):
+                    collected.append(chunk)
+            except _RetryableError as exc:
+                raised = exc
+            return collected, raised, fallback_call_count[0]
+
+        collected, raised, fb_calls = asyncio.run(_run())
+
+        assert len(collected) == 1
+        assert collected[0].content == "async-tok1"
+        assert raised is mid_err
+        assert fb_calls == 0  # fallback was never entered
+
+    def test_astream_pre_token_retryable_falls_to_fallback(self):
+        """astream() pre-token retryable failure falls back cleanly.
+
+        The primary raises before yielding any token, so the fallback can
+        safely re-stream from the beginning with no output duplication.
+        """
+
+        async def _run():
+            async def _astream_fail_early(*_args, **_kwargs):
+                raise _RetryableError("async connect timeout")
+                yield  # make it a generator  # pylint: disable=unreachable
+
+            fb_chunk = MagicMock(content="async-fb-tok")
+            fallback_call_count = [0]
+
+            async def _astream_fb_ok(*_args, **_kwargs):
+                fallback_call_count[0] += 1
+                yield fb_chunk
+
+            primary = MagicMock()
+            primary.astream = _astream_fail_early
+            fallback = MagicMock()
+            fallback.astream = _astream_fb_ok
+            policy = FallbackPolicy(retryable_exceptions=(_RetryableError,))
+            llm = FallbackLLM(primary=primary, fallbacks=[fallback], policy=policy)
+            chunks = [c async for c in llm.astream(["msg"])]
+            return chunks, fallback_call_count[0]
+
+        chunks, fb_calls = asyncio.run(_run())
+
+        assert len(chunks) == 1
+        assert chunks[0].content == "async-fb-tok"
+        assert fb_calls == 1  # fallback was called exactly once


### PR DESCRIPTION
## Summary

Adds an opt-in fallback mechanism that lets an `AgentSpec` declare an ordered list of alternative models to try whenever the primary provider fails with a transient error (rate limit, HTTP 5xx, API timeout).

## What ships

**New module: `bili/iris/providers/fallback.py`**

- `FallbackPolicy` — classifies exceptions as retryable or fatal. Three pluggable modes: type-based (`isinstance` check), callable (consumer-supplied predicate), or the default name-based matcher. `DEFAULT_POLICY` uses a frozenset of well-known retryable exception class names across OpenAI, Anthropic, Google Cloud, Boto3, and standard-library error families. No provider SDK needs to be imported for classification to work.
- `ProviderChain` — ordered `(provider_type, load_kwargs)` sequence that loads each fallback LLM on demand via the global `PROVIDER_REGISTRY`.
- `FallbackLLM` — transparent proxy exposing `.invoke()`, `.stream()`, and `.astream()`. Tries the primary LLM first; on a retryable error tries each fallback in order; on a fatal error re-raises immediately. `max_attempts` on the policy caps how many providers are tried (0 = unlimited, the default).
- `build_fallback_llm()` — convenience constructor for wrapping an existing LLM with an arbitrary fallback chain.

**Modified files**

- `bili/iris/providers/__init__.py` — re-exports the full fallback public API (`FallbackLLM`, `FallbackPolicy`, `ProviderChain`, `build_fallback_llm`, `DEFAULT_POLICY`).
- `bili/aether/schema/agent_spec.py` — additive `fallback_models: List[str] = []` field. Default is empty; all existing YAML configs continue to validate and run without modification.
- `bili/aether/compiler/llm_resolver.py` — `create_llm()` checks `agent.fallback_models` after loading the primary LLM. Empty list returns the plain LLM unchanged. Non-empty list resolves each fallback model name through the same `_resolve_model_full()` path, applies the same `temperature`/`max_tokens` values, and returns a `FallbackLLM`.

**Tests: `bili/iris/providers/tests/test_fallback.py`**

47 tests across 11 test classes covering all three `FallbackPolicy` modes, `ProviderChain` construction and `load_all()`, `FallbackLLM` invoke/stream/astream paths (primary success, first-fails-falls-to-second, all-fail, fatal-does-not-fallback, max_attempts cap), `build_fallback_llm()`, `AgentSpec.fallback_models` field round-trips, and `create_llm()` integration (no-fallback plain path, with-fallback FallbackLLM, temperature propagation, end-to-end invocation).

## Backward compatibility

`AgentSpec`, `MASExecutor`, `initialize_tools`, and `build_agent_graph` signatures are unchanged. The new `fallback_models` field defaults to an empty list; all existing YAML configs that do not set it behave identically to today.

## Test / quality results

- 3291 tests pass, 0 failures
- pylint 9.97/10 across modified modules (only pre-existing `W0621` in `agent_spec.py` outside our change)
- All pre-commit hooks pass (black, isort, autoflake, pylint)

## Example usage

```yaml
# aether/mas_configs/my_workflow.yaml
agents:
  - agent_id: worker
    role: analyst
    objective: "Analyze the input data and produce a structured summary."
    model_name: anthropic.claude-3-5-sonnet-20241022-v2:0
    fallback_models:
      - gpt-4o
      - gemini-1.5-pro
    temperature: 0.2
```

When `anthropic.claude-3-5-sonnet-20241022-v2:0` hits a rate limit, `create_llm()` returns a `FallbackLLM` that transparently tries `gpt-4o`, then `gemini-1.5-pro`. Callers see no difference — the returned object exposes the same `.invoke()` / `.stream()` / `.astream()` interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpXRrbE4UhL22Usj6UdEVQ