### PR TITLE
feat: CliLLM subprocess provider for command-line LLM tools

### DIFF
--- a/bili/aether/compiler/llm_resolver.py
+++ b/bili/aether/compiler/llm_resolver.py
@@ -60,6 +60,9 @@ _HEURISTIC_RULES = [
     ("llama-3", "remote_groq"),  # Groq-hosted Llama
     ("compound-beta", "remote_groq"),  # Groq compound system
     ("gemma2-", "remote_groq"),  # Groq-hosted Gemma
+    # Subprocess CLI provider -- matches the "cli:" sentinel prefix used
+    # for CLI models in LLM_MODELS and any user-configured cli model_id.
+    ("cli:", "cli"),
     # Broad pre-existing fallbacks -- preserved for backward compatibility.
     # These fire for non-catalog model IDs that match only the bare vendor
     # name (e.g. bare "gemini", legacy Bedrock-style "mistral-..." that did

--- a/bili/iris/config/llm_config.py
+++ b/bili/iris/config/llm_config.py
@@ -1517,6 +1517,42 @@ LLM_MODELS = {
             },
         ],
     },
+    # ------------------------------------------------------------------ #
+    # CLI (subprocess) provider                                          #
+    # ------------------------------------------------------------------ #
+    # The "cli" provider type drives any command-line LLM tool as a     #
+    # stateless text-in / text-out model.  The model_id is the display  #
+    # name only; the actual executable is configured via the "command"  #
+    # kwarg at runtime (e.g. command=["my-llm", "--no-color"]).         #
+    # The entry below serves as a UI placeholder / example; users may   #
+    # register additional entries for specific CLI tools in their own   #
+    # application config.                                               #
+    # ------------------------------------------------------------------ #
+    "cli": {
+        "name": "CLI Subprocess Provider",
+        "description": (
+            "Drives any command-line LLM tool as a stateless text model via "
+            "subprocess.  Configure the executable and arguments at runtime "
+            "using the 'command' kwarg."
+        ),
+        "model_help": "https://github.com/msu-denver/bili-core",
+        "models": [
+            {
+                "model_name": "CLI LLM (Custom Command)",
+                # The model_id is a sentinel; the real executable is set via
+                # the "command" kwarg when calling CliProvider.load().
+                "model_id": "cli:custom",
+                "supports_temperature": False,
+                "supports_seed": False,
+                "supports_max_output_tokens": False,
+                "supports_top_p": False,
+                "supports_top_k": False,
+                # CLI tools run as a subprocess -- tool-calling via the
+                # LangChain bind_tools() API is not available.
+                "supports_tools": False,
+            },
+        ],
+    },
     "local_llamacpp": {
         "name": "Local LlamaCpp Compatible Model",
         "description": "Local LlamaCpp compatible model loaded into memory.",

--- a/bili/iris/providers/base.py
+++ b/bili/iris/providers/base.py
@@ -43,8 +43,9 @@ KNOWN_PROVIDER_TYPES = frozenset(
         # Local in-process providers
         "local_llamacpp",
         "local_huggingface",
+        # Subprocess / transport-level providers
+        "cli",
         # Future provider shapes (not yet implemented)
-        # "cli"   -- subprocess / stdin-stdout transport
         # "mcp"   -- Model Context Protocol server transport
     }
 )

--- a/bili/iris/providers/builtin.py
+++ b/bili/iris/providers/builtin.py
@@ -27,6 +27,7 @@ Provider type string               Implementation class
 ``remote_groq``                    :class:`~.groq_provider.GroqProvider`
 ``local_llamacpp``                 :class:`~.llamacpp_provider.LlamaCppProvider`
 ``local_huggingface``              :class:`~.huggingface_provider.HuggingFaceProvider`
+``cli``                            :class:`~.cli_provider.CliProvider`
 ================================  ================================================
 """
 
@@ -35,6 +36,7 @@ import logging
 from .anthropic_provider import AnthropicProvider
 from .azure_openai_provider import AzureOpenAIProvider
 from .bedrock_provider import BedrockProvider
+from .cli_provider import CliProvider
 from .cohere_provider import CohereProvider
 from .deepseek_provider import DeepSeekProvider
 from .google_genai_provider import GoogleGenAIProvider
@@ -63,6 +65,7 @@ _BUILTIN_PROVIDERS = {
     "remote_groq": GroqProvider,
     "local_llamacpp": LlamaCppProvider,
     "local_huggingface": HuggingFaceProvider,
+    "cli": CliProvider,
 }
 
 

--- a/bili/iris/providers/cli_provider.py
+++ b/bili/iris/providers/cli_provider.py
@@ -68,12 +68,13 @@ No new optional dependency is required; the module uses stdlib ``subprocess``
 and ``re`` only.
 """
 
+import asyncio
 import logging
 import os
 import re
 import subprocess
 import tempfile
-from typing import Any, Iterator, List, Optional, Tuple
+from typing import Any, AsyncIterator, Iterator, List, Optional, Tuple
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import (
@@ -456,12 +457,16 @@ class CliLLM(BaseChatModel):
         stop: Optional[List[str]] = None,  # pylint: disable=unused-argument
         run_manager: Optional[Any] = None,  # pylint: disable=unused-argument
         **kwargs: Any,  # pylint: disable=unused-argument
-    ):
-        """Async stream — delegates to the sync path (subprocess is blocking).
+    ) -> AsyncIterator[ChatGenerationChunk]:
+        """Async stream the CLI response as a single chunk without blocking
+        the event loop.
 
-        Yields the full response as a single :class:`AIMessageChunk`.
+        The subprocess is run in a thread via :func:`asyncio.to_thread` so the
+        event loop remains free for other coroutines while the CLI tool
+        executes.  Yields the full response as a single
+        :class:`ChatGenerationChunk` once the subprocess completes.
         """
-        content = self._call_cli(messages)
+        content = await asyncio.to_thread(self._call_cli, messages)
         yield ChatGenerationChunk(message=AIMessageChunk(content=content))
 
 

--- a/bili/iris/providers/cli_provider.py
+++ b/bili/iris/providers/cli_provider.py
@@ -1,0 +1,579 @@
+"""CLI (subprocess) provider for bili-core IRIS.
+
+Drives any command-line LLM tool as a stateless text-in / text-out model
+behind the :class:`LLMProvider` interface.  The provider spawns the
+configured executable as a subprocess, sends the rendered prompt via stdin
+or a command-line argument, captures stdout, and returns the result.
+
+This enables "BYO-CLI" usage: users who have a CLI LLM tool but not an API
+key can plug it into any bili-core agent or AETHER multi-agent workflow
+without writing integration code.  The provider is intentionally generic --
+no specific CLI tool is hard-coded or special-cased.
+
+Design
+------
+A non-zero exit code or subprocess timeout raises :class:`CliLLMError`, which
+propagates up to the caller.  When used with the fallback engine
+(:class:`~bili.iris.providers.fallback.FallbackLLM`), ``CliLLMError`` is
+treated as retryable so the chain can fall through to an API provider.
+
+The LLM object returned by :meth:`CliProvider.load` is a
+:class:`CliLLM` -- a concrete :class:`~langchain_core.language_models.BaseChatModel`
+subclass.  This makes it a drop-in replacement inside any LangChain/LangGraph
+pipeline, AETHER agent, or IRIS node without modification.
+
+Message rendering
+-----------------
+CLI tools accept a single text prompt, not a structured message list.  The
+provider supports three ``message_format`` strategies:
+
+``"last"`` (default)
+    Send only the content of the last ``HumanMessage``.  Use this for
+    interactive CLIs that handle their own conversation state, or for
+    one-shot question-answer usage.  This is the honest stateless
+    behaviour -- the provider does not pretend to carry history.
+
+``"roles"``
+    Render the full message list as plain text with role prefixes::
+
+        System: <system content>
+        User: <first user turn>
+        Assistant: <first assistant turn>
+        User: <second user turn>
+
+    Suitable for CLI tools that accept a full conversation context as a
+    single string.
+
+``"chatml"``
+    Render the full message list in ChatML format::
+
+        <|im_start|>system
+        <system content>
+        <|im_end|>
+        <|im_start|>user
+        <first user turn>
+        <|im_end|>
+        ...
+
+    Some local model runners (e.g. llama.cpp with a chat template) parse
+    this format natively.
+
+Auth
+----
+The subprocess inherits the calling process's environment (``os.environ``).
+Whatever credential the CLI tool requires (OAuth session, API key file, etc.)
+must already be present in the environment -- bili-core never touches it.
+
+No new optional dependency is required; the module uses stdlib ``subprocess``
+and ``re`` only.
+"""
+
+import logging
+import os
+import re
+import subprocess
+import tempfile
+from typing import Any, Iterator, List, Optional, Tuple
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+)
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+
+from .base import LLMProvider
+
+LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Supported values for the ``message_format`` config key.
+SUPPORTED_MESSAGE_FORMATS = frozenset({"last", "roles", "chatml"})
+
+#: Supported values for the ``prompt_via`` config key.
+SUPPORTED_PROMPT_VIA = frozenset({"stdin", "arg", "file"})
+
+#: Supported values for the ``output_format`` config key.
+SUPPORTED_OUTPUT_FORMATS = frozenset({"text", "json"})
+
+#: ANSI escape-sequence pattern for stripping colour codes from output.
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*[mGKHF]")
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class CliLLMError(RuntimeError):
+    """Raised when the CLI subprocess exits non-zero or times out.
+
+    The fallback engine's default retryable-name set includes
+    ``CliLLMError`` so failed CLI calls fall over to the next provider in
+    the chain automatically.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Message rendering
+# ---------------------------------------------------------------------------
+
+
+def _role_label(msg: BaseMessage) -> str:
+    """Return a human-readable role label for *msg*."""
+    if isinstance(msg, SystemMessage):
+        return "System"
+    if isinstance(msg, HumanMessage):
+        return "User"
+    if isinstance(msg, AIMessage):
+        return "Assistant"
+    # Generic fallback for any other message type
+    msg_type = type(msg).__name__
+    return msg_type.replace("Message", "").replace("message", "") or "Unknown"
+
+
+def render_messages(
+    messages: List[BaseMessage],
+    message_format: str = "last",
+) -> str:
+    """Collapse a list of LangChain messages into a single prompt string.
+
+    :param messages: The message list from a LangChain invocation.
+    :param message_format: One of ``"last"``, ``"roles"``, or ``"chatml"``.
+    :returns: A single string ready to send to the CLI tool.
+    :raises ValueError: If ``message_format`` is not recognised, or if the
+        message list is empty.
+    """
+    if not messages:
+        raise ValueError("Cannot render an empty message list")
+    if message_format not in SUPPORTED_MESSAGE_FORMATS:
+        raise ValueError(
+            f"Unknown message_format {message_format!r}. "
+            f"Supported: {sorted(SUPPORTED_MESSAGE_FORMATS)}"
+        )
+
+    if message_format == "last":
+        # Find the last human message (most common case)
+        for msg in reversed(messages):
+            if isinstance(msg, HumanMessage):
+                return str(msg.content)
+        # Fall back to the very last message if no HumanMessage found
+        return str(messages[-1].content)
+
+    if message_format == "roles":
+        parts = []
+        for msg in messages:
+            label = _role_label(msg)
+            parts.append(f"{label}: {msg.content}")
+        return "\n".join(parts)
+
+    # chatml
+    parts = []
+    for msg in messages:
+        role = _role_label(msg).lower()
+        # Normalise "User" -> "user", "System" -> "system", etc.
+        parts.append(f"<|im_start|>{role}\n{msg.content}\n<|im_end|>")
+    # Append the open assistant turn so the model knows to continue
+    parts.append("<|im_start|>assistant")
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# ANSI stripping
+# ---------------------------------------------------------------------------
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from *text*.
+
+    CLI tools that emit colour output (progress bars, formatting) leave
+    garbage in the captured stdout.  This function strips all standard ANSI
+    SGR / cursor-movement codes.
+    """
+    return _ANSI_ESCAPE.sub("", text)
+
+
+# ---------------------------------------------------------------------------
+# JSON extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_json_path(obj: Any, path: str) -> str:
+    """Traverse a nested dict/list using a dot-separated *path*.
+
+    Examples::
+
+        extract_json_path({"content": "hello"}, "content")          # "hello"
+        extract_json_path({"choices": [{"text": "hi"}]}, "choices.0.text")  # "hi"
+
+    :param obj: The parsed JSON object (dict, list, or scalar).
+    :param path: Dot-separated key/index path.
+    :returns: The value at *path* as a string.
+    :raises KeyError: If any segment of the path is missing.
+    :raises IndexError: If a numeric segment is out of range.
+    :raises TypeError: If a non-container node is traversed as a container.
+    """
+    current: Any = obj
+    for segment in path.split("."):
+        if isinstance(current, dict):
+            current = current[segment]
+        elif isinstance(current, list):
+            current = current[int(segment)]
+        else:
+            raise TypeError(
+                f"Cannot index into {type(current).__name__!r} "
+                f"at path segment {segment!r}"
+            )
+    return str(current)
+
+
+# ---------------------------------------------------------------------------
+# CliLLM — the LangChain-compatible model object
+# ---------------------------------------------------------------------------
+
+
+class CliLLM(BaseChatModel):
+    """A :class:`~langchain_core.language_models.BaseChatModel` backed by a
+    CLI subprocess.
+
+    Instances are created by :class:`CliProvider` and returned to the caller.
+    Do not instantiate directly -- use ``CliProvider().load(...)`` instead.
+
+    The model is **stateless**: each call spawns a fresh subprocess for a
+    fresh prompt.  No conversation history is persisted across calls.
+
+    **Streaming note:** ``_stream`` and ``_astream`` both yield the complete
+    response as a SINGLE chunk.  This is honest -- the subprocess runs to
+    completion before any output is available, so true per-token streaming
+    is not possible here.  The single-chunk contract is fully compatible with
+    LangChain's streaming consumers (they iterate over whatever chunks are
+    produced).
+
+    Config fields (all set by ``CliProvider.load``)
+    -----------------------------------------------
+    command : list[str]
+        The executable and its arguments (e.g. ``["claude", "--output-format",
+        "json"]``).  Do not include the prompt here; it is added by the
+        provider according to ``prompt_via``.
+    prompt_via : str
+        How the prompt is sent to the process.  One of:
+
+        ``"stdin"`` (default)
+            The prompt is written to the process's stdin pipe.
+
+        ``"arg"``
+            The prompt is appended as an extra positional argument to
+            ``command``.
+
+        ``"file"``
+            The prompt is written to a temporary file and its path is
+            appended as an extra argument.  Useful for CLIs that do not
+            read stdin.
+
+    message_format : str
+        Message rendering strategy -- ``"last"`` (default), ``"roles"``,
+        or ``"chatml"``.  See :func:`render_messages`.
+    output_format : str
+        How to parse the subprocess stdout.  ``"text"`` (default) returns
+        the raw stripped output; ``"json"`` parses JSON and extracts the
+        value at ``json_path``.
+    json_path : str
+        Dot-separated path into the parsed JSON object.  Only used when
+        ``output_format == "json"``.  Default ``"content"``.
+    strip_ansi_output : bool
+        Strip ANSI escape codes from stdout before parsing.  Default
+        ``True``.
+    timeout_seconds : float
+        Subprocess wall-clock timeout.  Default 120 s.  A timeout raises
+        :class:`CliLLMError`.
+    """
+
+    # ------------------------------------------------------------------
+    # Pydantic fields (must be declared for BaseChatModel subclasses)
+    # ------------------------------------------------------------------
+
+    command: List[str]
+    prompt_via: str = "stdin"
+    message_format: str = "last"
+    output_format: str = "text"
+    json_path: str = "content"
+    strip_ansi_output: bool = True
+    timeout_seconds: float = 120.0
+
+    # ------------------------------------------------------------------
+    # BaseChatModel required property
+    # ------------------------------------------------------------------
+
+    @property
+    def _llm_type(self) -> str:
+        return "cli"
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_run_args(
+        self, prompt: str
+    ) -> Tuple[List[str], Optional[str], Optional[str]]:
+        """Return ``(cmd, stdin_text, tmp_file_path)`` for the subprocess call.
+
+        The caller is responsible for cleaning up ``tmp_file_path`` if set.
+        """
+        if self.prompt_via == "stdin":
+            return list(self.command), prompt, None
+        if self.prompt_via == "arg":
+            return list(self.command) + [prompt], None, None
+        # "file"
+        # Write to a temp file and pass the path as an extra arg
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".txt",
+            delete=False,
+            encoding="utf-8",
+        ) as tmp:
+            tmp.write(prompt)
+            tmp_path = tmp.name
+        return list(self.command) + [tmp_path], None, tmp_path
+
+    def _run_subprocess(self, prompt: str) -> str:
+        """Execute the CLI with *prompt* and return the captured output text.
+
+        :raises CliLLMError: On non-zero exit code or timeout.
+        """
+        cmd, stdin_text, tmp_path = self._build_run_args(prompt)
+        LOGGER.debug(
+            "CliLLM: running %s (prompt_via=%s, timeout=%ss)",
+            cmd[0],
+            self.prompt_via,
+            self.timeout_seconds,
+        )
+        try:
+            result = subprocess.run(  # pylint: disable=subprocess-run-check
+                cmd,
+                input=stdin_text,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_seconds,
+                env=os.environ.copy(),
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise CliLLMError(
+                f"CLI subprocess timed out after {self.timeout_seconds}s: {cmd[0]}"
+            ) from exc
+        finally:
+            if tmp_path is not None:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass  # Best-effort cleanup
+
+        if result.returncode != 0:
+            stderr_snippet = (result.stderr or "")[:500]
+            raise CliLLMError(
+                f"CLI subprocess exited with code {result.returncode}: "
+                f"{cmd[0]}\nstderr: {stderr_snippet}"
+            )
+
+        output = result.stdout
+        if self.strip_ansi_output:
+            output = strip_ansi(output)
+        return output
+
+    def _parse_output(self, raw: str) -> str:
+        """Parse *raw* stdout according to ``output_format``."""
+        if self.output_format == "text":
+            return raw.strip()
+
+        # json
+        import json  # pylint: disable=import-outside-toplevel
+
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise CliLLMError(
+                f"CLI output is not valid JSON (output_format='json'): {exc}"
+            ) from exc
+        try:
+            return extract_json_path(parsed, self.json_path)
+        except (KeyError, IndexError, TypeError) as exc:
+            raise CliLLMError(
+                f"json_path={self.json_path!r} not found in CLI output: {exc}"
+            ) from exc
+
+    def _call_cli(self, messages: List[BaseMessage]) -> str:
+        """Render messages, run the CLI, and return the parsed response text."""
+        prompt = render_messages(messages, self.message_format)
+        raw = self._run_subprocess(prompt)
+        return self._parse_output(raw)
+
+    # ------------------------------------------------------------------
+    # BaseChatModel abstract method implementation
+    # ------------------------------------------------------------------
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,  # pylint: disable=unused-argument
+        run_manager: Optional[Any] = None,  # pylint: disable=unused-argument
+        **kwargs: Any,  # pylint: disable=unused-argument
+    ) -> ChatResult:
+        """Run the CLI and return the result as a :class:`ChatResult`."""
+        content = self._call_cli(messages)
+        return ChatResult(
+            generations=[ChatGeneration(message=AIMessage(content=content))]
+        )
+
+    # ------------------------------------------------------------------
+    # Streaming: yield the full response as ONE chunk (honest, not faked)
+    # ------------------------------------------------------------------
+
+    def _stream(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,  # pylint: disable=unused-argument
+        run_manager: Optional[Any] = None,  # pylint: disable=unused-argument
+        **kwargs: Any,  # pylint: disable=unused-argument
+    ) -> Iterator[ChatGenerationChunk]:
+        """Stream the CLI response as a single chunk.
+
+        The subprocess runs to completion before any output is available, so
+        true per-token streaming is not possible.  Yielding one chunk is the
+        honest contract: callers receive all content in the first (and only)
+        iteration, which is fully compatible with LangChain streaming
+        consumers.
+        """
+        content = self._call_cli(messages)
+        yield ChatGenerationChunk(message=AIMessageChunk(content=content))
+
+    async def _astream(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,  # pylint: disable=unused-argument
+        run_manager: Optional[Any] = None,  # pylint: disable=unused-argument
+        **kwargs: Any,  # pylint: disable=unused-argument
+    ):
+        """Async stream — delegates to the sync path (subprocess is blocking).
+
+        Yields the full response as a single :class:`AIMessageChunk`.
+        """
+        content = self._call_cli(messages)
+        yield ChatGenerationChunk(message=AIMessageChunk(content=content))
+
+
+# ---------------------------------------------------------------------------
+# CliProvider — the LLMProvider factory
+# ---------------------------------------------------------------------------
+
+
+# pylint: disable=too-few-public-methods
+class CliProvider(LLMProvider):
+    """LLM provider that drives a command-line tool as a stateless text model.
+
+    Returns a :class:`CliLLM` instance configured from the supplied kwargs.
+    No optional SDK is required -- the implementation uses ``subprocess``
+    from the Python standard library.
+
+    **Auth note:** The subprocess inherits ``os.environ`` in full.  Whatever
+    authentication the CLI tool requires (OAuth session written to a config
+    file, environment variable, etc.) must already be present in the calling
+    process's environment.  bili-core does not manage credentials for CLI
+    tools.
+
+    Accepted kwargs
+    ---------------
+    command : list[str]
+        **Required.** The executable and any fixed arguments.  Example::
+
+            command=["my-llm-cli", "--model", "fast", "--no-color"]
+
+    prompt_via : str, optional
+        How the prompt is delivered to the process.
+        ``"stdin"`` (default), ``"arg"``, or ``"file"``.
+
+    message_format : str, optional
+        How the LangChain message list is rendered into a prompt string.
+        ``"last"`` (default), ``"roles"``, or ``"chatml"``.
+
+    output_format : str, optional
+        How the subprocess stdout is parsed.
+        ``"text"`` (default) or ``"json"``.
+
+    json_path : str, optional
+        Dot-separated extraction path for ``output_format="json"``.
+        Default ``"content"``.
+
+    strip_ansi : bool, optional
+        Strip ANSI colour codes from stdout.  Default ``True``.
+
+    timeout_seconds : float, optional
+        Per-call wall-clock timeout in seconds.  Default ``120``.
+    """
+
+    # The `strip_ansi` parameter intentionally shares its name with the
+    # module-level helper function.  The parameter is the public API kwarg
+    # documented in the class docstring; the module function is an
+    # implementation detail.  Pylint sees the parameter as shadowing the
+    # outer-scope name, which is benign here.
+    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments,redefined-outer-name
+        self,
+        command: List[str],
+        prompt_via: str = "stdin",
+        message_format: str = "last",
+        output_format: str = "text",
+        json_path: str = "content",
+        strip_ansi: bool = True,
+        timeout_seconds: float = 120.0,
+        **_extra: Any,
+    ) -> CliLLM:
+        """Create and return a :class:`CliLLM` instance.
+
+        :param command: The executable and fixed arguments list.
+        :param prompt_via: How the prompt is sent -- ``"stdin"``,
+            ``"arg"``, or ``"file"``.
+        :param message_format: Message rendering strategy -- ``"last"``,
+            ``"roles"``, or ``"chatml"``.
+        :param output_format: Output parsing strategy -- ``"text"`` or
+            ``"json"``.
+        :param json_path: Extraction path for JSON output.
+        :param strip_ansi: Strip ANSI escape codes from stdout.
+        :param timeout_seconds: Per-call subprocess timeout in seconds.
+        :returns: A configured :class:`CliLLM` instance.
+        :raises ValueError: If ``command`` is empty, or any config value is
+            not among the supported options.
+        """
+        if not command:
+            raise ValueError("CliProvider requires a non-empty 'command' list")
+        if prompt_via not in SUPPORTED_PROMPT_VIA:
+            raise ValueError(
+                f"prompt_via={prompt_via!r} is not supported. "
+                f"Choose from: {sorted(SUPPORTED_PROMPT_VIA)}"
+            )
+        if message_format not in SUPPORTED_MESSAGE_FORMATS:
+            raise ValueError(
+                f"message_format={message_format!r} is not supported. "
+                f"Choose from: {sorted(SUPPORTED_MESSAGE_FORMATS)}"
+            )
+        if output_format not in SUPPORTED_OUTPUT_FORMATS:
+            raise ValueError(
+                f"output_format={output_format!r} is not supported. "
+                f"Choose from: {sorted(SUPPORTED_OUTPUT_FORMATS)}"
+            )
+
+        LOGGER.info("Initializing CliLLM: command=%s", command[0])
+
+        llm = CliLLM(
+            command=command,
+            prompt_via=prompt_via,
+            message_format=message_format,
+            output_format=output_format,
+            json_path=json_path,
+            strip_ansi_output=strip_ansi,
+            timeout_seconds=timeout_seconds,
+        )
+        LOGGER.debug(llm)
+        return llm

--- a/bili/iris/providers/fallback.py
+++ b/bili/iris/providers/fallback.py
@@ -106,6 +106,15 @@ _DEFAULT_RETRYABLE_NAMES: Tuple[str, ...] = (
     "ConnectionError",
     "ConnectionResetError",
     "BrokenPipeError",
+    # bili-core subprocess provider -- transient failures from the CLI tool
+    # (non-zero exit, OS timeout) should fall through to the next provider so
+    # a CLI provider can sit at the front of a fallback chain with an API
+    # provider as the safety net.  Config/usage errors from the CLI are still
+    # CliLLMError; treating all CliLLMErrors as retryable is acceptable for v1
+    # because a config error will simply exhaust the chain rather than masking
+    # a specific fatal exception type (unlike API-provider errors where 401
+    # AuthError vs RateLimitError have different semantics).
+    "CliLLMError",
 )
 
 

--- a/bili/iris/providers/tests/test_cli_provider.py
+++ b/bili/iris/providers/tests/test_cli_provider.py
@@ -40,6 +40,11 @@ from bili.iris.providers.cli_provider import (
     render_messages,
     strip_ansi,
 )
+from bili.iris.providers.fallback import (
+    _DEFAULT_RETRYABLE_NAMES,
+    DEFAULT_POLICY,
+    FallbackLLM,
+)
 from bili.iris.providers.registry import PROVIDER_REGISTRY
 
 # ---------------------------------------------------------------------------
@@ -571,6 +576,41 @@ class TestAStream:
         assert len(chunks) == 1
         assert chunks[0].message.content == "async result"
 
+    def test_astream_does_not_block_event_loop(self):
+        """_astream runs the blocking subprocess in a thread executor.
+
+        Verify that _call_cli is invoked via asyncio.to_thread by patching
+        asyncio.to_thread and asserting it is awaited with the correct
+        callable.  This ensures the event loop is not blocked for the
+        duration of the subprocess call.
+        """
+
+        async def _run():
+            """Async inner coroutine that patches asyncio.to_thread."""
+            llm = _llm()
+            to_thread_calls = []
+
+            async def fake_to_thread(func, *args, **kwargs):
+                """Capture the call and return a fixed value."""
+                to_thread_calls.append((func, args, kwargs))
+                return "threaded result"
+
+            with patch("asyncio.to_thread", side_effect=fake_to_thread):
+                chunks = []
+                async for chunk in llm._astream(messages=[_human("hi")]):
+                    chunks.append(chunk)
+            return to_thread_calls, chunks
+
+        calls, chunks = asyncio.run(_run())
+        # asyncio.to_thread must have been called exactly once
+        assert len(calls) == 1
+        # The first positional arg to to_thread is the callable (_call_cli)
+        func, _args, _ = calls[0]
+        assert callable(func)
+        # The result from to_thread is used as the chunk content
+        assert len(chunks) == 1
+        assert chunks[0].message.content == "threaded result"
+
 
 # ---------------------------------------------------------------------------
 # Integration: full invoke() path
@@ -720,3 +760,83 @@ class TestLLMType:
         """The _llm_type property returns 'cli'."""
         llm = _llm()
         assert llm._llm_type == "cli"
+
+
+# ---------------------------------------------------------------------------
+# FallbackLLM integration: CliLLMError retryability
+# ---------------------------------------------------------------------------
+
+
+class TestCliLLMErrorRetryability:
+    """Verify CliLLMError is treated as retryable by the fallback engine.
+
+    The fallback engine's DEFAULT_POLICY must classify CliLLMError as
+    retryable so that a CLI provider can be placed at the front of a fallback
+    chain (e.g. try the CLI first, fall through to an API provider if it
+    fails) without requiring consumers to write a custom FallbackPolicy.
+    """
+
+    def test_default_policy_treats_cli_llm_error_as_retryable(self):
+        """DEFAULT_POLICY.should_fallback(CliLLMError(...)) returns True."""
+        err = CliLLMError("subprocess exited with code 1")
+        assert DEFAULT_POLICY.should_fallback(err) is True
+
+    def test_cli_llm_error_name_in_retryable_names(self):
+        """'CliLLMError' appears in the fallback engine's retryable name set."""
+        assert "CliLLMError" in _DEFAULT_RETRYABLE_NAMES
+
+    def test_fallback_llm_falls_over_on_cli_error(self):
+        """A FallbackLLM with a failing CliLLM primary falls through to the next
+        provider.
+
+        Construct a FallbackLLM where:
+        - primary is a CliLLM that always raises CliLLMError
+        - fallback is a mock LLM that succeeds
+
+        Assert that the FallbackLLM's invoke() returns the fallback's response,
+        not the primary's error.
+        """
+        # Primary: a CliLLM configured to always fail
+        primary = _llm()
+        primary._call_cli = MagicMock(  # type: ignore[method-assign]
+            side_effect=CliLLMError("CLI tool crashed")
+        )
+
+        # Fallback: a simple mock that succeeds
+        fallback_response = AIMessage(content="API fallback succeeded")
+        fallback_llm = MagicMock()
+        fallback_llm.invoke = MagicMock(return_value=fallback_response)
+
+        chain = FallbackLLM(primary=primary, fallbacks=[fallback_llm])
+        result = chain.invoke([_human("hello")])
+
+        # The fallback response must be returned
+        assert result is fallback_response
+        # The primary must have been tried
+        primary._call_cli.assert_called_once()
+        # The fallback must have been invoked
+        fallback_llm.invoke.assert_called_once()
+
+    def test_fallback_not_triggered_for_non_retryable_errors(self):
+        """A FallbackLLM does NOT fall over on a ValueError from the primary.
+
+        ValueError is not in the retryable set, so the chain must re-raise it
+        immediately rather than trying the fallback.
+        """
+        primary = _llm()
+        primary._call_cli = MagicMock(  # type: ignore[method-assign]
+            side_effect=ValueError("bad configuration")
+        )
+
+        fallback_llm = MagicMock()
+        fallback_llm.invoke = MagicMock(
+            return_value=AIMessage(content="should not reach")
+        )
+
+        chain = FallbackLLM(primary=primary, fallbacks=[fallback_llm])
+
+        with pytest.raises(ValueError, match="bad configuration"):
+            chain.invoke([_human("hello")])
+
+        # The fallback must NOT have been called
+        fallback_llm.invoke.assert_not_called()

--- a/bili/iris/providers/tests/test_cli_provider.py
+++ b/bili/iris/providers/tests/test_cli_provider.py
@@ -1,0 +1,722 @@
+"""Tests for the CLI subprocess provider.
+
+Covers :class:`~bili.iris.providers.cli_provider.CliProvider`,
+:class:`~bili.iris.providers.cli_provider.CliLLM`, and the supporting
+helpers :func:`~bili.iris.providers.cli_provider.render_messages`,
+:func:`~bili.iris.providers.cli_provider.strip_ansi`, and
+:func:`~bili.iris.providers.cli_provider.extract_json_path`.
+
+No real subprocess is spawned; :mod:`subprocess` is mocked throughout
+so the tests run in any environment without a CLI LLM tool installed.
+"""
+
+# pylint: disable=too-few-public-methods,protected-access
+
+import asyncio
+import json
+import os
+import subprocess
+from typing import Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    HumanMessage,
+    SystemMessage,
+)
+from langchain_core.outputs import ChatGenerationChunk, ChatResult
+
+import bili.iris.providers.builtin  # noqa: F401  pylint: disable=unused-import
+from bili.aether.compiler.llm_resolver import resolve_provider
+from bili.iris.config.llm_config import LLM_MODELS
+from bili.iris.providers.base import KNOWN_PROVIDER_TYPES
+from bili.iris.providers.cli_provider import (
+    CliLLM,
+    CliLLMError,
+    CliProvider,
+    extract_json_path,
+    render_messages,
+    strip_ansi,
+)
+from bili.iris.providers.registry import PROVIDER_REGISTRY
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _human(text: str) -> HumanMessage:
+    """Return a HumanMessage with the given content."""
+    return HumanMessage(content=text)
+
+
+def _system(text: str) -> SystemMessage:
+    """Return a SystemMessage with the given content."""
+    return SystemMessage(content=text)
+
+
+def _ai(text: str) -> AIMessage:
+    """Return an AIMessage with the given content."""
+    return AIMessage(content=text)
+
+
+def _make_completed_proc(stdout: str = "", returncode: int = 0, stderr: str = ""):
+    """Return a mock subprocess.CompletedProcess object."""
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.returncode = returncode
+    return proc
+
+
+def _llm(**kwargs) -> CliLLM:
+    """Shorthand to build a CliLLM via CliProvider.load with a default command."""
+    defaults: Dict = {"command": ["echo"]}
+    defaults.update(kwargs)
+    return CliProvider().load(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# render_messages
+# ---------------------------------------------------------------------------
+
+
+class TestRenderMessages:
+    """Unit tests for the message rendering helper."""
+
+    def test_last_single_human(self):
+        """last format returns the content of the only human message."""
+        result = render_messages([_human("hello")], "last")
+        assert result == "hello"
+
+    def test_last_picks_last_human_in_multi_turn(self):
+        """last format returns the last HumanMessage in a multi-turn conversation."""
+        msgs = [_system("sys"), _human("first"), _ai("resp"), _human("second")]
+        result = render_messages(msgs, "last")
+        assert result == "second"
+
+    def test_last_falls_back_to_final_message_when_no_human(self):
+        """last format falls back to the last message when no HumanMessage is present."""
+        msgs = [_system("sys"), _ai("response")]
+        result = render_messages(msgs, "last")
+        assert result == "response"
+
+    def test_roles_format(self):
+        """roles format prefixes each message with its role label."""
+        msgs = [_system("be helpful"), _human("hi"), _ai("hello")]
+        result = render_messages(msgs, "roles")
+        assert result == "System: be helpful\nUser: hi\nAssistant: hello"
+
+    def test_roles_single_message(self):
+        """roles format works for a single message."""
+        result = render_messages([_human("ping")], "roles")
+        assert result == "User: ping"
+
+    def test_chatml_format_structure(self):
+        """chatml format includes the required im_start/im_end markers."""
+        msgs = [_system("system"), _human("question")]
+        result = render_messages(msgs, "chatml")
+        assert "<|im_start|>system" in result
+        assert "<|im_end|>" in result
+        assert "<|im_start|>user" in result
+        assert "<|im_start|>assistant" in result
+        lines = result.splitlines()
+        assert lines[-1] == "<|im_start|>assistant"
+
+    def test_chatml_full_conversation(self):
+        """chatml format emits correct marker counts for a full conversation."""
+        msgs = [_system("sys"), _human("q"), _ai("a"), _human("q2")]
+        result = render_messages(msgs, "chatml")
+        # 4 message blocks + 1 open assistant turn = 5 im_start markers
+        assert result.count("<|im_start|>") == 5
+        assert result.count("<|im_end|>") == 4
+
+    def test_empty_messages_raises(self):
+        """render_messages raises ValueError for an empty message list."""
+        with pytest.raises(ValueError, match="empty message list"):
+            render_messages([], "last")
+
+    def test_unknown_format_raises(self):
+        """render_messages raises ValueError for an unsupported format string."""
+        with pytest.raises(ValueError, match="Unknown message_format"):
+            render_messages([_human("x")], "unknown_format")
+
+
+# ---------------------------------------------------------------------------
+# strip_ansi
+# ---------------------------------------------------------------------------
+
+
+class TestStripAnsi:
+    """Tests for ANSI escape code stripping."""
+
+    def test_strips_color_codes(self):
+        """Common SGR color codes are removed."""
+        text = "\x1b[32mhello\x1b[0m world"
+        assert strip_ansi(text) == "hello world"
+
+    def test_strips_bold(self):
+        """Bold ANSI codes are removed."""
+        text = "\x1b[1mbold\x1b[0m"
+        assert strip_ansi(text) == "bold"
+
+    def test_no_ansi_passthrough(self):
+        """Plain text without ANSI codes is returned unchanged."""
+        text = "plain text"
+        assert strip_ansi(text) == "plain text"
+
+    def test_empty_string(self):
+        """Empty string input returns empty string."""
+        assert strip_ansi("") == ""
+
+    def test_strips_cursor_movement(self):
+        """Cursor movement codes used by progress bars are removed."""
+        text = "\x1b[2Kprogress done\x1b[0m"
+        assert strip_ansi(text) == "progress done"
+
+
+# ---------------------------------------------------------------------------
+# extract_json_path
+# ---------------------------------------------------------------------------
+
+
+class TestExtractJsonPath:
+    """Tests for the dot-separated JSON path extractor."""
+
+    def test_top_level_key(self):
+        """A single-segment path extracts a top-level key."""
+        assert extract_json_path({"content": "hello"}, "content") == "hello"
+
+    def test_nested_key(self):
+        """A multi-segment path traverses nested dicts and lists."""
+        obj = {"choices": [{"text": "hi"}]}
+        assert extract_json_path(obj, "choices.0.text") == "hi"
+
+    def test_deeply_nested(self):
+        """A deeply nested path is traversed correctly."""
+        obj = {"a": {"b": {"c": "value"}}}
+        assert extract_json_path(obj, "a.b.c") == "value"
+
+    def test_list_index(self):
+        """A numeric path segment indexes into a list."""
+        obj = [{"x": "first"}, {"x": "second"}]
+        assert extract_json_path(obj, "1.x") == "second"
+
+    def test_missing_key_raises(self):
+        """A missing dict key raises KeyError."""
+        with pytest.raises(KeyError):
+            extract_json_path({"a": "b"}, "missing")
+
+    def test_out_of_range_raises(self):
+        """An out-of-range list index raises IndexError."""
+        with pytest.raises(IndexError):
+            extract_json_path([1, 2], "5")
+
+    def test_non_container_traversal_raises(self):
+        """Attempting to traverse a scalar node raises TypeError."""
+        with pytest.raises(TypeError):
+            extract_json_path({"a": "scalar"}, "a.nested")
+
+    def test_converts_to_str(self):
+        """The returned value is always a string regardless of the JSON type."""
+        result = extract_json_path({"n": 42}, "n")
+        assert result == "42"
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# CliProvider.load validation
+# ---------------------------------------------------------------------------
+
+
+class TestCliProviderLoad:
+    """Tests for CliProvider.load() parameter validation."""
+
+    def test_empty_command_raises(self):
+        """An empty command list raises ValueError."""
+        with pytest.raises(ValueError, match="non-empty"):
+            CliProvider().load(command=[])
+
+    def test_invalid_prompt_via_raises(self):
+        """An unsupported prompt_via value raises ValueError."""
+        with pytest.raises(ValueError, match="prompt_via"):
+            CliProvider().load(command=["echo"], prompt_via="unknown")
+
+    def test_invalid_message_format_raises(self):
+        """An unsupported message_format value raises ValueError."""
+        with pytest.raises(ValueError, match="message_format"):
+            CliProvider().load(command=["echo"], message_format="bad")
+
+    def test_invalid_output_format_raises(self):
+        """An unsupported output_format value raises ValueError."""
+        with pytest.raises(ValueError, match="output_format"):
+            CliProvider().load(command=["echo"], output_format="xml")
+
+    def test_returns_cli_llm_instance(self):
+        """load() returns a CliLLM instance."""
+        llm = CliProvider().load(command=["echo", "hello"])
+        assert isinstance(llm, CliLLM)
+
+    def test_defaults_propagated(self):
+        """Default config values are set correctly on the returned CliLLM."""
+        llm = CliProvider().load(command=["my-cli"])
+        assert llm.prompt_via == "stdin"
+        assert llm.message_format == "last"
+        assert llm.output_format == "text"
+        assert llm.strip_ansi_output is True
+        assert llm.timeout_seconds == 120.0
+
+    def test_custom_values_propagated(self):
+        """Custom config values are forwarded to the CliLLM instance."""
+        llm = CliProvider().load(
+            command=["my-cli", "--json"],
+            prompt_via="arg",
+            message_format="roles",
+            output_format="json",
+            json_path="result.text",
+            strip_ansi=False,
+            timeout_seconds=30.0,
+        )
+        assert llm.command == ["my-cli", "--json"]
+        assert llm.prompt_via == "arg"
+        assert llm.message_format == "roles"
+        assert llm.output_format == "json"
+        assert llm.json_path == "result.text"
+        assert llm.strip_ansi_output is False
+        assert llm.timeout_seconds == 30.0
+
+    def test_extra_kwargs_ignored(self):
+        """Extra kwargs from an llm_config catalog entry do not raise."""
+        llm = CliProvider().load(
+            command=["my-cli"],
+            model_name="cli:custom",
+            temperature=0.7,
+        )
+        assert isinstance(llm, CliLLM)
+
+
+# ---------------------------------------------------------------------------
+# CliLLM._build_run_args
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRunArgs:
+    """Tests for command-line construction logic."""
+
+    def test_stdin_returns_stdin_text(self):
+        """stdin mode returns the prompt as stdin_text and no temp file."""
+        llm = _llm(prompt_via="stdin")
+        cmd, stdin_text, tmp = llm._build_run_args("hello")
+        assert cmd == ["echo"]
+        assert stdin_text == "hello"
+        assert tmp is None
+
+    def test_arg_appends_prompt(self):
+        """arg mode appends the prompt to the command and leaves stdin empty."""
+        llm = _llm(prompt_via="arg")
+        cmd, stdin_text, tmp = llm._build_run_args("hello")
+        assert cmd == ["echo", "hello"]
+        assert stdin_text is None
+        assert tmp is None
+
+    def test_file_creates_temp_and_appends_path(self):
+        """file mode writes the prompt to a temp file and appends its path."""
+        llm = _llm(prompt_via="file")
+        cmd, stdin_text, tmp = llm._build_run_args("write me to a file")
+        assert stdin_text is None
+        assert tmp is not None
+        assert os.path.exists(tmp)
+        with open(tmp, encoding="utf-8") as f:
+            assert f.read() == "write me to a file"
+        os.unlink(tmp)
+        assert cmd[-1] == tmp
+
+    def test_command_is_not_mutated(self):
+        """_build_run_args does not mutate the CliLLM.command list."""
+        llm = _llm(command=["my-llm", "--flag"], prompt_via="arg")
+        original = list(llm.command)
+        llm._build_run_args("prompt")
+        assert llm.command == original
+
+
+# ---------------------------------------------------------------------------
+# CliLLM subprocess execution
+# ---------------------------------------------------------------------------
+
+
+class TestRunSubprocess:
+    """Tests for the subprocess execution layer."""
+
+    def test_successful_run_returns_stdout(self):
+        """A zero-exit subprocess returns its stdout unchanged (pre-strip)."""
+        llm = _llm()
+        with patch(
+            "subprocess.run", return_value=_make_completed_proc("hello world\n")
+        ):
+            result = llm._run_subprocess("prompt")
+        assert result == "hello world\n"
+
+    def test_ansi_stripped_when_flag_set(self):
+        """ANSI codes are removed from stdout when strip_ansi_output is True."""
+        llm = _llm(strip_ansi=True)
+        with patch(
+            "subprocess.run",
+            return_value=_make_completed_proc("\x1b[32mgreen\x1b[0m text\n"),
+        ):
+            result = llm._run_subprocess("prompt")
+        assert result == "green text\n"
+
+    def test_ansi_preserved_when_flag_false(self):
+        """ANSI codes are preserved when strip_ansi_output is False."""
+        llm = _llm(strip_ansi=False)
+        raw = "\x1b[32mgreen\x1b[0m text"
+        with patch("subprocess.run", return_value=_make_completed_proc(raw)):
+            result = llm._run_subprocess("prompt")
+        assert "\x1b[32m" in result
+
+    def test_non_zero_exit_raises_cli_llm_error(self):
+        """A non-zero exit code raises CliLLMError."""
+        llm = _llm()
+        with patch(
+            "subprocess.run",
+            return_value=_make_completed_proc("", returncode=1, stderr="oops"),
+        ):
+            with pytest.raises(CliLLMError, match="exited with code 1"):
+                llm._run_subprocess("prompt")
+
+    def test_timeout_raises_cli_llm_error(self):
+        """A subprocess timeout raises CliLLMError."""
+        llm = _llm(timeout_seconds=5.0)
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["echo"], timeout=5),
+        ):
+            with pytest.raises(CliLLMError, match="timed out"):
+                llm._run_subprocess("prompt")
+
+    def test_env_is_passed(self):
+        """The subprocess is called with a copy of os.environ."""
+        llm = _llm()
+        with patch(
+            "subprocess.run", return_value=_make_completed_proc("ok")
+        ) as mock_run:
+            llm._run_subprocess("prompt")
+        call_kwargs = mock_run.call_args.kwargs
+        assert "env" in call_kwargs
+        assert isinstance(call_kwargs["env"], dict)
+
+    def test_stdin_mode_passes_prompt_as_input(self):
+        """stdin mode passes the prompt as the subprocess input kwarg."""
+        llm = _llm(prompt_via="stdin")
+        with patch(
+            "subprocess.run", return_value=_make_completed_proc("out")
+        ) as mock_run:
+            llm._run_subprocess("my prompt")
+        call_kwargs = mock_run.call_args.kwargs
+        assert call_kwargs.get("input") == "my prompt"
+
+    def test_arg_mode_does_not_pass_stdin(self):
+        """arg mode does not pass stdin to the subprocess."""
+        llm = _llm(prompt_via="arg")
+        with patch(
+            "subprocess.run", return_value=_make_completed_proc("out")
+        ) as mock_run:
+            llm._run_subprocess("my prompt")
+        call_kwargs = mock_run.call_args.kwargs
+        assert call_kwargs.get("input") is None
+
+    def test_stderr_truncated_in_error_message(self):
+        """The error message includes at most 500 chars of stderr."""
+        long_stderr = "X" * 600
+        llm = _llm()
+        with patch(
+            "subprocess.run",
+            return_value=_make_completed_proc("", returncode=2, stderr=long_stderr),
+        ):
+            with pytest.raises(CliLLMError) as exc_info:
+                llm._run_subprocess("p")
+        assert len(str(exc_info.value)) < 600 + 100
+
+
+# ---------------------------------------------------------------------------
+# CliLLM._parse_output
+# ---------------------------------------------------------------------------
+
+
+class TestParseOutput:
+    """Tests for output parsing (text vs JSON)."""
+
+    def test_text_strips_whitespace(self):
+        """text format strips leading/trailing whitespace."""
+        llm = _llm(output_format="text")
+        assert llm._parse_output("  hello world  \n") == "hello world"
+
+    def test_json_extracts_default_content_path(self):
+        """json format extracts the value at the default 'content' path."""
+        llm = _llm(output_format="json")
+        raw = json.dumps({"content": "extracted"})
+        assert llm._parse_output(raw) == "extracted"
+
+    def test_json_custom_path(self):
+        """json format extracts the value at a custom dot-path."""
+        llm = _llm(output_format="json", json_path="choices.0.text")
+        raw = json.dumps({"choices": [{"text": "the answer"}]})
+        assert llm._parse_output(raw) == "the answer"
+
+    def test_invalid_json_raises(self):
+        """Non-JSON stdout raises CliLLMError when output_format='json'."""
+        llm = _llm(output_format="json")
+        with pytest.raises(CliLLMError, match="not valid JSON"):
+            llm._parse_output("not json")
+
+    def test_missing_json_path_raises(self):
+        """A missing path in JSON output raises CliLLMError."""
+        llm = _llm(output_format="json", json_path="nonexistent")
+        raw = json.dumps({"other": "field"})
+        with pytest.raises(CliLLMError, match="json_path"):
+            llm._parse_output(raw)
+
+
+# ---------------------------------------------------------------------------
+# CliLLM._generate (LangChain interface)
+# ---------------------------------------------------------------------------
+
+
+class TestGenerate:
+    """Tests for the LangChain _generate() entrypoint."""
+
+    def test_returns_chat_result(self):
+        """_generate returns a ChatResult instance."""
+        llm = _llm()
+        # type: ignore[method-assign]
+        llm._run_subprocess = MagicMock(return_value="Hello from CLI")
+        result = llm._generate(messages=[_human("hi")])
+        assert isinstance(result, ChatResult)
+        assert len(result.generations) == 1
+
+    def test_generation_contains_ai_message(self):
+        """The single generation contains an AIMessage with the CLI output."""
+        llm = _llm()
+        llm._run_subprocess = MagicMock(return_value="CLI response")  # type: ignore[method-assign]
+        result = llm._generate(messages=[_human("ping")])
+        msg = result.generations[0].message
+        assert isinstance(msg, AIMessage)
+        assert msg.content == "CLI response"
+
+    def test_uses_parsed_output(self):
+        """_generate delegates parsing to _call_cli, not raw stdout."""
+        llm = _llm()
+        with patch.object(llm, "_call_cli", return_value="parsed") as mock_call:
+            result = llm._generate(messages=[_human("q")])
+        mock_call.assert_called_once()
+        assert result.generations[0].message.content == "parsed"
+
+
+# ---------------------------------------------------------------------------
+# CliLLM._stream (single-chunk streaming)
+# ---------------------------------------------------------------------------
+
+
+class TestStream:
+    """Tests for the synchronous _stream() method."""
+
+    def test_yields_single_chunk(self):
+        """_stream yields exactly one ChatGenerationChunk."""
+        llm = _llm()
+        with patch.object(llm, "_call_cli", return_value="response text"):
+            chunks = list(llm._stream(messages=[_human("hi")]))
+        assert len(chunks) == 1
+        assert isinstance(chunks[0], ChatGenerationChunk)
+
+    def test_chunk_contains_full_content(self):
+        """The single chunk contains the complete CLI response."""
+        llm = _llm()
+        with patch.object(llm, "_call_cli", return_value="the full text"):
+            chunks = list(llm._stream(messages=[_human("hi")]))
+        msg = chunks[0].message
+        assert isinstance(msg, AIMessageChunk)
+        assert msg.content == "the full text"
+
+    def test_stream_propagates_cli_error(self):
+        """_stream propagates CliLLMError from the subprocess."""
+        llm = _llm()
+        with patch.object(llm, "_call_cli", side_effect=CliLLMError("boom")):
+            with pytest.raises(CliLLMError, match="boom"):
+                list(llm._stream(messages=[_human("hi")]))
+
+
+# ---------------------------------------------------------------------------
+# CliLLM._astream (async streaming)
+# ---------------------------------------------------------------------------
+
+
+class TestAStream:
+    """Tests for the async _astream() method."""
+
+    def test_async_yields_single_chunk(self):
+        """_astream yields exactly one chunk containing the full CLI response."""
+
+        async def _run():
+            """Async inner coroutine to collect chunks from _astream."""
+            llm = _llm()
+            with patch.object(llm, "_call_cli", return_value="async result"):
+                chunks = []
+                async for chunk in llm._astream(messages=[_human("hi")]):
+                    chunks.append(chunk)
+            return chunks
+
+        chunks = asyncio.run(_run())
+        assert len(chunks) == 1
+        assert chunks[0].message.content == "async result"
+
+
+# ---------------------------------------------------------------------------
+# Integration: full invoke() path
+# ---------------------------------------------------------------------------
+
+
+class TestInvokeEndToEnd:
+    """Integration tests: full .invoke() path with subprocess.run mocked."""
+
+    def test_invoke_returns_ai_message(self):
+        """invoke() returns an AIMessage containing the CLI output."""
+        llm = _llm(command=["echo", "hello"])
+        with patch("subprocess.run", return_value=_make_completed_proc("AI output")):
+            response = llm.invoke([_human("what is 2+2")])
+        assert isinstance(response, AIMessage)
+        assert "AI output" in response.content
+
+    def test_invoke_json_output_format(self):
+        """invoke() parses JSON output and extracts the configured path."""
+        llm = _llm(
+            command=["my-cli", "--json"],
+            output_format="json",
+            json_path="message",
+        )
+        stdout = json.dumps({"message": "the answer is 4"})
+        with patch("subprocess.run", return_value=_make_completed_proc(stdout)):
+            response = llm.invoke([_human("what is 2+2")])
+        assert response.content == "the answer is 4"
+
+    def test_invoke_roles_message_format_sends_full_history(self):
+        """roles format includes System/User/Assistant prefixes in the subprocess input."""
+        llm = _llm(message_format="roles")
+        messages = [_system("be helpful"), _human("hi"), _ai("hello"), _human("bye")]
+        with patch(
+            "subprocess.run", return_value=_make_completed_proc("ok")
+        ) as mock_run:
+            llm.invoke(messages)
+        call_kwargs = mock_run.call_args.kwargs
+        stdin_text = call_kwargs.get("input", "")
+        assert "System:" in stdin_text
+        assert "User:" in stdin_text
+        assert "Assistant:" in stdin_text
+
+    def test_invoke_chatml_message_format(self):
+        """chatml format includes im_start markers in the subprocess input."""
+        llm = _llm(message_format="chatml")
+        messages = [_system("sys"), _human("q")]
+        with patch(
+            "subprocess.run", return_value=_make_completed_proc("ok")
+        ) as mock_run:
+            llm.invoke(messages)
+        call_kwargs = mock_run.call_args.kwargs
+        stdin_text = call_kwargs.get("input", "")
+        assert "<|im_start|>system" in stdin_text
+        assert "<|im_start|>user" in stdin_text
+
+    def test_invoke_arg_mode_no_stdin(self):
+        """arg mode appends the prompt to the command and passes no stdin."""
+        llm = _llm(prompt_via="arg")
+        with patch(
+            "subprocess.run", return_value=_make_completed_proc("answer")
+        ) as mock_run:
+            llm.invoke([_human("question")])
+        positional_cmd = mock_run.call_args.args[0]
+        assert positional_cmd[-1] == "question"
+        assert mock_run.call_args.kwargs.get("input") is None
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryIntegration:
+    """Verify the 'cli' type is registered in the built-in provider registry."""
+
+    def test_cli_registered_in_builtin_registry(self):
+        """The 'cli' provider type is present in PROVIDER_REGISTRY."""
+        assert "cli" in PROVIDER_REGISTRY
+
+    def test_cli_provider_class_correct(self):
+        """The 'cli' type maps to CliProvider in the registry."""
+        assert PROVIDER_REGISTRY.get("cli") is CliProvider
+
+    def test_cli_in_known_provider_types(self):
+        """'cli' appears in KNOWN_PROVIDER_TYPES."""
+        assert "cli" in KNOWN_PROVIDER_TYPES
+
+
+# ---------------------------------------------------------------------------
+# Heuristic resolver: "cli:" prefix
+# ---------------------------------------------------------------------------
+
+
+class TestHeuristicResolution:
+    """Verify the heuristic resolver maps 'cli:' prefixed IDs to the 'cli' provider."""
+
+    def test_cli_prefix_resolves_to_cli(self):
+        """Model IDs prefixed with 'cli:' resolve to the cli provider type."""
+        assert resolve_provider("cli:custom") == "cli"
+        assert resolve_provider("cli:my-local-tool") == "cli"
+
+
+# ---------------------------------------------------------------------------
+# LLM_MODELS catalog entry
+# ---------------------------------------------------------------------------
+
+
+class TestLLMModelsCatalog:
+    """Verify the 'cli' section is present and structurally valid."""
+
+    def test_cli_section_exists(self):
+        """LLM_MODELS contains a 'cli' top-level key."""
+        assert "cli" in LLM_MODELS
+
+    def test_cli_section_has_models(self):
+        """The 'cli' section has at least one model entry."""
+        models = LLM_MODELS["cli"]["models"]
+        assert len(models) > 0
+
+    def test_cli_model_has_required_fields(self):
+        """Each cli model entry has model_name and model_id fields."""
+        for entry in LLM_MODELS["cli"]["models"]:
+            assert "model_name" in entry
+            assert "model_id" in entry
+
+    def test_cli_model_id_uses_sentinel(self):
+        """CLI catalog model IDs use the 'cli:' sentinel prefix."""
+        ids = [e["model_id"] for e in LLM_MODELS["cli"]["models"]]
+        assert any(mid.startswith("cli:") for mid in ids)
+
+    def test_cli_supports_tools_is_false(self):
+        """CLI models set supports_tools=False (bind_tools() is not available)."""
+        for entry in LLM_MODELS["cli"]["models"]:
+            assert entry.get("supports_tools") is False
+
+
+# ---------------------------------------------------------------------------
+# CliLLM._llm_type property
+# ---------------------------------------------------------------------------
+
+
+class TestLLMType:
+    """Verify the _llm_type property returns the correct identifier."""
+
+    def test_llm_type_returns_cli(self):
+        """The _llm_type property returns 'cli'."""
+        llm = _llm()
+        assert llm._llm_type == "cli"


### PR DESCRIPTION
## Summary

Adds a new built-in `"cli"` provider type that drives any command-line LLM
tool as a stateless text-in / text-out model, fully compatible with
LangChain/LangGraph pipelines, AETHER agent nodes, and the IRIS runtime.

**Motivation:** Some deployment environments have a CLI LLM tool available but
not an API key.  The `"cli"` provider bridges that gap without forking the
codebase or maintaining a separate integration layer.  It is the fallback
companion to the direct-API providers added in #203.

## What was built

### Core (`bili/iris/providers/cli_provider.py`)

- `CliProvider(LLMProvider)` -- factory; validates config, returns `CliLLM`.
- `CliLLM(BaseChatModel)` -- concrete LangChain chat model backed by
  `subprocess.run`.  Implements `_generate()`, `_stream()`, and `_astream()`.
  `_stream`/`_astream` yield the full response as **one chunk** -- this is the
  honest contract, since the subprocess must complete before any output is
  available.
- `render_messages()` -- collapses a `List[BaseMessage]` to a single prompt
  string using one of three configurable strategies:
  - `"last"` (default): send only the last `HumanMessage`
  - `"roles"`: role-prefixed plain-text format (`System: ... / User: ...`)
  - `"chatml"`: ChatML `<|im_start|>/<|im_end|>` format
- `strip_ansi()` -- removes ANSI escape codes from subprocess stdout.
- `extract_json_path()` -- dot-separated path extractor for structured JSON
  output (e.g. `choices.0.text`).
- `CliLLMError` -- raised on non-zero subprocess exit or timeout; retryable by
  `FallbackLLM` (see fallback engine section below).

**Config** (all set via `CliProvider.load()`):

| kwarg | default | meaning |
|---|---|---|
| `command` | required | executable + fixed args list |
| `prompt_via` | `"stdin"` | how the prompt is sent: `stdin`, `arg`, `file` |
| `message_format` | `"last"` | message rendering strategy |
| `output_format` | `"text"` | output parsing: `text` or `json` |
| `json_path` | `"content"` | dot-path for JSON extraction |
| `strip_ansi` | `True` | strip ANSI codes from stdout |
| `timeout_seconds` | `120.0` | per-call wall-clock timeout |

**Auth:** The subprocess inherits `os.environ` in full.  bili-core does not
manage credentials for CLI tools.

**No new optional dependency:** the module uses only stdlib `subprocess`, `re`,
and `asyncio`.

### Registration

- `builtin.py`: `"cli"` registered in `_BUILTIN_PROVIDERS`
- `base.py`: `"cli"` added to `KNOWN_PROVIDER_TYPES`
- `llm_config.py`: `"cli"` catalog section with placeholder sentinel entry
  (`model_id="cli:custom"`, `supports_tools=False`)
- `llm_resolver.py`: `("cli:", "cli")` heuristic rule so `"cli:*"` model IDs
  resolve without an explicit `provider_type` argument

### Fallback engine (`bili/iris/providers/fallback.py`)

`CliLLMError` is added to `_DEFAULT_RETRYABLE_NAMES` so that CLI provider
failures (non-zero exit, timeout) automatically fall through to the next
provider in a `FallbackLLM` chain.  Rationale: treating all `CliLLMError`
instances as retryable is acceptable for v1 because a config error exhausts
the chain rather than silently masking a fatal auth failure (unlike API
providers where a 401 must not trigger fallback against remaining providers).
The comment in fallback.py documents this choice explicitly.

### Async correctness

`CliLLM._astream` runs the blocking subprocess via `asyncio.to_thread` so it
does not stall the event loop while the CLI tool executes.

### Tests (`bili/iris/providers/tests/test_cli_provider.py`, 75 tests)

| Test class | Count | What is tested |
|---|---|---|
| `TestRenderMessages` | 9 | all three formats, edge cases |
| `TestStripAnsi` | 5 | color, bold, cursor movement, passthrough |
| `TestExtractJsonPath` | 8 | nested paths, error cases, type conversion |
| `TestCliProviderLoad` | 8 | validation, defaults, extra kwargs |
| `TestBuildRunArgs` | 4 | stdin/arg/file modes, mutation safety |
| `TestRunSubprocess` | 9 | success, ANSI stripping, errors, env, stdin |
| `TestParseOutput` | 5 | text/json modes, error paths |
| `TestGenerate` | 3 | ChatResult shape, delegation |
| `TestStream` | 3 | single-chunk yield, error propagation |
| `TestAStream` | 2 | single-chunk yield; **to_thread dispatch verified** |
| `TestInvokeEndToEnd` | 5 | full `.invoke()` with all formats/modes |
| `TestRegistryIntegration` | 3 | registry key, class, KNOWN_PROVIDER_TYPES |
| `TestHeuristicResolution` | 1 | `"cli:"` prefix routing |
| `TestLLMModelsCatalog` | 5 | section shape, required fields, sentinel, tools |
| `TestLLMType` | 1 | `_llm_type` == `"cli"` |
| `TestCliLLMErrorRetryability` | 4 | DEFAULT_POLICY retryable; name in set; **end-to-end FallbackLLM chain fallover**; non-retryable error re-raised |

## Code quality

- Pylint: 10.00/10 (all changed files)
- Full suite: **3535 tests, 0 failures** (was 3460 before this PR)
- Pre-commit hooks: black, autoflake, isort, pylint -- all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpXRrbE4UhL22Usj6UdEVQ