### PR TITLE
feat(iris): add prompted tool-calling path to react_agent_node (#304)

### DIFF
--- a/bili/iris/nodes/react_agent_node.py
+++ b/bili/iris/nodes/react_agent_node.py
@@ -2,48 +2,103 @@
 react_agent_node.py
 -------------------
 
-This module provides a utility for constructing a REACT agent node for conversational workflows.
-It supports both tool-enabled and tool-less operation, adapting to the capabilities of the
-provided language model (LLM).
+This module provides a utility for constructing a REACT agent node for conversational
+workflows.  It supports three operating modes, selected automatically based on the tools
+provided and the ``supports_tools`` flag:
 
-Functions:
-----------
-- build_react_agent_node(tools: list[Tool] = None, state: StateSchema = State, llm_model=None,
-                        middleware: list = None, **kwargs):
-    Constructs a REACT agent node using the specified tools and state schema. If tools are provided,
-    a REACT agent is created with tool integration. Middleware can be provided to intercept and
-    modify agent execution. If tools are not supported, a fallback node is created that directly
-    invokes the LLM, filtering and repackaging messages for compatibility.
+1. **Native tool-calling** (default when ``tools`` is provided and the model supports
+   ``bind_tools``): builds a compiled LangGraph sub-graph via ``create_agent``.  The
+   model must implement ``BaseChatModel.bind_tools``; all major API providers do.
 
-Dependencies:
--------------
-- langchain_core.messages: Provides `AIMessage`, `HumanMessage`, and `SystemMessage`
-classes for chat history.
-- langchain_core.tools: Provides the `Tool` class for agent tool integration.
-- langchain.agents: Provides `create_agent` for agent construction with middleware support,
-  and `AgentState` base class for state schema.
-- bili.utils.langgraph_utils.State: Defines the state schema for conversation data.
-- bili.utils.logging_utils.get_logger: Initializes a logger for tracing and debugging.
+2. **Prompted tool-calling** (when ``tools`` is provided but ``supports_tools=False``
+   is passed via ``node_kwargs``): runs a hand-rolled ReAct loop entirely within the
+   node.  Tools are injected into a system-message preamble, the model's text responses
+   are parsed for ``Action:`` / ``Final Answer:`` markers, matched tools are executed,
+   and observations are fed back as ``HumanMessage`` turns.  This path works with any
+   model that can follow text instructions -- including CLI-backed models
+   (e.g. ``CliLLM``) that do not implement ``bind_tools``.
 
-Usage:
-------
-Import and use `build_react_agent_node` to create a REACT agent node for
+3. **Tool-less fallback** (when ``tools`` is ``None``): calls the model directly,
+   filtering ToolMessages from history for compatibility.
+
+Capability detection
+--------------------
+Pass ``supports_tools=False`` in ``node_kwargs`` alongside a non-``None`` ``tools``
+list to engage the prompted path.  The flag defaults to ``True`` so existing callers
+that pass tools without the flag continue to use the native path unchanged.
+
+``hasattr`` / ``try-bind_tools`` probing is intentionally avoided: LangChain's
+``BaseChatModel.bind_tools`` is always present (it raises ``NotImplementedError`` for
+models that do not override it), so attribute presence is not a reliable signal.
+
+Prompted ReAct protocol
+-----------------------
+The system preamble instructs the model to respond using one of two formats::
+
+    Thought: <reasoning>
+    Action: <tool_name>
+    Action Input: {"arg": value}
+
+or::
+
+    Thought: <reasoning>
+    Final Answer: <response>
+
+The parser scans the full response text with a regex, tolerating preamble, varying
+capitalisation, and markdown code fences.  Parse failures and tool errors are fed back
+as ``Observation: Error - <reason>`` turns so the model can self-correct.  Three
+consecutive unparseable responses terminate the loop early.  A configurable
+``max_react_iterations`` cap (default 10) prevents runaway loops.
+
+Observations are returned as ``HumanMessage`` objects to satisfy strict-alternating-turn
+constraints (Bedrock Converse API, some Mistral deployments).
+
+Functions
+---------
+- ``build_react_agent_node(tools, state, llm_model, middleware, **kwargs)``:
+  Entry point; selects the operating mode and returns the appropriate callable or
+  compiled graph.
+
+- ``_build_prompted_react_loop(llm_model, tools, max_react_iterations)``:
+  Internal factory; returns the ``prompted_react_loop(state) -> dict`` callable that
+  runs the ReAct loop for a single node invocation.
+
+- ``_build_tool_preamble(tools)``:
+  Internal helper; renders the tool-description block injected into the system message.
+
+Dependencies
+------------
+- ``langchain_core.messages``: ``AIMessage``, ``HumanMessage``, ``SystemMessage``
+- ``langchain_core.tools``: ``Tool`` (type hint)
+- ``langchain.agents``: ``AgentState``, ``create_agent``
+- ``bili.utils.langgraph_utils.State``: conversation state schema
+- ``bili.utils.logging_utils.get_logger``: structured logger
+
+Usage
+-----
+Import and use ``build_react_agent_node`` to create a REACT agent node for
 conversational agent workflows.
 
-Example:
---------
-from bili.iris.nodes.react_agent_node import build_react_agent_node
-from langchain.agents.middleware import SummarizationMiddleware
+Example (native path -- model supports bind_tools)::
 
-agent_node = build_react_agent_node(
-    tools=my_tools,
-    state=MyStateSchema,
-    llm_model=my_llm,
-    middleware=[SummarizationMiddleware()]
-)
-result = agent_node(state)
+    agent_node = build_react_agent_node(
+        tools=my_tools,
+        state=MyStateSchema,
+        llm_model=my_llm,
+    )
+
+Example (prompted path -- CLI or other text-only model)::
+
+    agent_node = build_react_agent_node(
+        tools=my_tools,
+        llm_model=cli_llm,
+        supports_tools=False,      # passed through **kwargs
+        max_react_iterations=8,    # optional; default 10
+    )
 """
 
+import json
+import re
 from functools import partial
 from typing import Type
 
@@ -58,75 +113,399 @@ from bili.utils.logging_utils import get_logger
 # Initialize logger for this module
 LOGGER = get_logger(__name__)
 
+# ──────────────────────────────────────────────────────────────────────────────
+# Default guard values for the prompted ReAct loop
+# ──────────────────────────────────────────────────────────────────────────────
+
+#: Maximum number of Thought/Action/Observation iterations before the loop
+#: gives up and returns whatever the model last said.
+_DEFAULT_MAX_REACT_ITERATIONS = 10
+
+#: Number of consecutive responses that cannot be parsed as either an Action
+#: or a Final Answer before the loop exits with the last response as-is.
+_MAX_CONSECUTIVE_PARSE_FAILURES = 3
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Prompted ReAct helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _build_tool_preamble(tools: list) -> str:
+    """Render the tool-description block for the system-message preamble.
+
+    Produces a plain-text listing of each tool's name, argument schema, and
+    description, followed by the Action/Observation protocol the model must
+    follow to invoke a tool or signal a final answer.
+
+    :param tools: List of LangChain ``BaseTool`` instances to describe.
+    :type tools: list
+    :return: Multi-line string to prepend to (or substitute for) the system message.
+    :rtype: str
+    """
+    lines = [
+        "You have access to the following tools.  Use them whenever they help you",
+        "answer the question accurately.\n",
+        "TOOLS:",
+    ]
+    for tool in tools:
+        # Extract argument names from the tool's args_schema when available
+        try:
+            schema = tool.args_schema.schema() if tool.args_schema else {}
+            props = schema.get("properties", {})
+            arg_parts = []
+            for arg_name, arg_info in props.items():
+                arg_type = arg_info.get("type", "any")
+                arg_parts.append(f"{arg_name}: {arg_type}")
+            sig = f"({', '.join(arg_parts)})" if arg_parts else "()"
+        except Exception:  # pylint: disable=broad-except
+            sig = "(...)"
+        description = getattr(tool, "description", "") or ""
+        lines.append(f"  - {tool.name}{sig}: {description}")
+
+    lines += [
+        "",
+        "RESPONSE FORMAT",
+        "To call a tool, your response must contain EXACTLY:",
+        "  Thought: <your reasoning>",
+        "  Action: <tool_name>",
+        "  Action Input: <JSON object of arguments>",
+        "",
+        "When you have the final answer (no more tools needed):",
+        "  Thought: <your reasoning>",
+        "  Final Answer: <your complete response to the user>",
+        "",
+        "Do not include any text after 'Final Answer:' on the same or later lines.",
+        "Do not mix Action and Final Answer in the same response.",
+    ]
+    return "\n".join(lines)
+
+
+# Regex patterns used by the response parser.  Compiled once at module load.
+_ACTION_RE = re.compile(r"Action\s*:\s*(.+?)(?:\n|$)", re.IGNORECASE)
+_ACTION_INPUT_RE = re.compile(
+    r"Action\s+Input\s*:\s*(\{.*?\}|\[.*?\]|\".*?\"|'.*?'|\S+)",
+    re.IGNORECASE | re.DOTALL,
+)
+_FINAL_ANSWER_RE = re.compile(r"Final\s+Answer\s*:\s*(.*)", re.IGNORECASE | re.DOTALL)
+
+
+def _parse_react_response(text: str):
+    """Parse a model response for Action/Input or Final Answer markers.
+
+    Scans the full response text (not line by line) to tolerate preamble
+    and reasoning text that precedes the structured markers.  Returns a
+    3-tuple:
+
+    - ``("action", tool_name, args_dict)`` when an Action block is found and
+      the Action Input JSON parses cleanly.
+    - ``("final", answer_text, None)`` when a Final Answer marker is found.
+    - ``("unknown", None, None)`` when neither marker is detected.
+    - ``("parse_error", raw_action_input, error_message)`` when an Action block
+      is found but the Action Input cannot be decoded as JSON.
+
+    :param text: Raw text content from the model's response.
+    :type text: str
+    :return: A 3-tuple ``(kind, value, extra)`` as described above.
+    :rtype: tuple
+    """
+    # Strip markdown code fences that some models add around structured output
+    text = re.sub(r"```(?:\w+)?\n?(.*?)```", r"\1", text, flags=re.DOTALL)
+
+    # Check for Final Answer first -- if present, we're done regardless of Actions
+    final_match = _FINAL_ANSWER_RE.search(text)
+    if final_match:
+        return ("final", final_match.group(1).strip(), None)
+
+    # Check for Action block
+    action_match = _ACTION_RE.search(text)
+    if action_match:
+        tool_name = action_match.group(1).strip()
+        input_match = _ACTION_INPUT_RE.search(text)
+        if input_match:
+            raw = input_match.group(1).strip()
+            try:
+                args = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                return ("parse_error", raw, str(exc))
+            return ("action", tool_name, args)
+        # Action with no parseable Input -- treat the remainder after Action as input
+        return ("parse_error", "", "Action Input block not found or not valid JSON")
+
+    return ("unknown", None, None)
+
+
+def _build_prompted_react_loop(
+    llm_model,
+    tools: list,
+    max_react_iterations: int = _DEFAULT_MAX_REACT_ITERATIONS,
+):
+    """Factory that returns the prompted ReAct node callable.
+
+    The returned callable runs entirely within a single LangGraph node invocation:
+    it injects the tool descriptions into the system message, then iterates --
+    invoking the model, parsing the response, executing any requested tool, and
+    feeding back the observation -- until a Final Answer is found, the iteration
+    cap is reached, or too many consecutive parse failures occur.
+
+    The callable always returns ``{"messages": [AIMessage(content=...)]}`` with
+    only the final answer, matching the shape produced by the tool-less
+    ``call_model`` fallback and compatible with the ``wrap_node`` wrapper in
+    ``langchain_loader.py``.
+
+    :param llm_model: LangChain-compatible chat model; must implement ``.invoke()``.
+    :param tools: List of LangChain ``BaseTool`` instances available to the model.
+    :param max_react_iterations: Maximum Thought/Action/Observation iterations before
+        the loop terminates with the last model response.
+    :type max_react_iterations: int
+    :return: A ``(state: dict) -> dict`` callable suitable for LangGraph.
+    :rtype: Callable
+    """
+    # Build the tool lookup dict and preamble once (at node-construction time)
+    tool_map = {t.name: t for t in tools}
+    tool_preamble = _build_tool_preamble(tools)
+
+    def prompted_react_loop(state: State) -> dict:  # pylint: disable=too-many-branches
+        """Execute the prompted ReAct loop for one node invocation.
+
+        :param state: LangGraph state dict; must contain ``"messages"``.
+        :return: Dict with ``"messages"`` key holding a single ``AIMessage``
+            containing the final answer.
+        :rtype: dict
+        """
+        # ── Inject the tool preamble into the system message ──────────────────
+        messages = list(state["messages"])
+
+        # Find an existing SystemMessage and augment it, or prepend a new one
+        sys_idx = next(
+            (i for i, m in enumerate(messages) if isinstance(m, SystemMessage)), None
+        )
+        if sys_idx is not None:
+            existing = messages[sys_idx].content
+            messages[sys_idx] = SystemMessage(content=f"{existing}\n\n{tool_preamble}")
+        else:
+            messages.insert(0, SystemMessage(content=tool_preamble))
+
+        llm_config = state.get("llm_config", {})
+        consecutive_parse_failures = 0
+        last_response_text = ""
+
+        for iteration in range(max_react_iterations):
+            # ── Model call ────────────────────────────────────────────────────
+            response = llm_model.invoke(messages, config=llm_config)
+            response_text = str(response.content) if response.content else ""
+            last_response_text = response_text
+
+            LOGGER.debug(
+                "Prompted ReAct iteration %d/%d | response length=%d chars",
+                iteration + 1,
+                max_react_iterations,
+                len(response_text),
+            )
+
+            # ── Parse ─────────────────────────────────────────────────────────
+            kind, value, extra = _parse_react_response(response_text)
+
+            if kind == "final":
+                LOGGER.debug(
+                    "Prompted ReAct: Final Answer after %d iteration(s).", iteration + 1
+                )
+                return {"messages": [AIMessage(content=value)]}
+
+            if kind == "action":
+                consecutive_parse_failures = 0
+                tool_name = value
+                args = extra
+
+                # Append the model's action turn to the conversation
+                messages.append(AIMessage(content=response_text))
+
+                # ── Tool execution ────────────────────────────────────────────
+                if tool_name not in tool_map:
+                    available = ", ".join(sorted(tool_map.keys()))
+                    observation = (
+                        f"Error - unknown tool '{tool_name}'.  "
+                        f"Available tools: {available}"
+                    )
+                    LOGGER.warning(
+                        "Prompted ReAct: model requested unknown tool '%s'.", tool_name
+                    )
+                else:
+                    try:
+                        observation = str(tool_map[tool_name].invoke(args))
+                        LOGGER.debug(
+                            "Prompted ReAct: tool '%s' returned observation of %d chars.",
+                            tool_name,
+                            len(observation),
+                        )
+                    except Exception as exc:  # pylint: disable=broad-except
+                        observation = f"Error - tool '{tool_name}' raised: {exc}"
+                        LOGGER.warning(
+                            "Prompted ReAct: tool '%s' raised an exception: %s",
+                            tool_name,
+                            exc,
+                        )
+
+                # Feed the observation back as a HumanMessage so strict-alternating-turn
+                # models (e.g. Bedrock Converse) accept the message sequence.
+                messages.append(HumanMessage(content=f"Observation: {observation}"))
+                continue
+
+            # kind is "parse_error" or "unknown"
+            consecutive_parse_failures += 1
+            LOGGER.warning(
+                "Prompted ReAct parse failure (%d/%d): kind=%s value=%r extra=%r",
+                consecutive_parse_failures,
+                _MAX_CONSECUTIVE_PARSE_FAILURES,
+                kind,
+                value,
+                extra,
+            )
+
+            if consecutive_parse_failures >= _MAX_CONSECUTIVE_PARSE_FAILURES:
+                LOGGER.warning(
+                    "Prompted ReAct: %d consecutive parse failures; returning last response.",
+                    consecutive_parse_failures,
+                )
+                return {"messages": [AIMessage(content=last_response_text)]}
+
+            # Feed the error back so the model can self-correct
+            messages.append(AIMessage(content=response_text))
+            error_detail = (
+                extra or "response matched neither Action nor Final Answer format"
+            )
+            messages.append(
+                HumanMessage(
+                    content=(
+                        f"Observation: Error - could not parse your response. "
+                        f"{error_detail}.  "
+                        "Please respond using the exact Action/Final Answer format."
+                    )
+                )
+            )
+
+        # ── Max iterations reached ─────────────────────────────────────────────
+        LOGGER.warning(
+            "Prompted ReAct: reached max_react_iterations=%d without a Final Answer; "
+            "returning last model response.",
+            max_react_iterations,
+        )
+        return {"messages": [AIMessage(content=last_response_text)]}
+
+    return prompted_react_loop
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Public node builder
+# ──────────────────────────────────────────────────────────────────────────────
+
 
 def build_react_agent_node(
     tools: list[Tool] = None,
     state: Type[AgentState] = State,
     llm_model=None,
     middleware: list = None,
-    **kwargs
+    **kwargs,
 ):
-    """
-    Constructs a REACT agent node using the specified tools and state or a fallback
-    node for models that do not support tools. The REACT agent integrates tools
-    and language models to process the input state and perform tasks.
+    """Construct a REACT agent node, selecting the appropriate execution mode.
 
-    If tools are provided, creates a REACT agent using the specified tools
-    with the associated state schema. If tools are not supported, creates a
-    fallback node that directly interacts with the language model (LLM) while
-    adapting the state's message format to prevent compatibility issues.
+    Three modes are available, selected automatically:
 
-    :param tools: List of tools to be integrated with the REACT agent. If None,
-        a fallback mechanism is used. Tools enable additional functionality for
-        task handling.
-    :type tools: list[Tool]
+    **Native tool-calling** (``tools`` is not ``None`` and ``supports_tools`` is
+    ``True`` or omitted):
+        Builds a compiled LangGraph sub-graph via ``create_agent`` + ``bind_tools``.
+        Requires the model to implement ``BaseChatModel.bind_tools`` (all major API
+        providers do).
 
-    :param state: Represents the schema of the state that interacts with the
-        agent or LLM. This includes maintaining messages and other context
-        required for conversation and workflows. Must be a subclass of AgentState.
+    **Prompted tool-calling** (``tools`` is not ``None`` and ``supports_tools=False``
+    is passed via ``**kwargs``):
+        Runs a hand-rolled ReAct loop inside the node.  Tools are described in a
+        system-message preamble; the model's text output is parsed for
+        ``Action:`` / ``Final Answer:`` markers.  Compatible with any model that
+        can follow text instructions, including CLI-backed models that do not
+        implement ``bind_tools``.  Does not call ``create_agent`` and never invokes
+        ``bind_tools``.
+
+        Extra ``**kwargs`` for this mode:
+
+        - ``supports_tools`` (``bool``, default ``True``): set ``False`` to engage
+          the prompted path.
+        - ``max_react_iterations`` (``int``, default 10): cap on
+          Thought/Action/Observation iterations.
+
+    **Tool-less fallback** (``tools`` is ``None``):
+        Calls the model directly, filtering ToolMessages from history for
+        compatibility with models that reject them.
+
+    :param tools: List of tools for the agent.  ``None`` engages the tool-less
+        fallback regardless of ``supports_tools``.
+    :type tools: list[Tool] or None
+
+    :param state: State schema (must subclass ``AgentState``).  Used only by the
+        native path (``create_agent``).
     :type state: Type[AgentState]
 
-    :param llm_model: The language model to be used by the agent or fallback
-        node. This model processes the input messages and produces responses.
-        The exact behavior may vary depending on the model's capabilities.
+    :param llm_model: LangChain-compatible chat model.
 
-    :param middleware: List of middleware to be applied to the agent. Middleware
-        can intercept and modify agent execution at various points (before_agent,
-        before_model, after_model, etc.). If None, no middleware is applied.
-    :type middleware: list
+    :param middleware: Middleware list forwarded to ``create_agent`` on the native
+        path.  Ignored on the prompted and fallback paths.
+    :type middleware: list or None
 
-    :param kwargs: Additional arguments and settings for constructing the REACT
-        agent or fallback node. This may include configuration options that are
-        passed to internal functions.
+    :param kwargs: Additional node configuration.  Recognised keys:
 
-    :return: A REACT agent node if tools are provided, otherwise a fallback node
-        that directly interacts with the language model. Both options are
-        structured to handle the input state appropriately and return the
-        processed state.
-    :rtype: Callable or any
+        - ``supports_tools`` (``bool``): capability flag; see above.
+        - ``max_react_iterations`` (``int``): iteration cap for the prompted path.
+
+    :return: A compiled ``CompiledStateGraph`` (native path) or a plain callable
+        ``(state: dict) -> dict`` (prompted and fallback paths).
+    :rtype: CompiledStateGraph or Callable
     """
+    supports_tools = kwargs.get("supports_tools", True)
+    max_react_iterations = kwargs.get(
+        "max_react_iterations", _DEFAULT_MAX_REACT_ITERATIONS
+    )
+
     LOGGER.debug(
-        "Using model: %s | Tools enabled: %s | Middleware count: %s",
+        "Using model: %s | Tools provided: %s | supports_tools: %s | Middleware count: %s",
         getattr(llm_model, "__class__", None),
         tools is not None,
+        supports_tools,
         len(middleware) if middleware else 0,
     )
-    if tools is not None:
-        # If tools are supported, create a REACT agent with the provided tools
-        LOGGER.debug("Creating REACT agent with tools: %s", tools)
+
+    if tools is not None and supports_tools:
+        # Native path: the model implements bind_tools; delegate to create_agent.
+        LOGGER.debug(
+            "Native tool-calling path: creating REACT agent with tools: %s", tools
+        )
         agent = create_agent(
             model=llm_model,
             state_schema=state,
             tools=tools,
             middleware=middleware or (),
         )
-    else:
+
+    elif tools is not None and not supports_tools:
+        # Prompted path: the model cannot bind_tools; run the ReAct loop ourselves.
         LOGGER.debug(
-            "TOOLS not supported for this LLM. Creating a simple graph node to invoke the LLM"
-            "directly, and to convert the state to a format that the LLM can understand."
+            "Prompted tool-calling path: model does not support bind_tools; "
+            "using prompted ReAct loop with %d tool(s) and max_react_iterations=%d.",
+            len(tools),
+            max_react_iterations,
+        )
+        agent = _build_prompted_react_loop(
+            llm_model=llm_model,
+            tools=tools,
+            max_react_iterations=max_react_iterations,
         )
 
-        # If tools are not supported, create a simple graph node that calls the LLM directly
+    else:
+        # Tool-less fallback: no tools provided; call the model directly.
+        LOGGER.debug(
+            "Tool-less fallback path: no tools provided; invoking the LLM directly "
+            "and converting the state to a format the LLM can understand."
+        )
+
         def call_model(state: State):
             # Filter out any tool messages to prevent errors in the LLM during the call
             # This is to allow for the scenario where the state was established with a model
@@ -153,6 +532,7 @@ def build_react_agent_node(
             return {"messages": [response]}
 
         agent = call_model
+
     return agent
 
 

--- a/bili/iris/nodes/tests/test_react_agent_node.py
+++ b/bili/iris/nodes/tests/test_react_agent_node.py
@@ -7,13 +7,22 @@ Tests the ReAct agent node builder:
 - Fallback node filters non-text messages and invokes the LLM
 - Fallback node forwards llm_config from state
 - Middleware is forwarded to create_agent
+- Prompted tool-calling path (supports_tools=False) exercises the hand-rolled
+  ReAct loop: tool injection, Action/Final Answer parsing, tool execution,
+  error handling, iteration cap, and consecutive-parse-failure escape hatch.
+- Auto-selection between native, prompted, and fallback paths.
 """
 
 from unittest.mock import MagicMock, patch
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
-from bili.iris.nodes.react_agent_node import build_react_agent_node, react_agent_node
+from bili.iris.nodes.react_agent_node import (
+    _build_prompted_react_loop,
+    _parse_react_response,
+    build_react_agent_node,
+    react_agent_node,
+)
 
 
 class TestBuildReactAgentNode:
@@ -210,3 +219,437 @@ class TestReactAgentNodePartial:
         mock_llm = MagicMock()
         result = node(tools=None, llm_model=mock_llm)
         assert callable(result)
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal mock tool
+# ---------------------------------------------------------------------------
+
+
+def _make_tool(name: str, description: str = "", return_value: str = "42"):
+    """Return a MagicMock that quacks like a LangChain BaseTool."""
+    tool = MagicMock()
+    tool.name = name
+    tool.description = description
+    tool.args_schema = None  # triggers the sig=(...)  fallback
+    tool.invoke.return_value = return_value
+    return tool
+
+
+# ---------------------------------------------------------------------------
+# _parse_react_response unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseReactResponse:
+    """Unit tests for the response-parser helper."""
+
+    def test_final_answer(self):
+        """'Final Answer:' in response returns ('final', answer_text, None)."""
+        text = "Thought: I know the answer.\nFinal Answer: 42"
+        kind, value, extra = _parse_react_response(text)
+        assert kind == "final"
+        assert value == "42"
+        assert extra is None
+
+    def test_action_with_valid_json(self):
+        """Action + valid JSON Input returns ('action', tool_name, args_dict)."""
+        text = 'Thought: I need to add.\nAction: add\nAction Input: {"a": 1, "b": 2}'
+        kind, value, extra = _parse_react_response(text)
+        assert kind == "action"
+        assert value == "add"
+        assert extra == {"a": 1, "b": 2}
+
+    def test_action_with_malformed_json(self):
+        """Action with invalid JSON returns ('parse_error', raw_input, error_msg)."""
+        text = "Action: add\nAction Input: {not valid json}"
+        kind, value, extra = _parse_react_response(text)
+        assert kind == "parse_error"
+        assert value == "{not valid json}"
+        assert extra  # error message string
+
+    def test_unknown_response(self):
+        """Response with neither marker returns ('unknown', None, None)."""
+        kind, value, extra = _parse_react_response("I don't know what to do.")
+        assert kind == "unknown"
+        assert value is None
+        assert extra is None
+
+    def test_final_answer_wins_over_action(self):
+        """When both markers appear, Final Answer takes precedence."""
+        text = "Action: foo\nAction Input: {}\nFinal Answer: done"
+        kind, value, _ = _parse_react_response(text)
+        assert kind == "final"
+        assert value == "done"
+
+    def test_strips_markdown_code_fences(self):
+        """Markdown code fences around JSON are stripped before parsing."""
+        text = 'Action: add\nAction Input: ```json\n{"a": 1}\n```'
+        kind, value, extra = _parse_react_response(text)
+        assert kind == "action"
+        assert value == "add"
+        assert extra == {"a": 1}
+
+    def test_case_insensitive_final_answer(self):
+        """'final answer:' (lowercase) is accepted."""
+        text = "final answer: result text"
+        kind, value, _ = _parse_react_response(text)
+        assert kind == "final"
+        assert value == "result text"
+
+
+# ---------------------------------------------------------------------------
+# _build_prompted_react_loop integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestPromptedReactLoop:
+    """Tests for the prompted ReAct loop path."""
+
+    # -- 1. Happy path: one tool call then final answer -----------------------
+
+    def test_happy_path_one_tool_call(self):
+        """Loop calls the tool once then returns the Final Answer."""
+        add_tool = _make_tool("add", return_value="3")
+
+        mock_llm = MagicMock()
+        mock_llm.invoke.side_effect = [
+            AIMessage(
+                content='Thought: I need to add.\nAction: add\nAction Input: {"a": 1, "b": 2}'
+            ),
+            AIMessage(content="Thought: I have the result.\nFinal Answer: 3"),
+        ]
+
+        loop = _build_prompted_react_loop(mock_llm, [add_tool])
+        state = {"messages": [HumanMessage(content="What is 1 + 2?")]}
+        result = loop(state)
+
+        assert result["messages"] == [AIMessage(content="3")]
+        add_tool.invoke.assert_called_once_with({"a": 1, "b": 2})
+        assert mock_llm.invoke.call_count == 2
+
+    # -- 2. Multi-step tool calls ---------------------------------------------
+
+    def test_multi_step_tool_calls(self):
+        """Loop handles two sequential tool calls before the final answer."""
+        search_tool = _make_tool("search", return_value="Paris")
+        pop_tool = _make_tool("population", return_value="2 million")
+
+        mock_llm = MagicMock()
+        mock_llm.invoke.side_effect = [
+            AIMessage(
+                content='Action: search\nAction Input: {"q": "capital of France"}'
+            ),
+            AIMessage(content='Action: population\nAction Input: {"city": "Paris"}'),
+            AIMessage(content="Final Answer: Paris has about 2 million people."),
+        ]
+
+        loop = _build_prompted_react_loop(mock_llm, [search_tool, pop_tool])
+        state = {
+            "messages": [
+                HumanMessage(content="What is the population of the French capital?")
+            ]
+        }
+        result = loop(state)
+
+        assert "Paris" in result["messages"][0].content
+        assert search_tool.invoke.call_count == 1
+        assert pop_tool.invoke.call_count == 1
+        assert mock_llm.invoke.call_count == 3
+
+    # -- 3. Final answer on first response (no tools needed) ------------------
+
+    def test_final_answer_first_response(self):
+        """When the model answers immediately no tool should be called."""
+        tool = _make_tool("unused")
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = AIMessage(content="Final Answer: Paris")
+
+        loop = _build_prompted_react_loop(mock_llm, [tool])
+        result = loop({"messages": [HumanMessage(content="Capital of France?")]})
+
+        assert result["messages"] == [AIMessage(content="Paris")]
+        tool.invoke.assert_not_called()
+        assert mock_llm.invoke.call_count == 1
+
+    # -- 4. Unknown tool name -------------------------------------------------
+
+    def test_unknown_tool_name_feeds_error_observation(self):
+        """An unknown tool name produces an error observation and the loop continues."""
+        real_tool = _make_tool("real_tool", return_value="ok")
+        mock_llm = MagicMock()
+        mock_llm.invoke.side_effect = [
+            AIMessage(content="Action: ghost_tool\nAction Input: {}"),
+            AIMessage(content="Final Answer: recovered"),
+        ]
+
+        loop = _build_prompted_react_loop(mock_llm, [real_tool])
+        result = loop({"messages": [HumanMessage(content="test")]})
+
+        # The error observation should have been fed back
+        second_call_messages = mock_llm.invoke.call_args_list[1][0][0]
+        obs_texts = [
+            m.content for m in second_call_messages if isinstance(m, HumanMessage)
+        ]
+        assert any("unknown tool" in t for t in obs_texts)
+        assert result["messages"][0].content == "recovered"
+
+    # -- 5. Malformed JSON in Action Input ------------------------------------
+
+    def test_malformed_json_action_input(self):
+        """Malformed JSON in Action Input feeds a parse-error observation."""
+        tool = _make_tool("add")
+        mock_llm = MagicMock()
+        mock_llm.invoke.side_effect = [
+            AIMessage(content="Action: add\nAction Input: not json at all"),
+            AIMessage(content="Final Answer: sorry, fixed"),
+        ]
+
+        loop = _build_prompted_react_loop(mock_llm, [tool])
+        result = loop({"messages": [HumanMessage(content="test")]})
+
+        tool.invoke.assert_not_called()
+        # Error observation should have been injected
+        second_call_messages = mock_llm.invoke.call_args_list[1][0][0]
+        obs_texts = [
+            m.content for m in second_call_messages if isinstance(m, HumanMessage)
+        ]
+        assert any("Error" in t for t in obs_texts)
+        assert result["messages"][0].content == "sorry, fixed"
+
+    # -- 6. Tool execution raises an exception --------------------------------
+
+    def test_tool_execution_error(self):
+        """A tool that raises feeds an error observation and the loop continues."""
+        bad_tool = _make_tool("bad_tool")
+        bad_tool.invoke.side_effect = RuntimeError("db timeout")
+
+        mock_llm = MagicMock()
+        mock_llm.invoke.side_effect = [
+            AIMessage(content="Action: bad_tool\nAction Input: {}"),
+            AIMessage(content="Final Answer: could not retrieve data"),
+        ]
+
+        loop = _build_prompted_react_loop(mock_llm, [bad_tool])
+        result = loop({"messages": [HumanMessage(content="test")]})
+
+        second_call_messages = mock_llm.invoke.call_args_list[1][0][0]
+        obs_texts = [
+            m.content for m in second_call_messages if isinstance(m, HumanMessage)
+        ]
+        assert any("db timeout" in t for t in obs_texts)
+        assert result["messages"][0].content == "could not retrieve data"
+
+    # -- 7. Max iterations guard ----------------------------------------------
+
+    def test_max_iterations_guard(self):
+        """Loop terminates at max_react_iterations and returns last response."""
+        tool = _make_tool("loop_tool", return_value="still looping")
+        mock_llm = MagicMock()
+        # Model always asks to call the tool; never produces Final Answer
+        mock_llm.invoke.return_value = AIMessage(
+            content="Action: loop_tool\nAction Input: {}"
+        )
+
+        loop = _build_prompted_react_loop(mock_llm, [tool], max_react_iterations=3)
+        result = loop({"messages": [HumanMessage(content="go")]})
+
+        # Should have stopped after 3 iterations
+        assert mock_llm.invoke.call_count == 3
+        assert "loop_tool" in result["messages"][0].content
+
+    # -- 8. Consecutive parse failure escape hatch ----------------------------
+
+    def test_consecutive_parse_failures_exit_loop(self):
+        """Three consecutive unparseable responses exit the loop gracefully."""
+        tool = _make_tool("some_tool")
+        mock_llm = MagicMock()
+        # Always returns garbage that can't be parsed
+        mock_llm.invoke.return_value = AIMessage(
+            content="I have no idea what to say here."
+        )
+
+        loop = _build_prompted_react_loop(mock_llm, [tool], max_react_iterations=10)
+        result = loop({"messages": [HumanMessage(content="test")]})
+
+        # Should have stopped after 3 consecutive failures (not all 10 iterations)
+        assert mock_llm.invoke.call_count == 3
+        assert result["messages"][0].content == "I have no idea what to say here."
+
+    # -- 9. llm_config forwarded on each iteration ----------------------------
+
+    def test_llm_config_forwarded_each_iteration(self):
+        """llm_config from state is passed to every model.invoke() call."""
+        tool = _make_tool("t", return_value="x")
+        config = {"thinking_config": {"budget": 500}}
+
+        mock_llm = MagicMock()
+        mock_llm.invoke.side_effect = [
+            AIMessage(content="Action: t\nAction Input: {}"),
+            AIMessage(content="Final Answer: done"),
+        ]
+
+        loop = _build_prompted_react_loop(mock_llm, [tool])
+        state = {
+            "messages": [HumanMessage(content="test")],
+            "llm_config": config,
+        }
+        loop(state)
+
+        for c in mock_llm.invoke.call_args_list:
+            assert c.kwargs["config"] is config
+
+    # -- 10. Tool preamble injected into existing system message --------------
+
+    def test_tool_preamble_appended_to_existing_system_message(self):
+        """The tool preamble is appended to an existing SystemMessage."""
+        tool = _make_tool("calc")
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = AIMessage(content="Final Answer: done")
+
+        loop = _build_prompted_react_loop(mock_llm, [tool])
+        state = {
+            "messages": [
+                SystemMessage(content="You are a helpful assistant."),
+                HumanMessage(content="hi"),
+            ]
+        }
+        loop(state)
+
+        first_call_messages = mock_llm.invoke.call_args_list[0][0][0]
+        sys_msgs = [m for m in first_call_messages if isinstance(m, SystemMessage)]
+        assert len(sys_msgs) == 1
+        assert "You are a helpful assistant." in sys_msgs[0].content
+        assert "calc" in sys_msgs[0].content  # tool name injected
+
+    # -- 11. Tool preamble added when no system message exists ----------------
+
+    def test_tool_preamble_prepended_when_no_system_message(self):
+        """When there is no system message, a new one is prepended with the preamble."""
+        tool = _make_tool("lookup")
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = AIMessage(content="Final Answer: ok")
+
+        loop = _build_prompted_react_loop(mock_llm, [tool])
+        state = {"messages": [HumanMessage(content="question")]}
+        loop(state)
+
+        first_call_messages = mock_llm.invoke.call_args_list[0][0][0]
+        assert isinstance(first_call_messages[0], SystemMessage)
+        assert "lookup" in first_call_messages[0].content
+
+    # -- 12. Observations injected as HumanMessage (strict-turn compat) -------
+
+    def test_observation_injected_as_human_message(self):
+        """Tool observations are fed back as HumanMessage, not ToolMessage."""
+        tool = _make_tool("greet", return_value="hello world")
+        mock_llm = MagicMock()
+        mock_llm.invoke.side_effect = [
+            AIMessage(content="Action: greet\nAction Input: {}"),
+            AIMessage(content="Final Answer: done"),
+        ]
+
+        loop = _build_prompted_react_loop(mock_llm, [tool])
+        loop({"messages": [HumanMessage(content="greet me")]})
+
+        second_call_messages = mock_llm.invoke.call_args_list[1][0][0]
+        obs_msgs = [
+            m
+            for m in second_call_messages
+            if isinstance(m, HumanMessage) and "Observation:" in m.content
+        ]
+        assert len(obs_msgs) == 1
+        assert "hello world" in obs_msgs[0].content
+
+
+# ---------------------------------------------------------------------------
+# Auto-selection tests
+# ---------------------------------------------------------------------------
+
+
+class TestAutoSelection:
+    """Verify that build_react_agent_node selects the correct path."""
+
+    @patch("bili.iris.nodes.react_agent_node.create_agent")
+    def test_native_path_when_supports_tools_true(self, mock_create_agent):
+        """tools + supports_tools=True (default) -> create_agent called."""
+        mock_create_agent.return_value = MagicMock()
+        tool = _make_tool("t")
+
+        build_react_agent_node(tools=[tool], llm_model=MagicMock(), supports_tools=True)
+
+        mock_create_agent.assert_called_once()
+
+    @patch("bili.iris.nodes.react_agent_node.create_agent")
+    def test_native_path_default_when_no_flag(self, mock_create_agent):
+        """tools without supports_tools kwarg defaults to native path."""
+        mock_create_agent.return_value = MagicMock()
+        tool = _make_tool("t")
+
+        build_react_agent_node(tools=[tool], llm_model=MagicMock())
+
+        mock_create_agent.assert_called_once()
+
+    @patch("bili.iris.nodes.react_agent_node.create_agent")
+    def test_prompted_path_when_supports_tools_false(self, mock_create_agent):
+        """tools + supports_tools=False -> create_agent NOT called; callable returned."""
+        tool = _make_tool("t")
+
+        result = build_react_agent_node(
+            tools=[tool], llm_model=MagicMock(), supports_tools=False
+        )
+
+        mock_create_agent.assert_not_called()
+        assert callable(result)
+
+    @patch("bili.iris.nodes.react_agent_node.create_agent")
+    def test_fallback_path_when_tools_none(self, mock_create_agent):
+        """tools=None -> existing call_model fallback; create_agent not called."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = AIMessage(content="hi")
+
+        result = build_react_agent_node(tools=None, llm_model=mock_llm)
+
+        mock_create_agent.assert_not_called()
+        assert callable(result)
+        # Verify it's the call_model fallback, not the prompted loop
+        state = {"messages": [HumanMessage(content="hi")]}
+        out = result(state)
+        assert "messages" in out
+
+    @patch("bili.iris.nodes.react_agent_node.create_agent")
+    def test_fallback_path_ignores_supports_tools_when_no_tools(
+        self, mock_create_agent
+    ):
+        """tools=None with supports_tools=False still uses the tool-less fallback."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = AIMessage(content="hi")
+
+        result = build_react_agent_node(
+            tools=None, llm_model=mock_llm, supports_tools=False
+        )
+
+        mock_create_agent.assert_not_called()
+        # Should be a plain callable (call_model), not the prompted loop
+        assert callable(result)
+
+    @patch("bili.iris.nodes.react_agent_node._build_prompted_react_loop")
+    @patch("bili.iris.nodes.react_agent_node.create_agent")
+    def test_max_react_iterations_forwarded_to_prompted_loop(
+        self, mock_create_agent, mock_prompted_factory
+    ):
+        """max_react_iterations kwarg is forwarded to _build_prompted_react_loop."""
+        mock_prompted_factory.return_value = MagicMock()
+        tool = _make_tool("t")
+
+        build_react_agent_node(
+            tools=[tool],
+            llm_model=MagicMock(),
+            supports_tools=False,
+            max_react_iterations=5,
+        )
+
+        mock_create_agent.assert_not_called()
+        mock_prompted_factory.assert_called_once()
+        call_kwargs = mock_prompted_factory.call_args.kwargs
+        assert call_kwargs["max_react_iterations"] == 5


### PR DESCRIPTION
## Summary

- Adds a prompted ReAct loop to `bili/iris/nodes/react_agent_node.py` so models that cannot use `bind_tools` (text-only models, CLI-backed providers, local models without tool support) can still drive registered tools without any change to callers that work with the native path.
- Auto-selects the path via `supports_tools` in `node_kwargs` (default `True`): native unchanged, prompted when `False`, tool-less fallback when `tools=None`.
- 39 tests (all passing); 98.4% overall coverage; all 214 runtime files at ≥ 90%; pylint 9.63/10 repo-wide.

## Three-path decision tree

| Condition | Path | Returns |
|---|---|---|
| `tools is not None` and `supports_tools=True` (default) | **Native** — `create_agent` + `bind_tools` | `CompiledStateGraph` (unchanged) |
| `tools is not None` and `supports_tools=False` | **Prompted** — hand-rolled ReAct loop | `Callable[[State], dict]` (new) |
| `tools is None` | **Fallback** — direct `llm.invoke()` | `Callable[[State], dict]` (unchanged) |

## Capability detection rationale

`hasattr` / `try-bind_tools` probing is rejected: `BaseChatModel.bind_tools` is always present (raises `NotImplementedError` for models that do not override it), so attribute presence is not a reliable signal. The `supports_tools` flag already exists in the LLM catalog (`llm_config.py`) and is already read by the Streamlit UI to gate tool loading — routing that same flag through `node_kwargs` is the lowest-friction approach for callers.

## Prompted ReAct protocol

Tools are described in a plain-text system-message preamble. The loop:

1. Injects the preamble into the existing `SystemMessage` (or prepends a new one).
2. Calls `model.invoke(messages)`.
3. Parses the response with lenient regex (`_parse_react_response`) tolerating preamble, markdown code fences, and varying capitalisation.
4. On `Action:` — executes the tool, appends `AIMessage` + `HumanMessage("Observation: ...")` and continues. Observations are `HumanMessage` to satisfy strict-alternating-turn constraints (Bedrock Converse, some Mistral deployments).
5. On `Final Answer:` — returns `{"messages": [AIMessage(content=answer)]}`.
6. Guards: 3 consecutive parse failures exit early; `max_react_iterations` (default 10, settable via `node_kwargs`) caps runaway loops.

## New test classes

| Class | Cases | What it covers |
|---|---|---|
| `TestParseReactResponse` | 7 | Parser unit: final answer, action + valid JSON, malformed JSON, unknown, final-wins-over-action, code fences, case-insensitive |
| `TestPromptedReactLoop` | 12 | Happy path, multi-step, immediate final answer, unknown tool, malformed input, tool error, max-iter guard, parse-failure escape, llm_config forwarded, preamble injection, HumanMessage observations |
| `TestAutoSelection` | 6 | Native path, default native, prompted, fallback (tools=None), fallback ignores supports_tools, max_react_iterations forwarded |

## LangChain 1.x note

The legacy `create_react_agent`, `AgentExecutor`, and `ReActSingleInputOutputParser` are gone from LangChain 1.0.8. `langchain.agents` exports only `AgentState` and `create_agent`. The hand-rolled parser is the only viable approach on this version.

## Follow-on (out of scope)

`bili/aether/compiler/agent_generator.py:132` (`_generate_tool_agent_node`) has the same binary split and will receive a parallel update in a separate PR using the same `supports_tools` flag pattern.

## Test plan

- [x] `pytest bili/iris/nodes/tests/test_react_agent_node.py -v` — 39/39 pass
- [x] `pytest bili/ --cov=bili --cov-report=json && python scripts/check_coverage.py` — all 214 files ≥ 90%
- [x] Pre-commit hooks (Black, Autoflake, Isort, Pylint) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpXRrbE4UhL22Usj6UdEVQ