### PR TITLE
feat: add 7 new API provider types to the built-in catalog

### DIFF
--- a/bili/aether/compiler/llm_resolver.py
+++ b/bili/aether/compiler/llm_resolver.py
@@ -26,31 +26,49 @@ LOGGER = logging.getLogger(__name__)
 
 _HEURISTIC_RULES = [
     # (substring_or_prefix, provider_type)
-    # Order matters — more specific patterns must come before broader ones.
+    # Order matters -- more specific patterns must come before broader ones.
+    # The heuristic layer only fires when LLM_MODELS lookup returns nothing,
+    # so these rules apply to non-catalog model IDs only.
     ("gpt-", "remote_openai"),
     ("gpt4", "remote_openai"),
     ("o1-", "remote_openai"),
     ("o1", "remote_openai"),
     ("o3-", "remote_openai"),
     ("o3", "remote_openai"),
-    # Bedrock-hosted models (prefix check before bare provider name checks)
+    # Bedrock-hosted models use dotted-namespace prefixes.  Check these first
+    # so that provider-bare patterns below do not intercept them.
     ("anthropic.claude", "remote_aws_bedrock"),
     ("amazon.nova", "remote_aws_bedrock"),
     ("amazon.titan", "remote_aws_bedrock"),
     ("meta.llama", "remote_aws_bedrock"),
     ("cohere.command", "remote_aws_bedrock"),
     ("mistral.mistral", "remote_aws_bedrock"),
-    # Direct provider API heuristics
+    # Direct-API heuristics for non-Bedrock-namespaced model IDs.
+    # Each pattern is more specific than the broad fallbacks below,
+    # so place them first.
     ("claude-", "remote_anthropic"),  # Anthropic direct API
-    ("mistral-", "remote_mistral"),  # Mistral AI direct
+    ("mistral-", "remote_mistral"),  # Mistral AI direct (not Bedrock)
     ("codestral", "remote_mistral"),  # Mistral's code model
     ("command-", "remote_cohere"),  # Cohere Command family
+    # "gemini-" routes to the Google AI Developer API.  Users who want
+    # Vertex AI should select a model by its catalog display name, use the
+    # Vertex-registered model_id directly, or invoke load_model() with
+    # provider_type="remote_google_vertex" explicitly.
     ("gemini-", "remote_google_genai"),  # Google GenAI developer API
     ("deepseek-", "remote_deepseek"),  # DeepSeek direct API
     ("grok-", "remote_xai"),  # xAI Grok
     ("llama-3", "remote_groq"),  # Groq-hosted Llama
     ("compound-beta", "remote_groq"),  # Groq compound system
     ("gemma2-", "remote_groq"),  # Groq-hosted Gemma
+    # Broad pre-existing fallbacks -- preserved for backward compatibility.
+    # These fire for non-catalog model IDs that match only the bare vendor
+    # name (e.g. bare "gemini", legacy Bedrock-style "mistral-..." that did
+    # not match "mistral.mistral-*" above).  Because "mistral-" already
+    # routes to remote_mistral, the "mistral" fallback below only triggers
+    # for strings containing "mistral" but NOT "mistral-" (e.g. a bare
+    # "mistral" string or "mistral_v2").
+    ("gemini", "remote_google_vertex"),  # bare/non-hyphenated gemini IDs
+    ("mistral", "remote_aws_bedrock"),  # legacy Bedrock Mistral catch-all
 ]
 
 

--- a/bili/aether/compiler/llm_resolver.py
+++ b/bili/aether/compiler/llm_resolver.py
@@ -33,14 +33,24 @@ _HEURISTIC_RULES = [
     ("o1", "remote_openai"),
     ("o3-", "remote_openai"),
     ("o3", "remote_openai"),
-    ("gemini", "remote_google_vertex"),
+    # Bedrock-hosted models (prefix check before bare provider name checks)
+    ("anthropic.claude", "remote_aws_bedrock"),
     ("amazon.nova", "remote_aws_bedrock"),
     ("amazon.titan", "remote_aws_bedrock"),
-    ("anthropic.claude", "remote_aws_bedrock"),  # Bedrock-hosted Claude
     ("meta.llama", "remote_aws_bedrock"),
-    ("mistral", "remote_aws_bedrock"),
     ("cohere.command", "remote_aws_bedrock"),
-    ("claude-", "remote_openai"),  # Direct Anthropic API (after Bedrock check)
+    ("mistral.mistral", "remote_aws_bedrock"),
+    # Direct provider API heuristics
+    ("claude-", "remote_anthropic"),  # Anthropic direct API
+    ("mistral-", "remote_mistral"),  # Mistral AI direct
+    ("codestral", "remote_mistral"),  # Mistral's code model
+    ("command-", "remote_cohere"),  # Cohere Command family
+    ("gemini-", "remote_google_genai"),  # Google GenAI developer API
+    ("deepseek-", "remote_deepseek"),  # DeepSeek direct API
+    ("grok-", "remote_xai"),  # xAI Grok
+    ("llama-3", "remote_groq"),  # Groq-hosted Llama
+    ("compound-beta", "remote_groq"),  # Groq compound system
+    ("gemma2-", "remote_groq"),  # Groq-hosted Gemma
 ]
 
 

--- a/bili/iris/config/llm_config.py
+++ b/bili/iris/config/llm_config.py
@@ -1094,6 +1094,423 @@ LLM_MODELS = {
             },
         ],
     },
+    # -------------------------------------------------------------------------
+    # Anthropic direct API
+    # https://docs.anthropic.com/en/docs/about-claude/models
+    # https://pypi.org/project/langchain-anthropic/
+    # -------------------------------------------------------------------------
+    "remote_anthropic": {
+        "name": "Anthropic",
+        "description": "Remote models accessed via the Anthropic API directly. "
+        "Supports Claude Opus, Sonnet, and Haiku model families. "
+        "See https://docs.anthropic.com/en/docs/about-claude/models for the "
+        "full model list.",
+        "model_help": "https://docs.anthropic.com/en/docs/about-claude/models",
+        "models": [
+            {
+                "model_name": "Claude Opus 4.8",
+                "model_id": "claude-opus-4-8",
+                "custom_model_path": False,
+                "max_input_tokens": 200000,
+                "max_output_tokens": 32000,
+                "supports_temperature": True,
+                "supports_seed": False,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": True,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+            {
+                "model_name": "Claude Sonnet 4.6",
+                "model_id": "claude-sonnet-4-6",
+                "custom_model_path": False,
+                "max_input_tokens": 200000,
+                "max_output_tokens": 16000,
+                "supports_temperature": True,
+                "supports_seed": False,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": True,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+            {
+                "model_name": "Claude Haiku 4.5",
+                "model_id": "claude-haiku-4-5",
+                "custom_model_path": False,
+                "max_input_tokens": 200000,
+                "max_output_tokens": 8096,
+                "supports_temperature": True,
+                "supports_seed": False,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": True,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+            {
+                "model_name": "Claude Fable 5",
+                "model_id": "claude-fable-5",
+                "custom_model_path": False,
+                "max_input_tokens": 200000,
+                "max_output_tokens": 16000,
+                "supports_temperature": True,
+                "supports_seed": False,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": True,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+        ],
+    },
+    # -------------------------------------------------------------------------
+    # Mistral AI
+    # https://docs.mistral.ai/models/overview
+    # https://pypi.org/project/langchain-mistralai/
+    # -------------------------------------------------------------------------
+    "remote_mistral": {
+        "name": "Mistral AI",
+        "description": "Remote models accessed via the Mistral AI API. "
+        "Supports Mistral Large, Small, and Codestral model families. "
+        "See https://docs.mistral.ai/models/overview for the full model list.",
+        "model_help": "https://docs.mistral.ai/models/overview",
+        "models": [
+            {
+                "model_name": "Mistral Large Latest",
+                "model_id": "mistral-large-latest",
+                "custom_model_path": False,
+                "max_input_tokens": 131072,
+                "max_output_tokens": 8192,
+                "supports_temperature": True,
+                "supports_seed": True,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": False,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+            {
+                "model_name": "Mistral Small Latest",
+                "model_id": "mistral-small-latest",
+                "custom_model_path": False,
+                "max_input_tokens": 131072,
+                "max_output_tokens": 8192,
+                "supports_temperature": True,
+                "supports_seed": True,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": False,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+            {
+                "model_name": "Codestral Latest",
+                "model_id": "codestral-latest",
+                "custom_model_path": False,
+                "max_input_tokens": 262144,
+                "max_output_tokens": 8192,
+                "supports_temperature": True,
+                "supports_seed": True,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": False,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+        ],
+    },
+    # -------------------------------------------------------------------------
+    # Cohere
+    # https://docs.cohere.com/docs/models
+    # https://pypi.org/project/langchain-cohere/
+    # -------------------------------------------------------------------------
+    "remote_cohere": {
+        "name": "Cohere",
+        "description": "Remote models accessed via the Cohere API. "
+        "Supports Command A+, Command A, Command R+, and Command R model "
+        "families. See https://docs.cohere.com/docs/models for the full list.",
+        "model_help": "https://docs.cohere.com/docs/models",
+        "models": [
+            {
+                "model_name": "Command A+",
+                "model_id": "command-a-plus-05-2026",
+                "custom_model_path": False,
+                "max_input_tokens": 256000,
+                "max_output_tokens": 8000,
+                "supports_temperature": True,
+                "supports_seed": True,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": True,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+            {
+                "model_name": "Command R+",
+                "model_id": "command-r-plus",
+                "custom_model_path": False,
+                "max_input_tokens": 128000,
+                "max_output_tokens": 4000,
+                "supports_temperature": True,
+                "supports_seed": True,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": True,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+            {
+                "model_name": "Command R",
+                "model_id": "command-r",
+                "custom_model_path": False,
+                "max_input_tokens": 128000,
+                "max_output_tokens": 4000,
+                "supports_temperature": True,
+                "supports_seed": True,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": True,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+        ],
+    },
+    # -------------------------------------------------------------------------
+    # Google Generative AI (Gemini developer API -- not Vertex AI)
+    # https://ai.google.dev/gemini-api/docs/models
+    # https://pypi.org/project/langchain-google-genai/
+    # -------------------------------------------------------------------------
+    "remote_google_genai": {
+        "name": "Google Generative AI (Gemini API)",
+        "description": "Remote Gemini models accessed via the Google AI Developer "
+        "API (GOOGLE_API_KEY). Complements the 'remote_google_vertex' provider "
+        "which routes through Google Cloud Vertex AI. "
+        "See https://ai.google.dev/gemini-api/docs/models for the model list.",
+        "model_help": "https://ai.google.dev/gemini-api/docs/models",
+        "models": [
+            {
+                "model_name": "Gemini 2.5 Flash",
+                "model_id": "gemini-2.5-flash",
+                "custom_model_path": False,
+                "max_input_tokens": 1048576,
+                "max_output_tokens": 65536,
+                "supports_temperature": True,
+                "supports_seed": False,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": True,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+            {
+                "model_name": "Gemini 2.0 Flash",
+                "model_id": "gemini-2.0-flash",
+                "custom_model_path": False,
+                "max_input_tokens": 1048576,
+                "max_output_tokens": 8192,
+                "supports_temperature": True,
+                "supports_seed": False,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": True,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+            {
+                "model_name": "Gemini 2.0 Flash Lite",
+                "model_id": "gemini-2.0-flash-lite",
+                "custom_model_path": False,
+                "max_input_tokens": 1048576,
+                "max_output_tokens": 8192,
+                "supports_temperature": True,
+                "supports_seed": False,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": True,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+        ],
+    },
+    # -------------------------------------------------------------------------
+    # DeepSeek
+    # https://api-docs.deepseek.com/
+    # https://pypi.org/project/langchain-deepseek/
+    # -------------------------------------------------------------------------
+    "remote_deepseek": {
+        "name": "DeepSeek",
+        "description": "Remote models accessed via the DeepSeek API. "
+        "Supports the DeepSeek-V3/V4 chat family and the DeepSeek-R1 "
+        "reasoning family. "
+        "See https://api-docs.deepseek.com/ for the full model list.",
+        "model_help": "https://api-docs.deepseek.com/",
+        "models": [
+            {
+                "model_name": "DeepSeek Chat",
+                "model_id": "deepseek-chat",
+                "custom_model_path": False,
+                "max_input_tokens": 65536,
+                "max_output_tokens": 8192,
+                "supports_temperature": True,
+                "supports_seed": True,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": False,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+            {
+                "model_name": "DeepSeek Reasoner",
+                "model_id": "deepseek-reasoner",
+                "custom_model_path": False,
+                "max_input_tokens": 65536,
+                "max_output_tokens": 32768,
+                "supports_temperature": False,
+                "supports_seed": True,
+                "supports_max_output_tokens": True,
+                "supports_top_p": False,
+                "supports_top_k": False,
+                "supports_tools": False,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+        ],
+    },
+    # -------------------------------------------------------------------------
+    # xAI (Grok)
+    # https://docs.x.ai/
+    # https://pypi.org/project/langchain-xai/
+    # -------------------------------------------------------------------------
+    "remote_xai": {
+        "name": "xAI (Grok)",
+        "description": "Remote Grok models accessed via the xAI API. "
+        "Supports the Grok model family including reasoning variants. "
+        "See https://docs.x.ai/ for the full model list.",
+        "model_help": "https://docs.x.ai/",
+        "models": [
+            {
+                "model_name": "Grok 3 Latest",
+                "model_id": "grok-3-latest",
+                "custom_model_path": False,
+                "max_input_tokens": 131072,
+                "max_output_tokens": 131072,
+                "supports_temperature": True,
+                "supports_seed": False,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": False,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+            {
+                "model_name": "Grok Beta",
+                "model_id": "grok-beta",
+                "custom_model_path": False,
+                "max_input_tokens": 131072,
+                "max_output_tokens": 131072,
+                "supports_temperature": True,
+                "supports_seed": False,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": False,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+        ],
+    },
+    # -------------------------------------------------------------------------
+    # Groq
+    # https://console.groq.com/docs/models
+    # https://pypi.org/project/langchain-groq/
+    # -------------------------------------------------------------------------
+    "remote_groq": {
+        "name": "Groq",
+        "description": "Remote models served on Groq's low-latency inference "
+        "hardware. Supports Llama, Gemma, and compound-beta model families. "
+        "See https://console.groq.com/docs/models for the full model list.",
+        "model_help": "https://console.groq.com/docs/models",
+        "models": [
+            {
+                "model_name": "Llama 3.3 70B Versatile",
+                "model_id": "llama-3.3-70b-versatile",
+                "custom_model_path": False,
+                "max_input_tokens": 128000,
+                "max_output_tokens": 32768,
+                "supports_temperature": True,
+                "supports_seed": True,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": False,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+            {
+                "model_name": "Llama 3.1 8B Instant",
+                "model_id": "llama-3.1-8b-instant",
+                "custom_model_path": False,
+                "max_input_tokens": 131072,
+                "max_output_tokens": 8000,
+                "supports_temperature": True,
+                "supports_seed": True,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": False,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+            {
+                "model_name": "Compound Beta",
+                "model_id": "compound-beta",
+                "custom_model_path": False,
+                "max_input_tokens": 131072,
+                "max_output_tokens": 8000,
+                "supports_temperature": True,
+                "supports_seed": False,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": False,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+            {
+                "model_name": "Compound Beta Mini",
+                "model_id": "compound-beta-mini",
+                "custom_model_path": False,
+                "max_input_tokens": 131072,
+                "max_output_tokens": 8000,
+                "supports_temperature": True,
+                "supports_seed": False,
+                "supports_max_output_tokens": True,
+                "supports_top_p": True,
+                "supports_top_k": False,
+                "supports_max_retries": True,
+                "max_retries_default": 2,
+                "max_retries_max": 10,
+            },
+        ],
+    },
     "local_llamacpp": {
         "name": "Local LlamaCpp Compatible Model",
         "description": "Local LlamaCpp compatible model loaded into memory.",

--- a/bili/iris/config/llm_config.py
+++ b/bili/iris/config/llm_config.py
@@ -1301,7 +1301,13 @@ LLM_MODELS = {
         "model_help": "https://ai.google.dev/gemini-api/docs/models",
         "models": [
             {
-                "model_name": "Gemini 2.5 Flash",
+                # Display name includes "(Direct API)" to disambiguate from the
+                # identically-named Vertex AI entries.  Users who want the Google
+                # AI Developer API (GOOGLE_API_KEY, not GCP/Vertex credentials)
+                # must select by this display name or invoke load_model() with
+                # provider_type="remote_google_genai" directly.  The model_id
+                # sent to the API remains the standard Gemini identifier.
+                "model_name": "Gemini 2.5 Flash (Direct API)",
                 "model_id": "gemini-2.5-flash",
                 "custom_model_path": False,
                 "max_input_tokens": 1048576,
@@ -1316,7 +1322,7 @@ LLM_MODELS = {
                 "max_retries_max": 10,
             },
             {
-                "model_name": "Gemini 2.0 Flash",
+                "model_name": "Gemini 2.0 Flash (Direct API)",
                 "model_id": "gemini-2.0-flash",
                 "custom_model_path": False,
                 "max_input_tokens": 1048576,
@@ -1331,7 +1337,7 @@ LLM_MODELS = {
                 "max_retries_max": 10,
             },
             {
-                "model_name": "Gemini 2.0 Flash Lite",
+                "model_name": "Gemini 2.0 Flash Lite (Direct API)",
                 "model_id": "gemini-2.0-flash-lite",
                 "custom_model_path": False,
                 "max_input_tokens": 1048576,

--- a/bili/iris/providers/anthropic_provider.py
+++ b/bili/iris/providers/anthropic_provider.py
@@ -1,0 +1,86 @@
+"""Anthropic direct API provider for bili-core IRIS.
+
+Wraps ``langchain_anthropic.ChatAnthropic`` behind the :class:`LLMProvider`
+interface.  Supports Claude model families (Opus, Sonnet, Haiku) accessed via
+the Anthropic API endpoint directly, as a complement to the existing
+``remote_aws_bedrock`` provider which routes Claude through AWS Bedrock.
+
+Authentication reads ``ANTHROPIC_API_KEY`` from the environment.
+
+Heavy dependencies
+------------------
+``langchain_anthropic`` is imported inside :meth:`AnthropicProvider.load` to
+avoid module-level import cost when this provider is not in use.
+"""
+
+# pylint: disable=duplicate-code
+import logging
+from typing import Any, Optional
+
+from .base import LLMProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=too-few-public-methods
+class AnthropicProvider(LLMProvider):
+    """LangChain-native Anthropic API provider.
+
+    Accepted kwargs
+    ---------------
+    model_name : str
+        Anthropic model identifier (e.g. ``"claude-opus-4-8"``,
+        ``"claude-sonnet-4-6"``).
+    max_tokens : int, optional
+        Maximum completion tokens.  Defaults to 1024 when not set
+        (``ChatAnthropic`` requires an explicit value; 1024 is a safe
+        minimum compatible with all Claude models).
+    temperature : float, optional
+        Sampling temperature.
+    top_p : float, optional
+        Nucleus sampling probability.
+    top_k : int, optional
+        Top-k sampling limit.
+    max_retries : int, optional
+        Maximum number of automatic retries on transient errors.
+    """
+
+    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments
+        self,
+        model_name: str,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        top_k: Optional[int] = None,
+        max_retries: Optional[int] = None,
+        **_extra: Any,
+    ) -> Any:
+        """Create and return a ``ChatAnthropic`` instance.
+
+        :param model_name: Anthropic model identifier.
+        :returns: A ``ChatAnthropic`` instance.
+        :raises ImportError: If ``langchain_anthropic`` is not installed.
+        """
+        from langchain_anthropic import (  # pylint: disable=import-outside-toplevel
+            ChatAnthropic,
+        )
+
+        LOGGER.info("Initializing Anthropic model: %s", model_name)
+
+        # ChatAnthropic requires max_tokens; use 1024 as a safe default.
+        config: dict = {
+            "model": model_name,
+            "max_tokens": max_tokens if max_tokens is not None else 1024,
+        }
+        if temperature is not None:
+            config["temperature"] = temperature
+        if top_p is not None:
+            config["top_p"] = top_p
+        if top_k is not None:
+            config["top_k"] = top_k
+        if max_retries is not None:
+            config["max_retries"] = max_retries
+
+        llm = ChatAnthropic(**config)
+        LOGGER.debug(llm)
+        return llm

--- a/bili/iris/providers/base.py
+++ b/bili/iris/providers/base.py
@@ -27,17 +27,25 @@ from typing import Any
 # the registry itself is the authoritative source of which types are active.
 KNOWN_PROVIDER_TYPES = frozenset(
     {
-        # LangChain-native remote API providers
+        # LangChain-native remote API providers (original)
         "remote_aws_bedrock",
         "remote_google_vertex",
         "remote_azure_openai",
         "remote_openai",
+        # LangChain-native remote API providers (expanded catalog)
+        "remote_anthropic",
+        "remote_mistral",
+        "remote_cohere",
+        "remote_google_genai",
+        "remote_deepseek",
+        "remote_xai",
+        "remote_groq",
         # Local in-process providers
         "local_llamacpp",
         "local_huggingface",
         # Future provider shapes (not yet implemented)
-        # "cli"   — subprocess / stdin-stdout transport
-        # "mcp"   — Model Context Protocol server transport
+        # "cli"   -- subprocess / stdin-stdout transport
+        # "mcp"   -- Model Context Protocol server transport
     }
 )
 

--- a/bili/iris/providers/builtin.py
+++ b/bili/iris/providers/builtin.py
@@ -1,8 +1,8 @@
 """Register all built-in providers in the global ``PROVIDER_REGISTRY``.
 
 Importing this module has the side effect of populating
-:data:`~bili.iris.providers.registry.PROVIDER_REGISTRY` with the six
-provider types shipped with bili-core.  It is imported once inside
+:data:`~bili.iris.providers.registry.PROVIDER_REGISTRY` with the provider
+types shipped with bili-core.  It is imported once inside
 :func:`bili.iris.loaders.llm_loader.load_model` at first call.
 
 External provider authors do NOT import this module; they call
@@ -11,27 +11,41 @@ own code at application startup.
 
 Built-in provider types
 -----------------------
-=========================  ============================================
-Provider type string        Implementation class
-=========================  ============================================
-``remote_aws_bedrock``      :class:`~.bedrock_provider.BedrockProvider`
-``remote_google_vertex``    :class:`~.vertex_provider.VertexAIProvider`
-``remote_azure_openai``     :class:`~.azure_openai_provider.AzureOpenAIProvider`
-``remote_openai``           :class:`~.openai_provider.OpenAIProvider`
-``local_llamacpp``          :class:`~.llamacpp_provider.LlamaCppProvider`
-``local_huggingface``       :class:`~.huggingface_provider.HuggingFaceProvider`
-=========================  ============================================
+================================  ================================================
+Provider type string               Implementation class
+================================  ================================================
+``remote_aws_bedrock``             :class:`~.bedrock_provider.BedrockProvider`
+``remote_google_vertex``           :class:`~.vertex_provider.VertexAIProvider`
+``remote_azure_openai``            :class:`~.azure_openai_provider.AzureOpenAIProvider`
+``remote_openai``                  :class:`~.openai_provider.OpenAIProvider`
+``remote_anthropic``               :class:`~.anthropic_provider.AnthropicProvider`
+``remote_mistral``                 :class:`~.mistral_provider.MistralProvider`
+``remote_cohere``                  :class:`~.cohere_provider.CohereProvider`
+``remote_google_genai``            :class:`~.google_genai_provider.GoogleGenAIProvider`
+``remote_deepseek``                :class:`~.deepseek_provider.DeepSeekProvider`
+``remote_xai``                     :class:`~.xai_provider.XAIProvider`
+``remote_groq``                    :class:`~.groq_provider.GroqProvider`
+``local_llamacpp``                 :class:`~.llamacpp_provider.LlamaCppProvider`
+``local_huggingface``              :class:`~.huggingface_provider.HuggingFaceProvider`
+================================  ================================================
 """
 
 import logging
 
+from .anthropic_provider import AnthropicProvider
 from .azure_openai_provider import AzureOpenAIProvider
 from .bedrock_provider import BedrockProvider
+from .cohere_provider import CohereProvider
+from .deepseek_provider import DeepSeekProvider
+from .google_genai_provider import GoogleGenAIProvider
+from .groq_provider import GroqProvider
 from .huggingface_provider import HuggingFaceProvider
 from .llamacpp_provider import LlamaCppProvider
+from .mistral_provider import MistralProvider
 from .openai_provider import OpenAIProvider
 from .registry import PROVIDER_REGISTRY
 from .vertex_provider import VertexAIProvider
+from .xai_provider import XAIProvider
 
 LOGGER = logging.getLogger(__name__)
 
@@ -40,6 +54,13 @@ _BUILTIN_PROVIDERS = {
     "remote_google_vertex": VertexAIProvider,
     "remote_azure_openai": AzureOpenAIProvider,
     "remote_openai": OpenAIProvider,
+    "remote_anthropic": AnthropicProvider,
+    "remote_mistral": MistralProvider,
+    "remote_cohere": CohereProvider,
+    "remote_google_genai": GoogleGenAIProvider,
+    "remote_deepseek": DeepSeekProvider,
+    "remote_xai": XAIProvider,
+    "remote_groq": GroqProvider,
     "local_llamacpp": LlamaCppProvider,
     "local_huggingface": HuggingFaceProvider,
 }

--- a/bili/iris/providers/cohere_provider.py
+++ b/bili/iris/providers/cohere_provider.py
@@ -1,0 +1,81 @@
+"""Cohere provider for bili-core IRIS.
+
+Wraps ``langchain_cohere.ChatCohere`` behind the :class:`LLMProvider`
+interface.  Supports Cohere Command model families (Command A+, Command A,
+Command R+, Command R) accessed via the Cohere API.
+
+Authentication reads ``COHERE_API_KEY`` from the environment.
+
+Heavy dependencies
+------------------
+``langchain_cohere`` is imported inside :meth:`CohereProvider.load` to
+avoid module-level import cost when this provider is not in use.
+"""
+
+# pylint: disable=duplicate-code
+import logging
+from typing import Any, Optional
+
+from .base import LLMProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=too-few-public-methods
+class CohereProvider(LLMProvider):
+    """LangChain-native Cohere provider.
+
+    Accepted kwargs
+    ---------------
+    model_name : str
+        Cohere model identifier (e.g. ``"command-a-plus-05-2026"``,
+        ``"command-r-plus"``).
+    max_tokens : int, optional
+        Maximum completion tokens.
+    temperature : float, optional
+        Sampling temperature.
+    top_p : float, optional
+        Nucleus sampling probability.
+    top_k : int, optional
+        Top-k sampling limit.
+    max_retries : int, optional
+        Maximum number of automatic retries on transient errors.
+    """
+
+    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments
+        self,
+        model_name: str,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        top_k: Optional[int] = None,
+        max_retries: Optional[int] = None,
+        **_extra: Any,
+    ) -> Any:
+        """Create and return a ``ChatCohere`` instance.
+
+        :param model_name: Cohere model identifier.
+        :returns: A ``ChatCohere`` instance.
+        :raises ImportError: If ``langchain_cohere`` is not installed.
+        """
+        from langchain_cohere import (  # pylint: disable=import-outside-toplevel,import-error
+            ChatCohere,
+        )
+
+        LOGGER.info("Initializing Cohere model: %s", model_name)
+
+        config: dict = {"model": model_name}
+        if max_tokens is not None:
+            config["max_tokens"] = max_tokens
+        if temperature is not None:
+            config["temperature"] = temperature
+        if top_p is not None:
+            config["p"] = top_p
+        if top_k is not None:
+            config["k"] = top_k
+        if max_retries is not None:
+            config["max_retries"] = max_retries
+
+        llm = ChatCohere(**config)
+        LOGGER.debug(llm)
+        return llm

--- a/bili/iris/providers/deepseek_provider.py
+++ b/bili/iris/providers/deepseek_provider.py
@@ -1,0 +1,76 @@
+"""DeepSeek provider for bili-core IRIS.
+
+Wraps ``langchain_deepseek.ChatDeepSeek`` behind the :class:`LLMProvider`
+interface.  Supports DeepSeek models (DeepSeek-V3/V4 chat and DeepSeek-R1
+reasoner families) accessed via the DeepSeek API.
+
+Authentication reads ``DEEPSEEK_API_KEY`` from the environment.
+
+Heavy dependencies
+------------------
+``langchain_deepseek`` is imported inside :meth:`DeepSeekProvider.load` to
+avoid module-level import cost when this provider is not in use.
+"""
+
+# pylint: disable=duplicate-code
+import logging
+from typing import Any, Optional
+
+from .base import LLMProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=too-few-public-methods
+class DeepSeekProvider(LLMProvider):
+    """LangChain-native DeepSeek provider.
+
+    Accepted kwargs
+    ---------------
+    model_name : str
+        DeepSeek model identifier (e.g. ``"deepseek-chat"``,
+        ``"deepseek-reasoner"``).
+    max_tokens : int, optional
+        Maximum completion tokens.
+    temperature : float, optional
+        Sampling temperature.
+    top_p : float, optional
+        Nucleus sampling probability.
+    max_retries : int, optional
+        Maximum number of automatic retries on transient errors.
+    """
+
+    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments
+        self,
+        model_name: str,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        max_retries: Optional[int] = None,
+        **_extra: Any,
+    ) -> Any:
+        """Create and return a ``ChatDeepSeek`` instance.
+
+        :param model_name: DeepSeek model identifier.
+        :returns: A ``ChatDeepSeek`` instance.
+        :raises ImportError: If ``langchain_deepseek`` is not installed.
+        """
+        from langchain_deepseek import (  # pylint: disable=import-outside-toplevel,import-error
+            ChatDeepSeek,
+        )
+
+        LOGGER.info("Initializing DeepSeek model: %s", model_name)
+
+        config: dict = {"model": model_name}
+        if max_tokens is not None:
+            config["max_tokens"] = max_tokens
+        if temperature is not None:
+            config["temperature"] = temperature
+        if top_p is not None:
+            config["top_p"] = top_p
+        if max_retries is not None:
+            config["max_retries"] = max_retries
+
+        llm = ChatDeepSeek(**config)
+        LOGGER.debug(llm)
+        return llm

--- a/bili/iris/providers/google_genai_provider.py
+++ b/bili/iris/providers/google_genai_provider.py
@@ -1,0 +1,82 @@
+"""Google Generative AI (Gemini direct API) provider for bili-core IRIS.
+
+Wraps ``langchain_google_genai.ChatGoogleGenerativeAI`` behind the
+:class:`LLMProvider` interface.  Provides access to Gemini models via the
+Google AI Developer API, as a complement to the existing
+``remote_google_vertex`` provider which routes through Google Cloud Vertex AI.
+
+Authentication reads ``GOOGLE_API_KEY`` from the environment.
+
+Heavy dependencies
+------------------
+``langchain_google_genai`` is imported inside :meth:`GoogleGenAIProvider.load`
+to avoid module-level import cost when this provider is not in use.
+"""
+
+# pylint: disable=duplicate-code
+import logging
+from typing import Any, Optional
+
+from .base import LLMProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=too-few-public-methods
+class GoogleGenAIProvider(LLMProvider):
+    """LangChain-native Google Generative AI (Gemini) provider.
+
+    Accepted kwargs
+    ---------------
+    model_name : str
+        Gemini model identifier (e.g. ``"gemini-2.5-flash"``,
+        ``"gemini-2.0-flash"``).
+    max_tokens : int, optional
+        Maximum completion tokens (mapped to ``max_output_tokens``).
+    temperature : float, optional
+        Sampling temperature.
+    top_p : float, optional
+        Nucleus sampling probability.
+    top_k : int, optional
+        Top-k sampling limit.
+    max_retries : int, optional
+        Maximum number of automatic retries on transient errors.
+    """
+
+    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments
+        self,
+        model_name: str,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        top_k: Optional[int] = None,
+        max_retries: Optional[int] = None,
+        **_extra: Any,
+    ) -> Any:
+        """Create and return a ``ChatGoogleGenerativeAI`` instance.
+
+        :param model_name: Gemini model identifier.
+        :returns: A ``ChatGoogleGenerativeAI`` instance.
+        :raises ImportError: If ``langchain_google_genai`` is not installed.
+        """
+        from langchain_google_genai import (  # pylint: disable=import-outside-toplevel,import-error
+            ChatGoogleGenerativeAI,
+        )
+
+        LOGGER.info("Initializing Google GenAI model: %s", model_name)
+
+        config: dict = {"model": model_name}
+        if max_tokens is not None:
+            config["max_output_tokens"] = max_tokens
+        if temperature is not None:
+            config["temperature"] = temperature
+        if top_p is not None:
+            config["top_p"] = top_p
+        if top_k is not None:
+            config["top_k"] = top_k
+        if max_retries is not None:
+            config["max_retries"] = max_retries
+
+        llm = ChatGoogleGenerativeAI(**config)
+        LOGGER.debug(llm)
+        return llm

--- a/bili/iris/providers/groq_provider.py
+++ b/bili/iris/providers/groq_provider.py
@@ -1,0 +1,76 @@
+"""Groq provider for bili-core IRIS.
+
+Wraps ``langchain_groq.ChatGroq`` behind the :class:`LLMProvider` interface.
+Supports models served on Groq's low-latency inference hardware, including the
+Llama, Gemma, and compound-beta families.
+
+Authentication reads ``GROQ_API_KEY`` from the environment.
+
+Heavy dependencies
+------------------
+``langchain_groq`` is imported inside :meth:`GroqProvider.load` to avoid
+module-level import cost when this provider is not in use.
+"""
+
+# pylint: disable=duplicate-code
+import logging
+from typing import Any, Optional
+
+from .base import LLMProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=too-few-public-methods
+class GroqProvider(LLMProvider):
+    """LangChain-native Groq provider.
+
+    Accepted kwargs
+    ---------------
+    model_name : str
+        Groq-hosted model identifier (e.g. ``"llama-3.3-70b-versatile"``,
+        ``"compound-beta"``).
+    max_tokens : int, optional
+        Maximum completion tokens.
+    temperature : float, optional
+        Sampling temperature.
+    top_p : float, optional
+        Nucleus sampling probability.
+    max_retries : int, optional
+        Maximum number of automatic retries on transient errors.
+    """
+
+    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments
+        self,
+        model_name: str,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        max_retries: Optional[int] = None,
+        **_extra: Any,
+    ) -> Any:
+        """Create and return a ``ChatGroq`` instance.
+
+        :param model_name: Groq-hosted model identifier.
+        :returns: A ``ChatGroq`` instance.
+        :raises ImportError: If ``langchain_groq`` is not installed.
+        """
+        from langchain_groq import (  # pylint: disable=import-outside-toplevel,import-error
+            ChatGroq,
+        )
+
+        LOGGER.info("Initializing Groq model: %s", model_name)
+
+        config: dict = {"model_name": model_name}
+        if max_tokens is not None:
+            config["max_tokens"] = max_tokens
+        if temperature is not None:
+            config["temperature"] = temperature
+        if top_p is not None:
+            config["top_p"] = top_p
+        if max_retries is not None:
+            config["max_retries"] = max_retries
+
+        llm = ChatGroq(**config)
+        LOGGER.debug(llm)
+        return llm

--- a/bili/iris/providers/mistral_provider.py
+++ b/bili/iris/providers/mistral_provider.py
@@ -1,0 +1,76 @@
+"""Mistral AI provider for bili-core IRIS.
+
+Wraps ``langchain_mistralai.ChatMistralAI`` behind the :class:`LLMProvider`
+interface.  Supports Mistral model families (Mistral Large, Mistral Small,
+Codestral, and related models) accessed via the Mistral AI API.
+
+Authentication reads ``MISTRAL_API_KEY`` from the environment.
+
+Heavy dependencies
+------------------
+``langchain_mistralai`` is imported inside :meth:`MistralProvider.load` to
+avoid module-level import cost when this provider is not in use.
+"""
+
+# pylint: disable=duplicate-code
+import logging
+from typing import Any, Optional
+
+from .base import LLMProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=too-few-public-methods
+class MistralProvider(LLMProvider):
+    """LangChain-native Mistral AI provider.
+
+    Accepted kwargs
+    ---------------
+    model_name : str
+        Mistral model identifier (e.g. ``"mistral-large-latest"``,
+        ``"mistral-small-latest"``).
+    max_tokens : int, optional
+        Maximum completion tokens.
+    temperature : float, optional
+        Sampling temperature.
+    top_p : float, optional
+        Nucleus sampling probability.
+    max_retries : int, optional
+        Maximum number of automatic retries on transient errors.
+    """
+
+    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments
+        self,
+        model_name: str,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        max_retries: Optional[int] = None,
+        **_extra: Any,
+    ) -> Any:
+        """Create and return a ``ChatMistralAI`` instance.
+
+        :param model_name: Mistral model identifier.
+        :returns: A ``ChatMistralAI`` instance.
+        :raises ImportError: If ``langchain_mistralai`` is not installed.
+        """
+        from langchain_mistralai import (  # pylint: disable=import-outside-toplevel,import-error
+            ChatMistralAI,
+        )
+
+        LOGGER.info("Initializing Mistral model: %s", model_name)
+
+        config: dict = {"model": model_name}
+        if max_tokens is not None:
+            config["max_tokens"] = max_tokens
+        if temperature is not None:
+            config["temperature"] = temperature
+        if top_p is not None:
+            config["top_p"] = top_p
+        if max_retries is not None:
+            config["max_retries"] = max_retries
+
+        llm = ChatMistralAI(**config)
+        LOGGER.debug(llm)
+        return llm

--- a/bili/iris/providers/tests/test_new_providers.py
+++ b/bili/iris/providers/tests/test_new_providers.py
@@ -1,0 +1,754 @@
+"""Tests for the new built-in API providers added in the provider-api-expansion.
+
+Covers:
+- Each concrete provider's ``load()`` method with mocked heavy dependencies:
+  Anthropic, Mistral, Cohere, Google GenAI, DeepSeek, xAI, Groq
+- All 7 new types are registered in PROVIDER_REGISTRY via builtin.py
+- LLM_MODELS entries exist for each new provider type
+- Heuristic resolution routes new model ID patterns correctly
+- ``load_model()`` delegates to each new provider via the registry else-branch
+"""
+
+# pylint: disable=too-few-public-methods,duplicate-code
+
+import sys
+from contextlib import contextmanager
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import bili.iris.providers.builtin  # noqa: F401  pylint: disable=unused-import
+from bili.iris.providers.anthropic_provider import AnthropicProvider
+from bili.iris.providers.base import LLMProvider
+from bili.iris.providers.cohere_provider import CohereProvider
+from bili.iris.providers.deepseek_provider import DeepSeekProvider
+from bili.iris.providers.google_genai_provider import GoogleGenAIProvider
+from bili.iris.providers.groq_provider import GroqProvider
+from bili.iris.providers.mistral_provider import MistralProvider
+from bili.iris.providers.registry import PROVIDER_REGISTRY
+from bili.iris.providers.xai_provider import XAIProvider
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _mock_module(module_name: str, **attrs):
+    """Temporarily inject a fake module into sys.modules for testing lazy imports.
+
+    Providers import their SDK inside ``load()`` to keep the base install lean.
+    When the SDK is not installed, tests need to mock the module so that the
+    ``from <sdk> import <Class>`` inside ``load()`` does not raise ImportError.
+
+    Usage::
+
+        with _mock_module("langchain_foo", ChatFoo=MagicMock()) as mod:
+            provider.load(model_name="foo")
+            kwargs = mod.ChatFoo.call_args[1]
+    """
+    mod = ModuleType(module_name)
+    for attr, value in attrs.items():
+        setattr(mod, attr, value)
+    already_present = module_name in sys.modules
+    sys.modules[module_name] = mod
+    try:
+        yield mod
+    finally:
+        if already_present:
+            sys.modules[module_name] = already_present  # type: ignore[assignment]
+        else:
+            sys.modules.pop(module_name, None)
+
+
+# ---------------------------------------------------------------------------
+# Builtin registration — new provider types
+# ---------------------------------------------------------------------------
+
+_NEW_PROVIDER_TYPES = {
+    "remote_anthropic",
+    "remote_mistral",
+    "remote_cohere",
+    "remote_google_genai",
+    "remote_deepseek",
+    "remote_xai",
+    "remote_groq",
+}
+
+
+class TestNewBuiltinRegistration:
+    """Verify all 7 new provider types are registered in PROVIDER_REGISTRY."""
+
+    def test_all_new_providers_registered(self):
+        """Verify each new provider type is present in PROVIDER_REGISTRY."""
+        for provider_type in _NEW_PROVIDER_TYPES:
+            assert (
+                provider_type in PROVIDER_REGISTRY
+            ), f"Expected '{provider_type}' in PROVIDER_REGISTRY"
+
+    def test_new_providers_are_llmprovider_subclasses(self):
+        """Verify every new registered provider is an LLMProvider subclass."""
+        for provider_type in _NEW_PROVIDER_TYPES:
+            cls = PROVIDER_REGISTRY.get(provider_type)
+            assert cls is not None
+            assert issubclass(
+                cls, LLMProvider
+            ), f"Provider '{provider_type}' → {cls} is not an LLMProvider subclass"
+
+    def test_provider_classes_map_correctly(self):
+        """Verify each type maps to its expected implementation class."""
+        mapping = {
+            "remote_anthropic": AnthropicProvider,
+            "remote_mistral": MistralProvider,
+            "remote_cohere": CohereProvider,
+            "remote_google_genai": GoogleGenAIProvider,
+            "remote_deepseek": DeepSeekProvider,
+            "remote_xai": XAIProvider,
+            "remote_groq": GroqProvider,
+        }
+        for provider_type, expected_cls in mapping.items():
+            registered = PROVIDER_REGISTRY.get(provider_type)
+            assert registered is expected_cls, (
+                f"Expected '{provider_type}' → {expected_cls.__name__}, "
+                f"got {registered}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# LLM_MODELS entries
+# ---------------------------------------------------------------------------
+
+
+class TestLLMModelsEntries:
+    """Verify each new provider type has entries in LLM_MODELS."""
+
+    def test_all_new_types_in_llm_models(self):
+        """Verify each new provider type key appears in LLM_MODELS."""
+        from bili.iris.config.llm_config import (  # pylint: disable=import-outside-toplevel
+            LLM_MODELS,
+        )
+
+        for provider_type in _NEW_PROVIDER_TYPES:
+            assert (
+                provider_type in LLM_MODELS
+            ), f"Expected '{provider_type}' in LLM_MODELS"
+
+    def test_each_entry_has_models_list(self):
+        """Verify every new LLM_MODELS entry has a non-empty models list."""
+        from bili.iris.config.llm_config import (  # pylint: disable=import-outside-toplevel
+            LLM_MODELS,
+        )
+
+        for provider_type in _NEW_PROVIDER_TYPES:
+            entry = LLM_MODELS.get(provider_type, {})
+            models = entry.get("models", [])
+            assert len(models) > 0, f"LLM_MODELS['{provider_type}']['models'] is empty"
+
+    def test_each_model_entry_has_required_fields(self):
+        """Verify every model entry has model_name and model_id."""
+        from bili.iris.config.llm_config import (  # pylint: disable=import-outside-toplevel
+            LLM_MODELS,
+        )
+
+        for provider_type in _NEW_PROVIDER_TYPES:
+            models = LLM_MODELS.get(provider_type, {}).get("models", [])
+            for model in models:
+                assert (
+                    "model_name" in model
+                ), f"Missing 'model_name' in {provider_type} entry: {model}"
+                assert (
+                    "model_id" in model
+                ), f"Missing 'model_id' in {provider_type} entry: {model}"
+
+    def test_anthropic_models_present(self):
+        """Verify the four Anthropic model IDs are in LLM_MODELS."""
+        from bili.iris.config.llm_config import (  # pylint: disable=import-outside-toplevel
+            LLM_MODELS,
+        )
+
+        ids = {m["model_id"] for m in LLM_MODELS["remote_anthropic"]["models"]}
+        assert "claude-opus-4-8" in ids
+        assert "claude-sonnet-4-6" in ids
+        assert "claude-haiku-4-5" in ids
+        assert "claude-fable-5" in ids
+
+    def test_groq_models_present(self):
+        """Verify Groq compound-beta models are in LLM_MODELS."""
+        from bili.iris.config.llm_config import (  # pylint: disable=import-outside-toplevel
+            LLM_MODELS,
+        )
+
+        ids = {m["model_id"] for m in LLM_MODELS["remote_groq"]["models"]}
+        assert "compound-beta" in ids
+        assert "compound-beta-mini" in ids
+
+
+# ---------------------------------------------------------------------------
+# Heuristic resolution — new patterns
+# ---------------------------------------------------------------------------
+
+
+class TestHeuristicResolution:
+    """Verify _HEURISTIC_RULES routes new model ID patterns correctly."""
+
+    def _resolve(self, model_name: str):
+        """Import and call _resolve_model_full, ignoring LLM_MODELS (patch it)."""
+        from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+            _resolve_model_full,
+        )
+
+        # Patch _lookup_in_llm_models to always return None so heuristics run.
+        with patch(
+            "bili.aether.compiler.llm_resolver._lookup_in_llm_models",
+            return_value=None,
+        ):
+            return _resolve_model_full(model_name)
+
+    def test_claude_routes_to_anthropic(self):
+        """Verify 'claude-' prefix routes to remote_anthropic."""
+        provider, model_id, _ = self._resolve("claude-opus-4-8")
+        assert provider == "remote_anthropic"
+        assert model_id == "claude-opus-4-8"
+
+    def test_anthropic_claude_prefix_still_routes_to_bedrock(self):
+        """Verify 'anthropic.claude' routes to remote_aws_bedrock (Bedrock-hosted)."""
+        provider, model_id, _ = self._resolve("anthropic.claude-v2")
+        assert provider == "remote_aws_bedrock"
+        assert model_id == "anthropic.claude-v2"
+
+    def test_mistral_routes_to_mistral_provider(self):
+        """Verify 'mistral-' prefix routes to remote_mistral."""
+        provider, _, _ = self._resolve("mistral-large-latest")
+        assert provider == "remote_mistral"
+
+    def test_codestral_routes_to_mistral_provider(self):
+        """Verify 'codestral' routes to remote_mistral."""
+        provider, _, _ = self._resolve("codestral-latest")
+        assert provider == "remote_mistral"
+
+    def test_command_routes_to_cohere(self):
+        """Verify 'command-' prefix routes to remote_cohere."""
+        provider, _, _ = self._resolve("command-r-plus")
+        assert provider == "remote_cohere"
+
+    def test_gemini_routes_to_google_genai(self):
+        """Verify 'gemini-' prefix routes to remote_google_genai."""
+        provider, _, _ = self._resolve("gemini-2.5-flash")
+        assert provider == "remote_google_genai"
+
+    def test_deepseek_routes_to_deepseek(self):
+        """Verify 'deepseek-' prefix routes to remote_deepseek."""
+        provider, _, _ = self._resolve("deepseek-chat")
+        assert provider == "remote_deepseek"
+
+    def test_grok_routes_to_xai(self):
+        """Verify 'grok-' prefix routes to remote_xai."""
+        provider, _, _ = self._resolve("grok-3-latest")
+        assert provider == "remote_xai"
+
+    def test_llama3_routes_to_groq(self):
+        """Verify 'llama-3' prefix routes to remote_groq."""
+        provider, _, _ = self._resolve("llama-3.3-70b-versatile")
+        assert provider == "remote_groq"
+
+    def test_compound_beta_routes_to_groq(self):
+        """Verify 'compound-beta' routes to remote_groq."""
+        provider, _, _ = self._resolve("compound-beta")
+        assert provider == "remote_groq"
+
+
+# ---------------------------------------------------------------------------
+# AnthropicProvider
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicProvider:
+    """Verify AnthropicProvider.load() constructs ChatAnthropic correctly."""
+
+    def test_minimal_load_applies_default_max_tokens(self):
+        """Verify minimal config uses 1024 as the default max_tokens."""
+        mock_cls = MagicMock()
+        with patch("langchain_anthropic.ChatAnthropic", mock_cls):
+            AnthropicProvider().load(model_name="claude-sonnet-4-6")
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model"] == "claude-sonnet-4-6"
+        assert kwargs["max_tokens"] == 1024
+
+    def test_explicit_max_tokens_overrides_default(self):
+        """Verify provided max_tokens takes precedence over the default."""
+        mock_cls = MagicMock()
+        with patch("langchain_anthropic.ChatAnthropic", mock_cls):
+            AnthropicProvider().load(model_name="claude-opus-4-8", max_tokens=4096)
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["max_tokens"] == 4096
+
+    def test_full_config(self):
+        """Verify all optional params are forwarded to ChatAnthropic."""
+        mock_cls = MagicMock()
+        with patch("langchain_anthropic.ChatAnthropic", mock_cls):
+            AnthropicProvider().load(
+                model_name="claude-haiku-4-5",
+                max_tokens=512,
+                temperature=0.7,
+                top_p=0.9,
+                top_k=10,
+                max_retries=3,
+            )
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model"] == "claude-haiku-4-5"
+        assert kwargs["max_tokens"] == 512
+        assert kwargs["temperature"] == 0.7
+        assert kwargs["top_p"] == 0.9
+        assert kwargs["top_k"] == 10
+        assert kwargs["max_retries"] == 3
+
+    def test_extra_kwargs_ignored(self):
+        """Verify unknown kwargs do not raise errors."""
+        mock_cls = MagicMock()
+        with patch("langchain_anthropic.ChatAnthropic", mock_cls):
+            AnthropicProvider().load(model_name="claude-sonnet-4-6", unknown="x")
+        assert mock_cls.called
+
+    def test_none_max_tokens_uses_default(self):
+        """Verify passing max_tokens=None applies the 1024 default."""
+        mock_cls = MagicMock()
+        with patch("langchain_anthropic.ChatAnthropic", mock_cls):
+            AnthropicProvider().load(model_name="claude-haiku-4-5", max_tokens=None)
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["max_tokens"] == 1024
+
+
+# ---------------------------------------------------------------------------
+# MistralProvider
+# ---------------------------------------------------------------------------
+
+
+class TestMistralProvider:
+    """Verify MistralProvider.load() constructs ChatMistralAI correctly."""
+
+    def test_minimal_load(self):
+        """Verify minimal config passes model to ChatMistralAI."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_mistralai", ChatMistralAI=mock_cls):
+            MistralProvider().load(model_name="mistral-large-latest")
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model"] == "mistral-large-latest"
+
+    def test_full_config(self):
+        """Verify all optional params are forwarded to ChatMistralAI."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_mistralai", ChatMistralAI=mock_cls):
+            MistralProvider().load(
+                model_name="mistral-small-latest",
+                max_tokens=1024,
+                temperature=0.4,
+                top_p=0.85,
+                max_retries=2,
+            )
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model"] == "mistral-small-latest"
+        assert kwargs["max_tokens"] == 1024
+        assert kwargs["temperature"] == 0.4
+        assert kwargs["top_p"] == 0.85
+        assert kwargs["max_retries"] == 2
+
+    def test_optional_params_absent_when_not_provided(self):
+        """Verify optional params are absent from config when not provided."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_mistralai", ChatMistralAI=mock_cls):
+            MistralProvider().load(model_name="mistral-large-latest")
+        kwargs = mock_cls.call_args[1]
+        for absent in ("max_tokens", "temperature", "top_p", "max_retries"):
+            assert absent not in kwargs
+
+    def test_extra_kwargs_ignored(self):
+        """Verify unknown kwargs do not raise errors."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_mistralai", ChatMistralAI=mock_cls):
+            MistralProvider().load(model_name="mistral-large-latest", seed=42)
+        assert mock_cls.called
+
+
+# ---------------------------------------------------------------------------
+# CohereProvider
+# ---------------------------------------------------------------------------
+
+
+class TestCohereProvider:
+    """Verify CohereProvider.load() constructs ChatCohere correctly."""
+
+    def test_minimal_load(self):
+        """Verify minimal config passes model to ChatCohere."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_cohere", ChatCohere=mock_cls):
+            CohereProvider().load(model_name="command-r-plus")
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model"] == "command-r-plus"
+
+    def test_top_p_maps_to_p(self):
+        """Verify top_p is forwarded as 'p' (Cohere's parameter name)."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_cohere", ChatCohere=mock_cls):
+            CohereProvider().load(model_name="command-r", top_p=0.8)
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["p"] == 0.8
+
+    def test_top_k_maps_to_k(self):
+        """Verify top_k is forwarded as 'k' (Cohere's parameter name)."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_cohere", ChatCohere=mock_cls):
+            CohereProvider().load(model_name="command-r", top_k=40)
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["k"] == 40
+
+    def test_full_config(self):
+        """Verify all optional params are forwarded to ChatCohere."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_cohere", ChatCohere=mock_cls):
+            CohereProvider().load(
+                model_name="command-a-plus-05-2026",
+                max_tokens=2000,
+                temperature=0.5,
+                top_p=0.9,
+                top_k=50,
+                max_retries=3,
+            )
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model"] == "command-a-plus-05-2026"
+        assert kwargs["max_tokens"] == 2000
+        assert kwargs["temperature"] == 0.5
+        assert kwargs["p"] == 0.9
+        assert kwargs["k"] == 50
+        assert kwargs["max_retries"] == 3
+
+    def test_extra_kwargs_ignored(self):
+        """Verify unknown kwargs do not raise errors."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_cohere", ChatCohere=mock_cls):
+            CohereProvider().load(model_name="command-r", seed=99)
+        assert mock_cls.called
+
+
+# ---------------------------------------------------------------------------
+# GoogleGenAIProvider
+# ---------------------------------------------------------------------------
+
+
+class TestGoogleGenAIProvider:
+    """Verify GoogleGenAIProvider.load() constructs ChatGoogleGenerativeAI correctly."""
+
+    def test_minimal_load(self):
+        """Verify minimal config passes model to ChatGoogleGenerativeAI."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_google_genai", ChatGoogleGenerativeAI=mock_cls):
+            GoogleGenAIProvider().load(model_name="gemini-2.5-flash")
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model"] == "gemini-2.5-flash"
+
+    def test_max_tokens_maps_to_max_output_tokens(self):
+        """Verify max_tokens is forwarded as max_output_tokens."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_google_genai", ChatGoogleGenerativeAI=mock_cls):
+            GoogleGenAIProvider().load(model_name="gemini-2.0-flash", max_tokens=1024)
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["max_output_tokens"] == 1024
+        assert "max_tokens" not in kwargs
+
+    def test_full_config(self):
+        """Verify all optional params are forwarded to ChatGoogleGenerativeAI."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_google_genai", ChatGoogleGenerativeAI=mock_cls):
+            GoogleGenAIProvider().load(
+                model_name="gemini-2.5-flash",
+                max_tokens=4096,
+                temperature=0.6,
+                top_p=0.95,
+                top_k=30,
+                max_retries=2,
+            )
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model"] == "gemini-2.5-flash"
+        assert kwargs["max_output_tokens"] == 4096
+        assert kwargs["temperature"] == 0.6
+        assert kwargs["top_p"] == 0.95
+        assert kwargs["top_k"] == 30
+        assert kwargs["max_retries"] == 2
+
+    def test_optional_params_absent_when_not_provided(self):
+        """Verify optional params are absent when not provided."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_google_genai", ChatGoogleGenerativeAI=mock_cls):
+            GoogleGenAIProvider().load(model_name="gemini-2.0-flash-lite")
+        kwargs = mock_cls.call_args[1]
+        for absent in ("max_output_tokens", "temperature", "top_p", "top_k"):
+            assert absent not in kwargs
+
+    def test_extra_kwargs_ignored(self):
+        """Verify unknown kwargs do not raise errors."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_google_genai", ChatGoogleGenerativeAI=mock_cls):
+            GoogleGenAIProvider().load(model_name="gemini-2.5-flash", seed=1)
+        assert mock_cls.called
+
+
+# ---------------------------------------------------------------------------
+# DeepSeekProvider
+# ---------------------------------------------------------------------------
+
+
+class TestDeepSeekProvider:
+    """Verify DeepSeekProvider.load() constructs ChatDeepSeek correctly."""
+
+    def test_minimal_load(self):
+        """Verify minimal config passes model to ChatDeepSeek."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_deepseek", ChatDeepSeek=mock_cls):
+            DeepSeekProvider().load(model_name="deepseek-chat")
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model"] == "deepseek-chat"
+
+    def test_full_config(self):
+        """Verify all optional params are forwarded to ChatDeepSeek."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_deepseek", ChatDeepSeek=mock_cls):
+            DeepSeekProvider().load(
+                model_name="deepseek-reasoner",
+                max_tokens=8192,
+                temperature=0.0,
+                top_p=1.0,
+                max_retries=3,
+            )
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model"] == "deepseek-reasoner"
+        assert kwargs["max_tokens"] == 8192
+        assert kwargs["temperature"] == 0.0
+        assert kwargs["top_p"] == 1.0
+        assert kwargs["max_retries"] == 3
+
+    def test_optional_params_absent_when_not_provided(self):
+        """Verify optional params are absent when not provided."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_deepseek", ChatDeepSeek=mock_cls):
+            DeepSeekProvider().load(model_name="deepseek-chat")
+        kwargs = mock_cls.call_args[1]
+        for absent in ("max_tokens", "temperature", "top_p", "max_retries"):
+            assert absent not in kwargs
+
+    def test_extra_kwargs_ignored(self):
+        """Verify unknown kwargs do not raise errors."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_deepseek", ChatDeepSeek=mock_cls):
+            DeepSeekProvider().load(model_name="deepseek-chat", seed=0)
+        assert mock_cls.called
+
+
+# ---------------------------------------------------------------------------
+# XAIProvider
+# ---------------------------------------------------------------------------
+
+
+class TestXAIProvider:
+    """Verify XAIProvider.load() constructs ChatXAI correctly."""
+
+    def test_minimal_load(self):
+        """Verify minimal config passes model to ChatXAI."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_xai", ChatXAI=mock_cls):
+            XAIProvider().load(model_name="grok-3-latest")
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model"] == "grok-3-latest"
+
+    def test_full_config(self):
+        """Verify all optional params are forwarded to ChatXAI."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_xai", ChatXAI=mock_cls):
+            XAIProvider().load(
+                model_name="grok-beta",
+                max_tokens=4096,
+                temperature=0.8,
+                top_p=0.9,
+                max_retries=2,
+            )
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model"] == "grok-beta"
+        assert kwargs["max_tokens"] == 4096
+        assert kwargs["temperature"] == 0.8
+        assert kwargs["top_p"] == 0.9
+        assert kwargs["max_retries"] == 2
+
+    def test_optional_params_absent_when_not_provided(self):
+        """Verify optional params are absent when not provided."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_xai", ChatXAI=mock_cls):
+            XAIProvider().load(model_name="grok-3-latest")
+        kwargs = mock_cls.call_args[1]
+        for absent in ("max_tokens", "temperature", "top_p", "max_retries"):
+            assert absent not in kwargs
+
+    def test_extra_kwargs_ignored(self):
+        """Verify unknown kwargs do not raise errors."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_xai", ChatXAI=mock_cls):
+            XAIProvider().load(model_name="grok-3-latest", seed=0)
+        assert mock_cls.called
+
+
+# ---------------------------------------------------------------------------
+# GroqProvider
+# ---------------------------------------------------------------------------
+
+
+class TestGroqProvider:
+    """Verify GroqProvider.load() constructs ChatGroq correctly."""
+
+    def test_minimal_load(self):
+        """Verify minimal config passes model_name to ChatGroq."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_groq", ChatGroq=mock_cls):
+            GroqProvider().load(model_name="llama-3.3-70b-versatile")
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model_name"] == "llama-3.3-70b-versatile"
+
+    def test_full_config(self):
+        """Verify all optional params are forwarded to ChatGroq."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_groq", ChatGroq=mock_cls):
+            GroqProvider().load(
+                model_name="compound-beta",
+                max_tokens=8000,
+                temperature=0.2,
+                top_p=0.95,
+                max_retries=3,
+            )
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model_name"] == "compound-beta"
+        assert kwargs["max_tokens"] == 8000
+        assert kwargs["temperature"] == 0.2
+        assert kwargs["top_p"] == 0.95
+        assert kwargs["max_retries"] == 3
+
+    def test_optional_params_absent_when_not_provided(self):
+        """Verify optional params are absent when not provided."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_groq", ChatGroq=mock_cls):
+            GroqProvider().load(model_name="llama-3.1-8b-instant")
+        kwargs = mock_cls.call_args[1]
+        for absent in ("max_tokens", "temperature", "top_p", "max_retries"):
+            assert absent not in kwargs
+
+    def test_extra_kwargs_ignored(self):
+        """Verify unknown kwargs do not raise errors."""
+        mock_cls = MagicMock()
+        with _mock_module("langchain_groq", ChatGroq=mock_cls):
+            GroqProvider().load(model_name="compound-beta-mini", seed=9)
+        assert mock_cls.called
+
+
+# ---------------------------------------------------------------------------
+# load_model() registry-path integration for new providers
+# ---------------------------------------------------------------------------
+
+
+class TestLoadModelNewProviders:
+    """Verify load_model() routes new provider types via the registry."""
+
+    def _run_via_registry(self, provider_type: str) -> MagicMock:
+        """Register a stub, call load_model(), return the stub LLM."""
+        from bili.iris.loaders.llm_loader import (  # pylint: disable=import-outside-toplevel
+            load_model,
+        )
+
+        mock_llm = MagicMock()
+
+        class _StubProvider(LLMProvider):
+            def load(self, **kwargs):
+                return mock_llm
+
+        # Each test uses a unique key to avoid collisions between parallel runs.
+        test_key = f"_test_{provider_type}"
+        PROVIDER_REGISTRY.register(test_key, _StubProvider)
+        try:
+            result = load_model(test_key, model_name="any")
+            assert result is mock_llm
+            return result
+        finally:
+            PROVIDER_REGISTRY.unregister(test_key)
+
+    def test_anthropic_registry_path(self):
+        """Verify load_model delegates to a registered anthropic-style provider."""
+        self._run_via_registry("remote_anthropic")
+
+    def test_mistral_registry_path(self):
+        """Verify load_model delegates to a registered mistral-style provider."""
+        self._run_via_registry("remote_mistral")
+
+    def test_cohere_registry_path(self):
+        """Verify load_model delegates to a registered cohere-style provider."""
+        self._run_via_registry("remote_cohere")
+
+    def test_google_genai_registry_path(self):
+        """Verify load_model delegates to a registered google-genai-style provider."""
+        self._run_via_registry("remote_google_genai")
+
+    def test_deepseek_registry_path(self):
+        """Verify load_model delegates to a registered deepseek-style provider."""
+        self._run_via_registry("remote_deepseek")
+
+    def test_xai_registry_path(self):
+        """Verify load_model delegates to a registered xai-style provider."""
+        self._run_via_registry("remote_xai")
+
+    def test_groq_registry_path(self):
+        """Verify load_model delegates to a registered groq-style provider."""
+        self._run_via_registry("remote_groq")
+
+    @pytest.mark.parametrize(
+        "model_id,expected_provider",
+        [
+            # Anthropic direct: claude-* IDs registered under remote_anthropic,
+            # NOT under Bedrock (those use the anthropic.claude-* prefix).
+            ("claude-sonnet-4-6", "remote_anthropic"),
+            ("claude-opus-4-8", "remote_anthropic"),
+            ("claude-haiku-4-5", "remote_anthropic"),
+            # Mistral: registered under remote_mistral (not Bedrock's mistral.*)
+            ("mistral-large-latest", "remote_mistral"),
+            ("codestral-latest", "remote_mistral"),
+            # Cohere: Command family registered under remote_cohere
+            ("command-r-plus", "remote_cohere"),
+            ("command-a-plus-05-2026", "remote_cohere"),
+            # DeepSeek: registered under remote_deepseek
+            ("deepseek-chat", "remote_deepseek"),
+            ("deepseek-reasoner", "remote_deepseek"),
+            # xAI: registered under remote_xai
+            ("grok-3-latest", "remote_xai"),
+            # Groq: registered under remote_groq
+            ("llama-3.3-70b-versatile", "remote_groq"),
+            ("compound-beta", "remote_groq"),
+            ("compound-beta-mini", "remote_groq"),
+        ],
+    )
+    def test_llm_models_lookup_resolves_new_providers(
+        self, model_id: str, expected_provider: str
+    ):
+        """Verify model IDs in LLM_MODELS resolve to the correct new provider.
+
+        Note: Gemini model IDs (e.g. gemini-2.5-flash) are intentionally absent
+        from this parametrize set.  All current Gemini model IDs in
+        LLM_MODELS["remote_google_genai"] are also present in
+        LLM_MODELS["remote_google_vertex"] (Vertex registers them first), so the
+        LLM_MODELS lookup returns Vertex for those IDs.  Users who want the
+        remote_google_genai provider invoke load_model("remote_google_genai", ...)
+        directly rather than relying on name resolution.  The heuristic-only
+        tests above (which patch out LLM_MODELS) confirm the gemini- heuristic
+        routes to remote_google_genai when the LLM_MODELS lookup finds nothing.
+        """
+        from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+            resolve_model,
+        )
+
+        provider, _ = resolve_model(model_id)
+        assert provider == expected_provider, (
+            f"Expected model '{model_id}' to resolve to '{expected_provider}', "
+            f"got '{provider}'"
+        )

--- a/bili/iris/providers/tests/test_new_providers.py
+++ b/bili/iris/providers/tests/test_new_providers.py
@@ -183,6 +183,38 @@ class TestLLMModelsEntries:
         assert "compound-beta" in ids
         assert "compound-beta-mini" in ids
 
+    def test_google_genai_display_names_include_direct_api(self):
+        """Verify remote_google_genai entries use '(Direct API)' in display names.
+
+        The disambiguation suffix makes these entries selectable via display name
+        without colliding with the identically-model_id'd Vertex entries.
+        """
+        from bili.iris.config.llm_config import (  # pylint: disable=import-outside-toplevel
+            LLM_MODELS,
+        )
+
+        for entry in LLM_MODELS["remote_google_genai"]["models"]:
+            assert "(Direct API)" in entry["model_name"], (
+                f"remote_google_genai entry missing '(Direct API)' in model_name: "
+                f"{entry['model_name']!r}"
+            )
+
+    def test_google_genai_display_names_are_distinct_from_vertex(self):
+        """Verify no remote_google_genai display name collides with Vertex display names."""
+        from bili.iris.config.llm_config import (  # pylint: disable=import-outside-toplevel
+            LLM_MODELS,
+        )
+
+        vertex_names = {
+            m["model_name"]
+            for m in LLM_MODELS.get("remote_google_vertex", {}).get("models", [])
+        }
+        for entry in LLM_MODELS["remote_google_genai"]["models"]:
+            assert entry["model_name"] not in vertex_names, (
+                f"remote_google_genai display name '{entry['model_name']}' collides "
+                f"with a remote_google_vertex entry"
+            )
+
 
 # ---------------------------------------------------------------------------
 # Heuristic resolution — new patterns
@@ -256,6 +288,50 @@ class TestHeuristicResolution:
         """Verify 'compound-beta' routes to remote_groq."""
         provider, _, _ = self._resolve("compound-beta")
         assert provider == "remote_groq"
+
+    # Backward-compat fallbacks (pre-existing rules restored in this PR)
+
+    def test_bare_gemini_still_routes_to_vertex(self):
+        """Verify bare 'gemini' (no hyphen) still falls back to remote_google_vertex.
+
+        Pre-existing behavior: 'gemini' was a broad heuristic for Vertex AI.
+        With the addition of 'gemini-' -> remote_google_genai, the hyphenated
+        form goes to GenAI while the bare form still reaches Vertex.
+        """
+        provider, _, _ = self._resolve("gemini")
+        assert (
+            provider == "remote_google_vertex"
+        ), "Bare 'gemini' must still fall back to remote_google_vertex"
+
+    def test_bare_mistral_still_routes_to_bedrock(self):
+        """Verify a bare 'mistral' string still falls back to remote_aws_bedrock.
+
+        Pre-existing behavior: 'mistral' was a Bedrock catch-all.  The more
+        specific 'mistral-' -> remote_mistral pattern handles direct-API IDs;
+        bare 'mistral' (no hyphen) reaches the Bedrock fallback.
+        """
+        provider, _, _ = self._resolve("mistral")
+        assert (
+            provider == "remote_aws_bedrock"
+        ), "Bare 'mistral' must still fall back to remote_aws_bedrock"
+
+    def test_gemini_hyphen_takes_priority_over_bare_gemini(self):
+        """Verify 'gemini-2.0-flash' hits the more-specific GenAI rule, not Vertex.
+
+        The 'gemini-' pattern fires first because it appears before the broad
+        'gemini' fallback in _HEURISTIC_RULES.
+        """
+        provider, _, _ = self._resolve("gemini-2.0-flash")
+        assert provider == "remote_google_genai"
+
+    def test_mistral_hyphen_takes_priority_over_bare_mistral(self):
+        """Verify 'mistral-large-latest' hits direct Mistral, not Bedrock fallback.
+
+        The 'mistral-' pattern fires first because it appears before the broad
+        'mistral' fallback in _HEURISTIC_RULES.
+        """
+        provider, _, _ = self._resolve("mistral-large-latest")
+        assert provider == "remote_mistral"
 
 
 # ---------------------------------------------------------------------------
@@ -717,6 +793,14 @@ class TestLoadModelNewProviders:
             # Cohere: Command family registered under remote_cohere
             ("command-r-plus", "remote_cohere"),
             ("command-a-plus-05-2026", "remote_cohere"),
+            # Google GenAI: use the disambiguation display name "(Direct API)" so
+            # the LLM_MODELS lookup selects remote_google_genai, not Vertex.
+            # The raw model_id (e.g. "gemini-2.5-flash") also exists in the
+            # Vertex catalog; passing the raw ID resolves to Vertex (first match
+            # in insertion order) -- that's tested in test_raw_gemini_resolves_to_vertex.
+            ("Gemini 2.5 Flash (Direct API)", "remote_google_genai"),
+            ("Gemini 2.0 Flash (Direct API)", "remote_google_genai"),
+            ("Gemini 2.0 Flash Lite (Direct API)", "remote_google_genai"),
             # DeepSeek: registered under remote_deepseek
             ("deepseek-chat", "remote_deepseek"),
             ("deepseek-reasoner", "remote_deepseek"),
@@ -731,17 +815,13 @@ class TestLoadModelNewProviders:
     def test_llm_models_lookup_resolves_new_providers(
         self, model_id: str, expected_provider: str
     ):
-        """Verify model IDs in LLM_MODELS resolve to the correct new provider.
+        """Verify display names in LLM_MODELS resolve to the correct new provider.
 
-        Note: Gemini model IDs (e.g. gemini-2.5-flash) are intentionally absent
-        from this parametrize set.  All current Gemini model IDs in
-        LLM_MODELS["remote_google_genai"] are also present in
-        LLM_MODELS["remote_google_vertex"] (Vertex registers them first), so the
-        LLM_MODELS lookup returns Vertex for those IDs.  Users who want the
-        remote_google_genai provider invoke load_model("remote_google_genai", ...)
-        directly rather than relying on name resolution.  The heuristic-only
-        tests above (which patch out LLM_MODELS) confirm the gemini- heuristic
-        routes to remote_google_genai when the LLM_MODELS lookup finds nothing.
+        Google GenAI entries use display names that include "(Direct API)" to
+        distinguish them from the identical model_id values registered under
+        remote_google_vertex.  Users who want the Google AI Developer API
+        (GOOGLE_API_KEY, not GCP/Vertex credentials) must select a model by its
+        display name or invoke load_model() with provider_type explicitly set.
         """
         from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
             resolve_model,
@@ -752,3 +832,23 @@ class TestLoadModelNewProviders:
             f"Expected model '{model_id}' to resolve to '{expected_provider}', "
             f"got '{provider}'"
         )
+
+    def test_raw_gemini_model_id_resolves_to_vertex(self):
+        """Verify raw gemini-* model IDs resolve to Vertex (first catalog match).
+
+        Because the same gemini-2.5-flash model_id exists in both
+        remote_google_vertex (registered first in LLM_MODELS) and
+        remote_google_genai, the raw ID resolves to Vertex.  This is expected
+        and backward-compatible.  Users reach remote_google_genai via the
+        '(Direct API)' display-name catalog entries or by calling load_model()
+        with an explicit provider_type.
+        """
+        from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+            resolve_model,
+        )
+
+        provider, model_id = resolve_model("gemini-2.5-flash")
+        assert (
+            provider == "remote_google_vertex"
+        ), "Raw 'gemini-2.5-flash' must resolve to Vertex (first catalog match)"
+        assert model_id == "gemini-2.5-flash"

--- a/bili/iris/providers/xai_provider.py
+++ b/bili/iris/providers/xai_provider.py
@@ -1,0 +1,75 @@
+"""xAI (Grok) provider for bili-core IRIS.
+
+Wraps ``langchain_xai.ChatXAI`` behind the :class:`LLMProvider` interface.
+Supports Grok model families accessed via the xAI API.
+
+Authentication reads ``XAI_API_KEY`` from the environment.
+
+Heavy dependencies
+------------------
+``langchain_xai`` is imported inside :meth:`XAIProvider.load` to avoid
+module-level import cost when this provider is not in use.
+"""
+
+# pylint: disable=duplicate-code
+import logging
+from typing import Any, Optional
+
+from .base import LLMProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=too-few-public-methods
+class XAIProvider(LLMProvider):
+    """LangChain-native xAI (Grok) provider.
+
+    Accepted kwargs
+    ---------------
+    model_name : str
+        xAI model identifier (e.g. ``"grok-3-latest"``,
+        ``"grok-beta"``).
+    max_tokens : int, optional
+        Maximum completion tokens.
+    temperature : float, optional
+        Sampling temperature.
+    top_p : float, optional
+        Nucleus sampling probability.
+    max_retries : int, optional
+        Maximum number of automatic retries on transient errors.
+    """
+
+    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments
+        self,
+        model_name: str,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        max_retries: Optional[int] = None,
+        **_extra: Any,
+    ) -> Any:
+        """Create and return a ``ChatXAI`` instance.
+
+        :param model_name: xAI model identifier.
+        :returns: A ``ChatXAI`` instance.
+        :raises ImportError: If ``langchain_xai`` is not installed.
+        """
+        from langchain_xai import (  # pylint: disable=import-outside-toplevel,import-error
+            ChatXAI,
+        )
+
+        LOGGER.info("Initializing xAI model: %s", model_name)
+
+        config: dict = {"model": model_name}
+        if max_tokens is not None:
+            config["max_tokens"] = max_tokens
+        if temperature is not None:
+            config["temperature"] = temperature
+        if top_p is not None:
+            config["top_p"] = top_p
+        if max_retries is not None:
+            config["max_retries"] = max_retries
+
+        llm = ChatXAI(**config)
+        LOGGER.debug(llm)
+        return llm

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,27 @@ setup(
         ],
     },
     install_requires=read_requirements(),  # Load only standard dependencies
+    extras_require={
+        # Provider extras — install the optional SDK for each new provider.
+        # Usage: pip install bili-core[anthropic,mistral]
+        "anthropic": ["langchain-anthropic>=0.3.0"],
+        "mistral": ["langchain-mistralai>=0.2.0"],
+        "cohere": ["langchain-cohere>=0.3.0"],
+        "google-genai": ["langchain-google-genai>=2.0.0"],
+        "deepseek": ["langchain-deepseek>=0.1.0"],
+        "xai": ["langchain-xai>=0.2.0"],
+        "groq": ["langchain-groq>=0.2.0"],
+        # Convenience bundle for all new API providers
+        "all-providers": [
+            "langchain-anthropic>=0.3.0",
+            "langchain-mistralai>=0.2.0",
+            "langchain-cohere>=0.3.0",
+            "langchain-google-genai>=2.0.0",
+            "langchain-deepseek>=0.1.0",
+            "langchain-xai>=0.2.0",
+            "langchain-groq>=0.2.0",
+        ],
+    },
     cmdclass={
         "install": PostInstallCommand,
     },


### PR DESCRIPTION
## Summary

Expands bili-core's built-in \`LLMProvider\` registry from 6 to 13 provider types, adding direct API access to seven additional LLM providers.

**Provider types added:**

| Provider type | SDK (optional extra) | Families |
|---|---|---|
| \`remote_anthropic\` | \`langchain-anthropic\` | Claude Opus, Sonnet, Haiku, Fable |
| \`remote_mistral\` | \`langchain-mistralai\` | Mistral Large, Small, Codestral |
| \`remote_cohere\` | \`langchain-cohere\` | Command A+, R+, R |
| \`remote_google_genai\` | \`langchain-google-genai\` | Gemini 2.x via Google AI Developer API |
| \`remote_deepseek\` | \`langchain-deepseek\` | DeepSeek Chat, Reasoner |
| \`remote_xai\` | \`langchain-xai\` | Grok model families |
| \`remote_groq\` | \`langchain-groq\` | Llama 3.x, Gemma 2, compound-beta |

**Architecture:**
- Each provider is a new \`LLMProvider\` subclass with lazy SDK import inside \`load()\`. Base install cost is zero; pay only when the optional extra is installed.
- All 7 types registered in \`builtin.py\` alongside the original 6.
- \`LLM_MODELS\` catalog extended with 20 model entries (context windows, capability flags, output limits).
- New SDKs declared as optional extras in \`setup.py\` (\`pip install bili-core[anthropic]\`, \`pip install bili-core[all-providers]\`).
- \`KNOWN_PROVIDER_TYPES\` in \`base.py\` updated to include all 7 new types.

**Heuristic resolution (\`_HEURISTIC_RULES\`):**

The following patterns were added:

| Pattern | Provider | Notes |
|---|---|---|
| \`claude-\` | \`remote_anthropic\` | Direct Anthropic API (not Bedrock) |
| \`mistral-\` | \`remote_mistral\` | Direct Mistral AI API |
| \`codestral\` | \`remote_mistral\` | Mistral's code model |
| \`command-\` | \`remote_cohere\` | Cohere Command family |
| \`gemini-\` | \`remote_google_genai\` | Google AI Developer API (hyphenated IDs) |
| \`deepseek-\` | \`remote_deepseek\` | DeepSeek direct API |
| \`grok-\` | \`remote_xai\` | xAI Grok |
| \`llama-3\` | \`remote_groq\` | Groq-hosted Llama |
| \`compound-beta\` | \`remote_groq\` | Groq compound system |
| \`gemma2-\` | \`remote_groq\` | Groq-hosted Gemma |

The **pre-existing broad fallbacks** are preserved at the END of the rule list:

| Pattern | Provider | Behavior |
|---|---|---|
| \`gemini\` (no hyphen) | \`remote_google_vertex\` | Bare/non-catalog Gemini IDs still route to Vertex |
| \`mistral\` (no hyphen) | \`remote_aws_bedrock\` | Bare/non-catalog Mistral IDs still route to Bedrock |

Specificity ordering ensures the more-specific hyphenated patterns fire first: \`gemini-2.0-flash\` matches \`gemini-\` (GenAI) before reaching the broad \`gemini\` (Vertex) fallback. Raw \`gemini-*\` model ID lookups that ARE in the LLM_MODELS catalog still resolve to Vertex (first catalog match), which is backward-compatible and explicitly tested.

**Google GenAI catalog disambiguation:**

The three GenAI catalog entries use distinct display names with a \`(Direct API)\` suffix (e.g. \`"Gemini 2.5 Flash (Direct API)"\`) to distinguish them from the identically-\`model_id\`'d Vertex entries. The \`model_id\` sent to the Google AI API remains the standard identifier (\`"gemini-2.5-flash"\`). Users who want the direct API select by display name; raw \`gemini-*\` ID lookups continue to resolve to Vertex.

## Test plan

- [x] \`test_new_providers.py\` (79 tests): registry population, class mapping, \`LLM_MODELS\` completeness, \`load()\` kwarg forwarding (minimal + full config + extras-ignored), heuristic routing for new model ID patterns, backward-compat heuristic fallbacks, GenAI display-name disambiguation, \`resolve_model()\` end-to-end for all new providers
- [x] Raw \`gemini-2.5-flash\` resolves to Vertex (pinned, backward-compat)
- [x] Bare \`"gemini"\` resolves to Vertex (backward-compat heuristic restored)
- [x] Bare \`"mistral"\` resolves to Bedrock (backward-compat heuristic restored)
- [x] GenAI display names distinct from Vertex display names (no collision)
- [x] 3455 tests pass across the full suite (0 regressions)
- [x] Pylint: 9.61/10. Pre-commit passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpXRrbE4UhL22Usj6UdEVQ