### PR TITLE
feat: named CLI provider presets (claude_code, codex, gemini_cli)

### DIFF
--- a/bili/iris/config/llm_config.py
+++ b/bili/iris/config/llm_config.py
@@ -1553,6 +1553,82 @@ LLM_MODELS = {
             },
         ],
     },
+    # ------------------------------------------------------------------ #
+    # CLI preset providers                                                #
+    # ------------------------------------------------------------------ #
+    # Each entry below is a named preset for a specific CLI LLM tool.   #
+    # The preset supplies the known one-shot invocation, prompt-delivery #
+    # strategy, and output config so callers need no per-tool knowledge. #
+    # The subprocess inherits os.environ; whatever credential the tool   #
+    # holds (OAuth session, API key env var, etc.) is reused.            #
+    # ------------------------------------------------------------------ #
+    "cli_claude_code": {
+        "name": "Claude Code CLI (Preset)",
+        "description": (
+            "Drives 'claude -p <prompt>' (Anthropic Claude Code CLI) in "
+            "one-shot print mode.  No API key configuration is required "
+            "beyond having the Claude CLI installed and authenticated.  "
+            "The subprocess reuses the calling process's OAuth session or "
+            "ANTHROPIC_API_KEY environment variable."
+        ),
+        "model_help": "https://docs.anthropic.com/en/docs/claude-code/cli-usage",
+        "models": [
+            {
+                "model_name": "Claude Code CLI",
+                "model_id": "cli:claude_code",
+                "supports_temperature": False,
+                "supports_seed": False,
+                "supports_max_output_tokens": False,
+                "supports_top_p": False,
+                "supports_top_k": False,
+                "supports_tools": False,
+            },
+        ],
+    },
+    "cli_codex": {
+        "name": "OpenAI Codex CLI (Preset)",
+        "description": (
+            "Drives 'codex exec <prompt>' (OpenAI Codex CLI) in "
+            "non-interactive mode.  Requires the Codex CLI to be installed "
+            "and authenticated via OPENAI_API_KEY or its interactive login "
+            "flow.  The subprocess reuses the calling process's environment."
+        ),
+        "model_help": "https://developers.openai.com/codex/noninteractive",
+        "models": [
+            {
+                "model_name": "Codex CLI",
+                "model_id": "cli:codex",
+                "supports_temperature": False,
+                "supports_seed": False,
+                "supports_max_output_tokens": False,
+                "supports_top_p": False,
+                "supports_top_k": False,
+                "supports_tools": False,
+            },
+        ],
+    },
+    "cli_gemini_cli": {
+        "name": "Google Gemini CLI (Preset)",
+        "description": (
+            "Drives 'gemini -p <prompt>' (Google Gemini CLI) in "
+            "non-interactive headless mode.  Requires the Gemini CLI to be "
+            "installed and authenticated via Google OAuth or GEMINI_API_KEY.  "
+            "The subprocess reuses the calling process's environment."
+        ),
+        "model_help": "https://github.com/google-gemini/gemini-cli",
+        "models": [
+            {
+                "model_name": "Gemini CLI",
+                "model_id": "cli:gemini_cli",
+                "supports_temperature": False,
+                "supports_seed": False,
+                "supports_max_output_tokens": False,
+                "supports_top_p": False,
+                "supports_top_k": False,
+                "supports_tools": False,
+            },
+        ],
+    },
     "local_llamacpp": {
         "name": "Local LlamaCpp Compatible Model",
         "description": "Local LlamaCpp compatible model loaded into memory.",

--- a/bili/iris/providers/base.py
+++ b/bili/iris/providers/base.py
@@ -45,6 +45,10 @@ KNOWN_PROVIDER_TYPES = frozenset(
         "local_huggingface",
         # Subprocess / transport-level providers
         "cli",
+        # Named CLI presets (each preset is a CliPresetProvider subclass)
+        "cli_claude_code",
+        "cli_codex",
+        "cli_gemini_cli",
         # Future provider shapes (not yet implemented)
         # "mcp"   -- Model Context Protocol server transport
     }

--- a/bili/iris/providers/builtin.py
+++ b/bili/iris/providers/builtin.py
@@ -28,6 +28,9 @@ Provider type string               Implementation class
 ``local_llamacpp``                 :class:`~.llamacpp_provider.LlamaCppProvider`
 ``local_huggingface``              :class:`~.huggingface_provider.HuggingFaceProvider`
 ``cli``                            :class:`~.cli_provider.CliProvider`
+``cli_claude_code``                :class:`~.preset_provider.CliPresetProvider` (Claude Code preset)
+``cli_codex``                      :class:`~.preset_provider.CliPresetProvider` (Codex CLI preset)
+``cli_gemini_cli``                 :class:`~.preset_provider.CliPresetProvider` (Gemini CLI preset)
 ================================  ================================================
 """
 
@@ -36,6 +39,7 @@ import logging
 from .anthropic_provider import AnthropicProvider
 from .azure_openai_provider import AzureOpenAIProvider
 from .bedrock_provider import BedrockProvider
+from .cli_presets import CLI_PRESET_CATALOG
 from .cli_provider import CliProvider
 from .cohere_provider import CohereProvider
 from .deepseek_provider import DeepSeekProvider
@@ -45,6 +49,7 @@ from .huggingface_provider import HuggingFaceProvider
 from .llamacpp_provider import LlamaCppProvider
 from .mistral_provider import MistralProvider
 from .openai_provider import OpenAIProvider
+from .preset_provider import CliPresetProvider
 from .registry import PROVIDER_REGISTRY
 from .vertex_provider import VertexAIProvider
 from .xai_provider import XAIProvider
@@ -81,6 +86,17 @@ def _register_builtins() -> None:
             LOGGER.debug("Built-in provider registered: '%s'", provider_type)
         else:
             LOGGER.debug("Built-in provider already registered: '%s'", provider_type)
+
+    # Register CLI preset providers.  Each preset gets a dynamically-generated
+    # CliPresetProvider subclass so the registry holds a distinct class per
+    # preset, which is required by ProviderRegistry's deduplication logic.
+    for preset_type, preset in CLI_PRESET_CATALOG.items():
+        if preset_type not in PROVIDER_REGISTRY:
+            preset_class = CliPresetProvider.for_preset(preset)
+            PROVIDER_REGISTRY.register(preset_type, preset_class)
+            LOGGER.debug("CLI preset provider registered: '%s'", preset_type)
+        else:
+            LOGGER.debug("CLI preset provider already registered: '%s'", preset_type)
 
 
 _register_builtins()

--- a/bili/iris/providers/cli_presets.py
+++ b/bili/iris/providers/cli_presets.py
@@ -1,0 +1,210 @@
+"""Named presets for common CLI LLM tools.
+
+Each preset bundles the known one-shot invocation pattern, prompt-delivery
+strategy, output format, and sensible defaults for a specific CLI tool, so
+callers can load a CLI-backed LLM **by name** instead of reverse-engineering
+the tool's flags.
+
+Usage
+-----
+Register a preset provider type at application startup and then pass the
+preset's provider-type string to :func:`~bili.iris.loaders.llm_loader.load_model`:
+
+.. code-block:: python
+
+    import bili.iris.providers.builtin  # noqa: F401  (registers built-ins)
+    from bili.iris.loaders.llm_loader import load_model
+
+    # Load Claude Code in one-shot mode -- no flags to look up.
+    llm = load_model("cli_claude_code")
+
+    # Override the timeout for a slow query.
+    llm = load_model("cli_claude_code", timeout_seconds=300.0)
+
+Each preset maps to a :class:`~bili.iris.providers.preset_provider.CliPresetProvider`
+registered under its type string in
+:data:`~bili.iris.providers.registry.PROVIDER_REGISTRY`.
+
+Built-in presets
+----------------
+``cli_claude_code``
+    Drives ``claude -p <prompt>`` (Anthropic Claude Code CLI) in one-shot
+    print mode.  The subprocess inherits the calling process's environment,
+    which supplies the OAuth session or API key that the Claude CLI already
+    holds.
+
+``cli_codex``
+    Drives ``codex exec <prompt>`` (OpenAI Codex CLI) in non-interactive
+    mode.  Requires the Codex CLI to be installed and authenticated.
+
+``cli_gemini_cli``
+    Drives ``gemini -p <prompt>`` (Google Gemini CLI) in non-interactive
+    headless mode.  Requires the Gemini CLI to be installed and authenticated.
+
+Adding custom presets
+---------------------
+Call :func:`register_cli_preset` at application startup to register an
+additional preset under its own provider-type string:
+
+.. code-block:: python
+
+    from bili.iris.providers.cli_presets import CliPreset, register_cli_preset
+
+    register_cli_preset(
+        "cli_my_tool",
+        CliPreset(
+            command=["my-llm-tool", "--no-color"],
+            prompt_via="stdin",
+            output_format="text",
+        ),
+    )
+"""
+
+from dataclasses import dataclass, field
+from typing import List
+
+# ---------------------------------------------------------------------------
+# CliPreset dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CliPreset:
+    """Configuration bundle for a specific CLI LLM tool.
+
+    Each field mirrors a parameter of
+    :meth:`~bili.iris.providers.cli_provider.CliProvider.load`, with a
+    sensible per-tool default.  Callers can override any field at
+    ``load_model()`` call-time.
+
+    :param command: The executable and its fixed arguments.  The prompt is
+        appended separately according to ``prompt_via``.
+    :param prompt_via: How the rendered prompt is delivered to the process.
+        ``"arg"`` (default for most CLIs -- appended as a positional argument),
+        ``"stdin"``, or ``"file"``.
+    :param message_format: How the LangChain message list is rendered before
+        delivery.  ``"last"`` (default) sends only the final human message.
+    :param output_format: How the subprocess stdout is parsed.  ``"text"``
+        (default) returns the raw stripped output; ``"json"`` parses JSON and
+        extracts the value at ``json_path``.
+    :param json_path: Extraction path for JSON output.  Default ``"content"``.
+    :param strip_ansi: Strip ANSI escape codes from stdout.  Default ``True``.
+    :param timeout_seconds: Per-call subprocess timeout in seconds.
+        Default ``120.0``.
+    """
+
+    command: List[str] = field(default_factory=list)
+    prompt_via: str = "arg"
+    message_format: str = "last"
+    output_format: str = "text"
+    json_path: str = "content"
+    strip_ansi: bool = True
+    timeout_seconds: float = 120.0
+
+
+# ---------------------------------------------------------------------------
+# Built-in preset definitions
+# ---------------------------------------------------------------------------
+
+#: Claude Code CLI -- ``claude -p <prompt>``
+#:
+#: Invokes the ``claude`` executable in one-shot print mode (``-p`` / ``--print``).
+#: Output is written to stdout as plain text and the process exits.  The
+#: subprocess inherits the calling process's environment, so whatever OAuth
+#: session or ``ANTHROPIC_API_KEY`` the CLI holds is reused automatically.
+#:
+#: Reference: ``claude --help`` (look for ``-p, --print``).
+CLAUDE_CODE_PRESET = CliPreset(
+    command=["claude", "-p"],
+    prompt_via="arg",
+    message_format="last",
+    output_format="text",
+    strip_ansi=True,
+    timeout_seconds=120.0,
+)
+
+#: OpenAI Codex CLI -- ``codex exec <prompt>``
+#:
+#: Invokes ``codex exec`` in non-interactive mode.  The prompt is passed as a
+#: positional argument.  The CLI prints the final agent message to stdout and
+#: exits.  Requires the Codex CLI to be installed and authenticated via
+#: ``OPENAI_API_KEY`` or its interactive login flow.
+#:
+#: Reference: ``codex --help`` / OpenAI Codex CLI documentation.
+CODEX_PRESET = CliPreset(
+    command=["codex", "exec"],
+    prompt_via="arg",
+    message_format="last",
+    output_format="text",
+    strip_ansi=True,
+    timeout_seconds=180.0,
+)
+
+#: Google Gemini CLI -- ``gemini -p <prompt>``
+#:
+#: Invokes the ``gemini`` executable in non-interactive headless mode
+#: (``-p`` / ``--prompt``).  Output is written to stdout as plain text and
+#: the process exits.  Requires the Gemini CLI to be installed and
+#: authenticated (Google account OAuth or ``GEMINI_API_KEY``).
+#:
+#: Reference: ``gemini --help`` (look for ``-p, --prompt``).
+GEMINI_CLI_PRESET = CliPreset(
+    command=["gemini", "-p"],
+    prompt_via="arg",
+    message_format="last",
+    output_format="text",
+    strip_ansi=True,
+    timeout_seconds=120.0,
+)
+
+# ---------------------------------------------------------------------------
+# Public preset catalog
+# ---------------------------------------------------------------------------
+
+#: Mapping from provider-type string to :class:`CliPreset`.
+#:
+#: Used by :mod:`bili.iris.providers.builtin` to register each preset as a
+#: :class:`~bili.iris.providers.preset_provider.CliPresetProvider` in the
+#: global :data:`~bili.iris.providers.registry.PROVIDER_REGISTRY`.
+CLI_PRESET_CATALOG: dict = {
+    "cli_claude_code": CLAUDE_CODE_PRESET,
+    "cli_codex": CODEX_PRESET,
+    "cli_gemini_cli": GEMINI_CLI_PRESET,
+}
+
+
+def register_cli_preset(provider_type: str, preset: "CliPreset") -> None:
+    """Register a custom :class:`CliPreset` in the global provider registry.
+
+    Creates a :class:`~bili.iris.providers.preset_provider.CliPresetProvider`
+    for *preset* and registers it under *provider_type* in the global
+    :data:`~bili.iris.providers.registry.PROVIDER_REGISTRY`.
+
+    Call this at application startup, before the application begins serving
+    requests.
+
+    :param provider_type: The provider-type key to register (e.g.
+        ``"cli_my_tool"``).  Must not already be registered.
+    :param preset: The :class:`CliPreset` configuration bundle.
+
+    Example::
+
+        from bili.iris.providers.cli_presets import CliPreset, register_cli_preset
+
+        register_cli_preset(
+            "cli_my_tool",
+            CliPreset(command=["my-llm", "--no-color"], prompt_via="stdin"),
+        )
+    """
+    # Lazy import to avoid circular dependency: cli_presets -> preset_provider
+    # -> cli_provider -> base; keeping cli_presets free of provider imports
+    # also lets callers import CliPreset without pulling in LangChain.
+    from bili.iris.providers.preset_provider import (  # pylint: disable=import-outside-toplevel
+        CliPresetProvider,
+    )
+    from bili.iris.providers.registry import (  # pylint: disable=import-outside-toplevel
+        PROVIDER_REGISTRY,
+    )
+
+    provider_class = CliPresetProvider.for_preset(preset)
+    PROVIDER_REGISTRY.register(provider_type, provider_class)

--- a/bili/iris/providers/preset_provider.py
+++ b/bili/iris/providers/preset_provider.py
@@ -1,0 +1,152 @@
+"""Provider wrapper that applies a :class:`~bili.iris.providers.cli_presets.CliPreset`
+as default configuration and delegates to
+:class:`~bili.iris.providers.cli_provider.CliProvider`.
+
+This module exists as a thin adapter layer between the named-preset catalog
+and the generic :class:`~bili.iris.providers.cli_provider.CliProvider`.  It
+is not part of the public API; use
+:data:`~bili.iris.providers.cli_presets.CLI_PRESET_CATALOG` and
+:func:`~bili.iris.providers.cli_presets.register_cli_preset` instead.
+
+Design note
+-----------
+A dynamically-generated subclass per preset (via :meth:`CliPresetProvider.for_preset`)
+is used so that each preset can be registered as a separate *class* in the
+:class:`~bili.iris.providers.registry.ProviderRegistry`.  The registry stores
+*classes* (not instances), and each registered class must be distinct --
+registering the same class under two different keys would mean both keys share
+the same preset defaults.  The ``for_preset`` factory avoids a proliferation of
+hand-written subclasses.
+"""
+
+import logging
+from typing import Any, List, Optional, Type
+
+from .base import LLMProvider
+from .cli_provider import CliLLM, CliProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CliPresetProvider(LLMProvider):
+    """An :class:`~bili.iris.providers.base.LLMProvider` that wraps a
+    :class:`~bili.iris.providers.cli_presets.CliPreset`.
+
+    Instances supply the preset's defaults for every parameter that the caller
+    does not override, then delegate to
+    :class:`~bili.iris.providers.cli_provider.CliProvider` for validation and
+    :class:`~bili.iris.providers.cli_provider.CliLLM` construction.
+
+    Do not instantiate this class directly.  Use
+    :meth:`for_preset` to obtain a subclass bound to a specific preset, or
+    call :func:`~bili.iris.providers.cli_presets.register_cli_preset` to
+    register a preset and let the registry instantiate it on demand.
+    """
+
+    #: The :class:`~bili.iris.providers.cli_presets.CliPreset` this provider
+    #: is bound to.  Set by :meth:`for_preset`; ``None`` in the base class.
+    _preset: Optional[Any] = None  # CliPreset -- kept as Any to avoid circular import
+
+    def _resolve_kwargs(self, overrides: dict) -> dict:
+        """Merge caller-supplied *overrides* with preset defaults.
+
+        For each CliProvider parameter, the caller-supplied value is used when
+        not ``None``; otherwise the bound preset's value is the default.
+        Returns a dict ready to pass to
+        :meth:`~bili.iris.providers.cli_provider.CliProvider.load`.
+
+        :param overrides: Mapping of parameter name to caller-supplied value
+            (or ``None`` to keep the preset default).
+        """
+        preset = self._preset
+        # command is special: copy the list to avoid mutating the preset.
+        cmd = overrides.get("command")
+        resolved: dict = {
+            "command": cmd if cmd is not None else list(preset.command),
+        }
+        for field in (
+            "prompt_via",
+            "message_format",
+            "output_format",
+            "json_path",
+            "strip_ansi",
+            "timeout_seconds",
+        ):
+            val = overrides.get(field)
+            resolved[field] = val if val is not None else getattr(preset, field)
+        return resolved
+
+    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments
+        self,
+        command: Optional[List[str]] = None,
+        prompt_via: Optional[str] = None,
+        message_format: Optional[str] = None,
+        output_format: Optional[str] = None,
+        json_path: Optional[str] = None,
+        strip_ansi: Optional[bool] = None,
+        timeout_seconds: Optional[float] = None,
+        **extra: Any,
+    ) -> CliLLM:
+        """Create a :class:`~bili.iris.providers.cli_provider.CliLLM` using
+        the bound preset's defaults, overridden by any supplied kwargs.
+
+        :param command: Override the preset's command list.
+        :param prompt_via: Override the preset's ``prompt_via``.
+        :param message_format: Override the preset's ``message_format``.
+        :param output_format: Override the preset's ``output_format``.
+        :param json_path: Override the preset's ``json_path``.
+        :param strip_ansi: Override the preset's ``strip_ansi``.
+        :param timeout_seconds: Override the preset's ``timeout_seconds``.
+        :returns: A configured :class:`~bili.iris.providers.cli_provider.CliLLM`.
+        :raises RuntimeError: If the provider was not created via
+            :meth:`for_preset` (i.e. ``_preset`` is ``None``).
+        """
+        if self._preset is None:
+            raise RuntimeError(
+                "CliPresetProvider must be created via CliPresetProvider.for_preset(). "
+                "Do not instantiate the base class directly."
+            )
+        kwargs = self._resolve_kwargs(
+            {
+                "command": command,
+                "prompt_via": prompt_via,
+                "message_format": message_format,
+                "output_format": output_format,
+                "json_path": json_path,
+                "strip_ansi": strip_ansi,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        LOGGER.info(
+            "CliPresetProvider: loading preset command=%s",
+            kwargs["command"][0] if kwargs["command"] else "<empty>",
+        )
+        return CliProvider().load(**kwargs, **extra)
+
+    @classmethod
+    def for_preset(cls, preset: Any) -> Type["CliPresetProvider"]:
+        """Return a new :class:`CliPresetProvider` subclass bound to *preset*.
+
+        Each call returns a **distinct class** so that the same preset class
+        can be registered under multiple provider-type strings in the
+        :class:`~bili.iris.providers.registry.ProviderRegistry` without
+        collision.
+
+        :param preset: A :class:`~bili.iris.providers.cli_presets.CliPreset`
+            instance.
+        :returns: A new :class:`CliPresetProvider` subclass.
+
+        Example::
+
+            preset = CliPreset(command=["my-llm"], prompt_via="arg")
+            MyPresetProvider = CliPresetProvider.for_preset(preset)
+            PROVIDER_REGISTRY.register("cli_my_llm", MyPresetProvider)
+        """
+        command_display = preset.command[0] if preset.command else "unknown"
+        # The class name is informational only; it appears in repr() and logs.
+        new_class = type(
+            f"CliPresetProvider[{command_display}]",
+            (cls,),
+            {"_preset": preset},
+        )
+        return new_class

--- a/bili/iris/providers/tests/test_cli_presets.py
+++ b/bili/iris/providers/tests/test_cli_presets.py
@@ -1,0 +1,495 @@
+"""Tests for CLI preset providers.
+
+Covers :mod:`bili.iris.providers.cli_presets`,
+:mod:`bili.iris.providers.preset_provider`, the three built-in preset
+entries in :data:`~bili.iris.config.llm_config.LLM_MODELS`, and the
+end-to-end ``load_model("<preset_type>")`` path via the provider registry.
+
+No real subprocess is spawned; :mod:`subprocess` is mocked so tests run
+in any environment without a CLI LLM tool installed.
+"""
+
+# pylint: disable=protected-access
+
+import subprocess
+from dataclasses import fields
+from typing import List
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+import bili.iris.providers.builtin  # noqa: F401  pylint: disable=unused-import
+from bili.iris.config.llm_config import LLM_MODELS
+from bili.iris.loaders.llm_loader import load_model
+from bili.iris.providers.base import KNOWN_PROVIDER_TYPES
+from bili.iris.providers.cli_presets import (
+    CLAUDE_CODE_PRESET,
+    CLI_PRESET_CATALOG,
+    CODEX_PRESET,
+    GEMINI_CLI_PRESET,
+    CliPreset,
+    register_cli_preset,
+)
+from bili.iris.providers.cli_provider import CliLLM, CliLLMError
+from bili.iris.providers.preset_provider import CliPresetProvider
+from bili.iris.providers.registry import PROVIDER_REGISTRY
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_completed_proc(stdout: str = "", returncode: int = 0, stderr: str = ""):
+    """Return a mock subprocess.CompletedProcess-like object."""
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.returncode = returncode
+    return proc
+
+
+def _run_preset_roundtrip(
+    provider_type: str,
+    prompt: str = "Hello",
+    response: str = "World",
+) -> str:
+    """Load a preset via load_model, invoke it, and return the response text."""
+    with patch(
+        "subprocess.run",
+        return_value=_make_completed_proc(stdout=response),
+    ):
+        llm = load_model(provider_type)
+        result = llm.invoke([HumanMessage(content=prompt)])
+    return result.content
+
+
+# ---------------------------------------------------------------------------
+# CliPreset dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestCliPreset:
+    """Unit tests for the CliPreset dataclass."""
+
+    def test_default_values(self):
+        """Default field values match the documented preset defaults."""
+        preset = CliPreset(command=["my-tool"])
+        assert preset.prompt_via == "arg"
+        assert preset.message_format == "last"
+        assert preset.output_format == "text"
+        assert preset.json_path == "content"
+        assert preset.strip_ansi is True
+        assert preset.timeout_seconds == 120.0
+
+    def test_custom_values_stored(self):
+        """Custom values supplied to the constructor are stored correctly."""
+        preset = CliPreset(
+            command=["llm", "--fast"],
+            prompt_via="stdin",
+            message_format="roles",
+            output_format="json",
+            json_path="result.text",
+            strip_ansi=False,
+            timeout_seconds=60.0,
+        )
+        assert preset.command == ["llm", "--fast"]
+        assert preset.prompt_via == "stdin"
+        assert preset.message_format == "roles"
+        assert preset.output_format == "json"
+        assert preset.json_path == "result.text"
+        assert preset.strip_ansi is False
+        assert preset.timeout_seconds == 60.0
+
+    def test_dataclass_has_expected_fields(self):
+        """CliPreset exposes exactly the fields that CliProvider.load accepts."""
+        field_names = {f.name for f in fields(CliPreset)}
+        expected = {
+            "command",
+            "prompt_via",
+            "message_format",
+            "output_format",
+            "json_path",
+            "strip_ansi",
+            "timeout_seconds",
+        }
+        assert expected == field_names
+
+
+# ---------------------------------------------------------------------------
+# Built-in preset definitions
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinPresets:
+    """Verify the three built-in preset definitions have correct defaults."""
+
+    def test_claude_code_preset_command(self):
+        """CLAUDE_CODE_PRESET uses 'claude -p' as the command."""
+        assert CLAUDE_CODE_PRESET.command == ["claude", "-p"]
+
+    def test_claude_code_preset_prompt_via(self):
+        """CLAUDE_CODE_PRESET delivers the prompt as a positional argument."""
+        assert CLAUDE_CODE_PRESET.prompt_via == "arg"
+
+    def test_claude_code_preset_output_format(self):
+        """CLAUDE_CODE_PRESET uses plain-text output."""
+        assert CLAUDE_CODE_PRESET.output_format == "text"
+
+    def test_claude_code_preset_strip_ansi(self):
+        """CLAUDE_CODE_PRESET strips ANSI codes by default."""
+        assert CLAUDE_CODE_PRESET.strip_ansi is True
+
+    def test_codex_preset_command(self):
+        """CODEX_PRESET uses 'codex exec' as the command."""
+        assert CODEX_PRESET.command == ["codex", "exec"]
+
+    def test_codex_preset_prompt_via(self):
+        """CODEX_PRESET delivers the prompt as a positional argument."""
+        assert CODEX_PRESET.prompt_via == "arg"
+
+    def test_codex_preset_output_format(self):
+        """CODEX_PRESET uses plain-text output."""
+        assert CODEX_PRESET.output_format == "text"
+
+    def test_codex_preset_timeout(self):
+        """CODEX_PRESET uses a longer default timeout than the base."""
+        assert CODEX_PRESET.timeout_seconds == 180.0
+
+    def test_gemini_cli_preset_command(self):
+        """GEMINI_CLI_PRESET uses 'gemini -p' as the command."""
+        assert GEMINI_CLI_PRESET.command == ["gemini", "-p"]
+
+    def test_gemini_cli_preset_prompt_via(self):
+        """GEMINI_CLI_PRESET delivers the prompt as a positional argument."""
+        assert GEMINI_CLI_PRESET.prompt_via == "arg"
+
+    def test_gemini_cli_preset_output_format(self):
+        """GEMINI_CLI_PRESET uses plain-text output."""
+        assert GEMINI_CLI_PRESET.output_format == "text"
+
+
+# ---------------------------------------------------------------------------
+# CLI_PRESET_CATALOG
+# ---------------------------------------------------------------------------
+
+
+class TestCliPresetCatalog:
+    """Verify the catalog contains exactly the expected preset keys."""
+
+    def test_catalog_contains_all_presets(self):
+        """All three built-in presets are present in CLI_PRESET_CATALOG."""
+        assert "cli_claude_code" in CLI_PRESET_CATALOG
+        assert "cli_codex" in CLI_PRESET_CATALOG
+        assert "cli_gemini_cli" in CLI_PRESET_CATALOG
+
+    def test_catalog_values_are_cli_preset_instances(self):
+        """Every catalog entry is a CliPreset instance."""
+        for key, value in CLI_PRESET_CATALOG.items():
+            assert isinstance(
+                value, CliPreset
+            ), f"CLI_PRESET_CATALOG[{key!r}] is {type(value)}, expected CliPreset"
+
+    def test_catalog_presets_match_module_constants(self):
+        """Catalog entries are the same objects as the module-level constants."""
+        assert CLI_PRESET_CATALOG["cli_claude_code"] is CLAUDE_CODE_PRESET
+        assert CLI_PRESET_CATALOG["cli_codex"] is CODEX_PRESET
+        assert CLI_PRESET_CATALOG["cli_gemini_cli"] is GEMINI_CLI_PRESET
+
+
+# ---------------------------------------------------------------------------
+# CliPresetProvider
+# ---------------------------------------------------------------------------
+
+
+class TestCliPresetProvider:
+    """Unit tests for CliPresetProvider."""
+
+    def test_for_preset_returns_subclass(self):
+        """for_preset() returns a class that is a subclass of CliPresetProvider."""
+        preset = CliPreset(command=["echo"])
+        klass = CliPresetProvider.for_preset(preset)
+        assert issubclass(klass, CliPresetProvider)
+
+    def test_for_preset_binds_preset(self):
+        """The returned subclass has _preset set to the supplied CliPreset."""
+        preset = CliPreset(command=["echo"])
+        klass = CliPresetProvider.for_preset(preset)
+        assert klass._preset is preset
+
+    def test_for_preset_creates_distinct_classes(self):
+        """Two calls to for_preset return distinct classes even for the same preset."""
+        preset = CliPreset(command=["echo"])
+        klass_a = CliPresetProvider.for_preset(preset)
+        klass_b = CliPresetProvider.for_preset(preset)
+        assert klass_a is not klass_b
+
+    def test_load_applies_preset_defaults(self):
+        """load() uses the preset's command and config when no overrides are given."""
+        preset = CliPreset(command=["myltool"], prompt_via="arg", output_format="text")
+        klass = CliPresetProvider.for_preset(preset)
+        with patch(
+            "subprocess.run",
+            return_value=_make_completed_proc(stdout="response"),
+        ) as mock_run:
+            llm = klass().load()
+            llm.invoke([HumanMessage(content="hi")])
+        cmd_used: List[str] = mock_run.call_args[0][0]
+        assert cmd_used[0] == "myltool"
+        assert cmd_used[-1] == "hi"  # prompt appended as arg
+
+    def test_load_overrides_command(self):
+        """load() accepts a caller-supplied command that overrides the preset."""
+        preset = CliPreset(command=["preset-tool"])
+        klass = CliPresetProvider.for_preset(preset)
+        with patch(
+            "subprocess.run",
+            return_value=_make_completed_proc(stdout="ok"),
+        ) as mock_run:
+            llm = klass().load(command=["override-tool"])
+            llm.invoke([HumanMessage(content="test")])
+        cmd_used: List[str] = mock_run.call_args[0][0]
+        assert cmd_used[0] == "override-tool"
+
+    def test_load_overrides_timeout(self):
+        """load() accepts a caller-supplied timeout_seconds override."""
+        preset = CliPreset(command=["tool"], timeout_seconds=60.0)
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load(timeout_seconds=300.0)
+        assert llm.timeout_seconds == 300.0
+
+    def test_load_without_preset_raises(self):
+        """load() raises RuntimeError if _preset is None (base class used directly)."""
+        provider = CliPresetProvider()
+        with pytest.raises(RuntimeError, match="for_preset"):
+            provider.load(command=["echo"])
+
+    def test_load_returns_cli_llm(self):
+        """load() returns a CliLLM instance."""
+        preset = CliPreset(command=["echo"])
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load()
+        assert isinstance(llm, CliLLM)
+
+
+# ---------------------------------------------------------------------------
+# Provider registry integration
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinPresetsRegistered:
+    """Verify that importing builtin.py registers all three preset types."""
+
+    def test_cli_claude_code_in_registry(self):
+        """cli_claude_code is registered in the global provider registry."""
+        assert "cli_claude_code" in PROVIDER_REGISTRY
+
+    def test_cli_codex_in_registry(self):
+        """cli_codex is registered in the global provider registry."""
+        assert "cli_codex" in PROVIDER_REGISTRY
+
+    def test_cli_gemini_cli_in_registry(self):
+        """cli_gemini_cli is registered in the global provider registry."""
+        assert "cli_gemini_cli" in PROVIDER_REGISTRY
+
+    def test_preset_providers_are_preset_subclasses(self):
+        """Each registered preset provider is a CliPresetProvider subclass."""
+        for key in ("cli_claude_code", "cli_codex", "cli_gemini_cli"):
+            klass = PROVIDER_REGISTRY.get(key)
+            assert klass is not None, f"{key!r} not in registry"
+            assert issubclass(
+                klass, CliPresetProvider
+            ), f"{key!r} maps to {klass}, not a CliPresetProvider subclass"
+
+    def test_preset_types_in_known_provider_types(self):
+        """All three preset type strings appear in KNOWN_PROVIDER_TYPES."""
+        for key in ("cli_claude_code", "cli_codex", "cli_gemini_cli"):
+            assert (
+                key in KNOWN_PROVIDER_TYPES
+            ), f"{key!r} missing from KNOWN_PROVIDER_TYPES"
+
+
+# ---------------------------------------------------------------------------
+# LLM_MODELS catalog entries
+# ---------------------------------------------------------------------------
+
+
+class TestLlmModelsCatalog:
+    """Verify that LLM_MODELS contains accurate entries for each preset."""
+
+    def test_cli_claude_code_entry_present(self):
+        """LLM_MODELS contains a 'cli_claude_code' entry."""
+        assert "cli_claude_code" in LLM_MODELS
+
+    def test_cli_codex_entry_present(self):
+        """LLM_MODELS contains a 'cli_codex' entry."""
+        assert "cli_codex" in LLM_MODELS
+
+    def test_cli_gemini_cli_entry_present(self):
+        """LLM_MODELS contains a 'cli_gemini_cli' entry."""
+        assert "cli_gemini_cli" in LLM_MODELS
+
+    def test_preset_entries_have_required_catalog_fields(self):
+        """Each preset entry has name, description, model_help, and models keys."""
+        for key in ("cli_claude_code", "cli_codex", "cli_gemini_cli"):
+            entry = LLM_MODELS[key]
+            assert "name" in entry, f"{key} missing 'name'"
+            assert "description" in entry, f"{key} missing 'description'"
+            assert "model_help" in entry, f"{key} missing 'model_help'"
+            assert "models" in entry, f"{key} missing 'models'"
+            assert len(entry["models"]) >= 1, f"{key} has empty models list"
+
+    def test_preset_entries_disable_unsupported_features(self):
+        """CLI preset model entries mark temperature, seed, tools etc. as unsupported."""
+        for key in ("cli_claude_code", "cli_codex", "cli_gemini_cli"):
+            model = LLM_MODELS[key]["models"][0]
+            assert (
+                model.get("supports_temperature") is False
+            ), f"{key} should have supports_temperature=False"
+            assert (
+                model.get("supports_tools") is False
+            ), f"{key} should have supports_tools=False"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end load_model round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestLoadModelRoundtrip:
+    """End-to-end tests: load_model(preset_type) returns a working CliLLM."""
+
+    def test_claude_code_roundtrip(self):
+        """load_model('cli_claude_code') returns a CliLLM that produces a response."""
+        response = _run_preset_roundtrip("cli_claude_code", response="Claude response")
+        assert response == "Claude response"
+
+    def test_codex_roundtrip(self):
+        """load_model('cli_codex') returns a CliLLM that produces a response."""
+        response = _run_preset_roundtrip("cli_codex", response="Codex response")
+        assert response == "Codex response"
+
+    def test_gemini_cli_roundtrip(self):
+        """load_model('cli_gemini_cli') returns a CliLLM that produces a response."""
+        response = _run_preset_roundtrip("cli_gemini_cli", response="Gemini response")
+        assert response == "Gemini response"
+
+    def test_claude_code_command_is_claude(self):
+        """The subprocess command for cli_claude_code starts with 'claude'."""
+        with patch(
+            "subprocess.run",
+            return_value=_make_completed_proc(stdout="ok"),
+        ) as mock_run:
+            llm = load_model("cli_claude_code")
+            llm.invoke([HumanMessage(content="test")])
+        cmd: List[str] = mock_run.call_args[0][0]
+        assert cmd[0] == "claude"
+
+    def test_codex_command_is_codex_exec(self):
+        """The subprocess command for cli_codex starts with 'codex exec'."""
+        with patch(
+            "subprocess.run",
+            return_value=_make_completed_proc(stdout="ok"),
+        ) as mock_run:
+            llm = load_model("cli_codex")
+            llm.invoke([HumanMessage(content="test")])
+        cmd: List[str] = mock_run.call_args[0][0]
+        assert cmd[0] == "codex"
+        assert cmd[1] == "exec"
+
+    def test_gemini_cli_command_is_gemini(self):
+        """The subprocess command for cli_gemini_cli starts with 'gemini'."""
+        with patch(
+            "subprocess.run",
+            return_value=_make_completed_proc(stdout="ok"),
+        ) as mock_run:
+            llm = load_model("cli_gemini_cli")
+            llm.invoke([HumanMessage(content="test")])
+        cmd: List[str] = mock_run.call_args[0][0]
+        assert cmd[0] == "gemini"
+
+    def test_prompt_appended_as_arg_for_all_presets(self):
+        """Each preset appends the prompt as the final positional argument."""
+        for preset_type in ("cli_claude_code", "cli_codex", "cli_gemini_cli"):
+            with patch(
+                "subprocess.run",
+                return_value=_make_completed_proc(stdout="ok"),
+            ) as mock_run:
+                llm = load_model(preset_type)
+                llm.invoke([HumanMessage(content="my-prompt")])
+            cmd: List[str] = mock_run.call_args[0][0]
+            assert (
+                cmd[-1] == "my-prompt"
+            ), f"{preset_type}: expected prompt as last arg, got cmd={cmd}"
+
+    def test_timeout_override_respected(self):
+        """A timeout_seconds override passed to load_model is applied to CliLLM."""
+        llm = load_model("cli_claude_code", timeout_seconds=300.0)
+        assert llm.timeout_seconds == 300.0
+
+    def test_subprocess_error_raises_cli_llm_error(self):
+        """A non-zero subprocess exit for a preset raises CliLLMError."""
+        with patch(
+            "subprocess.run",
+            return_value=_make_completed_proc(returncode=1, stderr="fail"),
+        ):
+            llm = load_model("cli_claude_code")
+            with pytest.raises(CliLLMError, match="exited with code 1"):
+                llm.invoke([HumanMessage(content="hello")])
+
+    def test_subprocess_timeout_raises_cli_llm_error(self):
+        """A subprocess timeout for a preset raises CliLLMError."""
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["claude", "-p"], timeout=120),
+        ):
+            llm = load_model("cli_claude_code")
+            with pytest.raises(CliLLMError, match="timed out"):
+                llm.invoke([HumanMessage(content="hello")])
+
+
+# ---------------------------------------------------------------------------
+# register_cli_preset
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterCliPreset:
+    """Tests for the register_cli_preset() helper."""
+
+    def test_register_and_invoke(self):
+        """A custom preset registered via register_cli_preset is callable via load_model."""
+        # Use a unique type string for this test to avoid registry collisions.
+        provider_type = "cli_test_custom_preset_xyz"
+        if provider_type in PROVIDER_REGISTRY:
+            PROVIDER_REGISTRY.unregister(provider_type)
+
+        preset = CliPreset(command=["custom-cli"], prompt_via="arg")
+        register_cli_preset(provider_type, preset)
+
+        with patch(
+            "subprocess.run",
+            return_value=_make_completed_proc(stdout="custom response"),
+        ) as mock_run:
+            llm = load_model(provider_type)
+            result = llm.invoke([HumanMessage(content="hi")])
+
+        assert result.content == "custom response"
+        cmd: List[str] = mock_run.call_args[0][0]
+        assert cmd[0] == "custom-cli"
+        # Cleanup so other tests are not affected.
+        PROVIDER_REGISTRY.unregister(provider_type)
+
+    def test_register_duplicate_raises(self):
+        """Registering the same type twice raises ValueError."""
+        provider_type = "cli_test_dup_preset_xyz"
+        if provider_type in PROVIDER_REGISTRY:
+            PROVIDER_REGISTRY.unregister(provider_type)
+
+        preset = CliPreset(command=["dup-cli"])
+        register_cli_preset(provider_type, preset)
+
+        with pytest.raises(ValueError, match="already registered"):
+            register_cli_preset(provider_type, preset)
+
+        # Cleanup.
+        PROVIDER_REGISTRY.unregister(provider_type)


### PR DESCRIPTION
## Summary

- Adds `CliPreset` dataclass: a named configuration bundle for a specific CLI LLM tool (command, prompt_via, output_format, timeout, etc.)
- Adds `CliPresetProvider`: a thin `LLMProvider` wrapper that applies a preset's defaults and delegates to `CliProvider`. Uses `for_preset()` to generate a distinct subclass per preset, which satisfies the registry's one-class-per-type requirement.
- Ships three built-in presets registered in `PROVIDER_REGISTRY` at import time:
  - `cli_claude_code` — `claude -p <prompt>` (Anthropic Claude Code CLI, one-shot print mode)
  - `cli_codex` — `codex exec <prompt>` (OpenAI Codex CLI, non-interactive mode)
  - `cli_gemini_cli` — `gemini -p <prompt>` (Google Gemini CLI, headless mode)
- `LLM_MODELS` catalog entries for all three, with accurate capability flags
- `KNOWN_PROVIDER_TYPES` updated to include all three preset type strings
- `register_cli_preset()` public helper so application code can register additional presets without subclassing

Users load a CLI-backed LLM by name, with no per-tool flag knowledge required:

```python
import bili.iris.providers.builtin  # noqa — registers built-ins
from bili.iris.loaders.llm_loader import load_model

llm = load_model("cli_claude_code")
llm = load_model("cli_codex", timeout_seconds=300.0)
llm = load_model("cli_gemini_cli")
```

The base `CliLLM` and `CliProvider` are unchanged. The presets are purely additive configuration bundles; there is no branching in the base on tool name.

## Test plan

- [ ] 47 new tests in `bili/iris/providers/tests/test_cli_presets.py` cover: `CliPreset` field defaults and storage, each built-in preset's command and config, `CLI_PRESET_CATALOG`, `CliPresetProvider.for_preset()`, load/override behavior, registry integration, `LLM_MODELS` catalog entries, end-to-end `load_model()` round-trips for all three presets, error propagation (non-zero exit, timeout), and `register_cli_preset()`
- [ ] Full suite: 3722 passed, 1 skipped
- [ ] Per-file coverage gate: all 214 runtime files >= 90% (overall 98.5%)
- [ ] pylint: 9.63/10 (repo-wide); 10.00/10 on new files
- [ ] Pre-commit hooks: black, autoflake, isort, pylint all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpXRrbE4UhL22Usj6UdEVQ