### PR TITLE
feat(aether): prompted tool-calling in agent_generator, parallel to IRIS (#304)

### DIFF
--- a/bili/aether/README.md
+++ b/bili/aether/README.md
@@ -656,15 +656,36 @@ Each compiled graph gets a dynamic `TypedDict` state schema. Base fields are alw
 
 ### Agent Nodes
 
-Agent nodes are generated in one of three modes based on the `AgentSpec` configuration:
+Agent nodes are generated in one of four modes based on the `AgentSpec` configuration and the
+model's capability flags:
 
-1. **Tool-enabled LLM node** — When `model_name` is set and `tools` are configured, the node uses `create_agent()` from `langchain.agents` with resolved tool instances. This mirrors the pattern used by `bili/iris/nodes/react_agent_node.py`.
+1. **Tool-enabled LLM node (native)** — `model_name` set, `tools` configured, and the model
+   supports `bind_tools` (`supports_tools: true` in `LLM_MODELS`, the default for all API
+   providers). Uses `create_agent()` from `langchain.agents` with resolved tool instances.
 
-2. **Direct LLM node** — When `model_name` is set but no tools are configured, the node calls `llm.invoke(messages)` directly. Messages are filtered to compatible types (`AIMessage`, `HumanMessage`, `SystemMessage`).
+2. **Tool-enabled LLM node (prompted)** — `model_name` set, `tools` configured, and the model
+   does **not** support `bind_tools` (`supports_tools: false` in `LLM_MODELS`, set for CLI
+   models and some legacy providers). Uses the shared prompted ReAct loop from IRIS
+   (`_build_prompted_react_loop` in `bili/iris/nodes/react_agent_node.py`). Tools are described
+   in a system-message preamble; the model's text output is parsed for `Action:` /
+   `Final Answer:` markers — the same protocol IRIS uses. This path works with any model that
+   can follow text instructions, including `CliLLM` instances. Tune the iteration cap via
+   `AgentSpec.metadata["max_react_iterations"]` (default 10).
 
-3. **Stub node** — When `model_name` is `None`, the node emits a placeholder `AIMessage` without making LLM calls. This allows compilation and graph execution without API keys (all example YAMLs use this mode).
+3. **Direct LLM node** — When `model_name` is set but no tools are configured, the node calls
+   `llm.invoke(messages)` directly. Messages are filtered to compatible types (`AIMessage`,
+   `HumanMessage`, `SystemMessage`).
 
-Model resolution is handled by `llm_resolver.py`, which maps `AgentSpec.model_name` to a `(provider_type, model_id)` pair. It searches `bili.iris.config.llm_config.LLM_MODELS` first (by `model_id`, then by display name), and falls back to heuristic prefix-based detection. LLM instances are created via `bili.iris.loaders.llm_loader.load_model()`. Tool names are resolved via `bili.iris.loaders.tools_loader.initialize_tools()`.
+4. **Stub node** — When `model_name` is `None`, the node emits a placeholder `AIMessage`
+   without making LLM calls. This allows compilation and graph execution without API keys (all
+   example YAMLs use this mode).
+
+Model resolution is handled by `llm_resolver.py`, which maps `AgentSpec.model_name` to a
+`(provider_type, model_id)` pair. It searches `bili.iris.config.llm_config.LLM_MODELS` first
+(by `model_id`, then by display name), and falls back to heuristic prefix-based detection. The
+`supports_tools` flag is also read from `LLM_MODELS` to select native vs prompted path. LLM
+instances are created via `bili.iris.loaders.llm_loader.load_model()`. Tool names are resolved
+via `bili.iris.loaders.tools_loader.initialize_tools()`.
 
 Each agent node callable has an `.agent_spec` attribute attached for introspection:
 
@@ -826,7 +847,7 @@ graph = compiled.compile_graph(checkpointer=get_pg_checkpointer(keep_last_n=5))
 
 ### Per-Agent Middleware
 
-Agents can configure middleware to intercept and modify their execution. Middleware is resolved via bili-core's `initialize_middleware()` and passed to `create_agent()` for tool-enabled agents.
+Agents can configure middleware to intercept and modify their execution. Middleware is resolved via bili-core's `initialize_middleware()` and passed to `create_agent()` for tool-enabled agents on the **native** path.
 
 ```yaml
 agents:
@@ -862,7 +883,7 @@ agents:
 | `model_call_limit` | Circuit-breaker for runaway agent loops | `run_limit` (default: 10), `exit_behavior` (`"end"` or `"error"`) |
 
 **Limitations:**
-- Middleware only applies to **tool-enabled agents** (agents with `tools` configured). If middleware is set on an agent without tools, a warning is logged and middleware is skipped.
+- Middleware only applies to **native tool-enabled agents** (agents with `tools` configured and a model that supports `bind_tools`). If middleware is set on an agent without tools, or on an agent using the prompted ReAct path (`supports_tools: false`), a warning is logged and middleware is skipped.
 - Middleware requires `langchain.agents.middleware` — if unavailable, agents run without middleware.
 
 ### CLI Tool (Compiler)

--- a/bili/aether/compiler/agent_generator.py
+++ b/bili/aether/compiler/agent_generator.py
@@ -2,8 +2,26 @@
 
 When an ``AgentSpec`` has ``model_name`` set, the generated node makes
 real LLM calls using bili-core's ``llm_loader``.  If the agent also has
-``tools`` configured, the node is built with ``langchain.agents.create_agent``
-— the same pattern used by ``bili/iris/nodes/react_agent_node.py``.
+``tools`` configured, the node execution path is selected based on the
+model's ``supports_tools`` flag (sourced from ``LLM_MODELS``), mirroring
+the 3-way selection in ``bili/iris/nodes/react_agent_node.py``:
+
+1. **Native tool-calling** (``supports_tools=True``, the default for API
+   providers): uses ``langchain.agents.create_agent`` + ``bind_tools``.
+
+2. **Prompted tool-calling** (``supports_tools=False``, set for CLI and
+   some legacy models): uses the shared
+   :func:`~bili.iris.nodes.react_agent_node._build_prompted_react_loop`
+   factory imported from IRIS.  Tools are described in a system-message
+   preamble; the model's text output is parsed for ``Action:`` /
+   ``Final Answer:`` markers.  Works with any model that can follow text
+   instructions, including ``CliLLM`` instances that do not implement
+   ``bind_tools``.
+
+3. **No tools**: calls ``llm.invoke()`` directly (unchanged).
+
+The prompted-loop implementation is shared with IRIS via a direct import
+from ``bili.iris.nodes.react_agent_node`` — no code is duplicated.
 """
 
 import json
@@ -110,14 +128,23 @@ def _generate_llm_agent_node(agent: AgentSpec) -> Callable[[dict], dict]:
     resolved and passed to ``create_agent`` for tool-enabled agents.
     """
     # pylint: disable=import-outside-toplevel
-    from bili.aether.compiler.llm_resolver import create_llm, resolve_tools
+    from bili.aether.compiler.llm_resolver import (
+        create_llm,
+        resolve_supports_tools,
+        resolve_tools,
+    )
 
     llm = create_llm(agent)
     tools = resolve_tools(agent)
     middleware = _resolve_middleware(agent)
+    supports_tools = (
+        resolve_supports_tools(agent.model_name) if agent.model_name else True
+    )
 
     if tools:
-        return _generate_tool_agent_node(agent, llm, tools, middleware)
+        return _generate_tool_agent_node(
+            agent, llm, tools, middleware, supports_tools=supports_tools
+        )
 
     if middleware:
         LOGGER.warning(
@@ -134,17 +161,65 @@ def _generate_tool_agent_node(
     llm: object,
     tools: List,
     middleware: Optional[List] = None,
+    supports_tools: bool = True,
 ) -> Callable[[dict], dict]:
-    """Create a node using ``create_agent()`` for tool-enabled agents.
+    """Create a node for tool-enabled agents, selecting native or prompted path.
 
-    Mirrors the tool-enabled path in ``bili/iris/nodes/react_agent_node.py``.
-    Middleware (if provided) is forwarded to ``create_agent()``.
+    When ``supports_tools`` is ``True`` (the default for API-backed models),
+    delegates to ``langchain.agents.create_agent`` — the same native path as
+    before.  When ``supports_tools`` is ``False`` (CLI models, some legacy
+    providers), uses the shared prompted ReAct loop imported from
+    ``bili/iris/nodes/react_agent_node.py`` instead.  Middleware is forwarded
+    to ``create_agent()`` on the native path; it is not applicable on the
+    prompted path and is silently ignored there.
+
+    ``max_react_iterations`` for the prompted path can be tuned via
+    ``agent.metadata["max_react_iterations"]``; the default is 10.
     """
-    from langchain.agents import (  # pylint: disable=import-error,import-outside-toplevel
-        create_agent,
-    )
+    # ── Build the executor at node-construction time ──────────────────────────
+    if supports_tools:
+        from langchain.agents import (  # pylint: disable=import-error,import-outside-toplevel
+            create_agent,
+        )
 
-    react_agent = create_agent(model=llm, tools=tools, middleware=middleware or ())
+        react_agent = create_agent(model=llm, tools=tools, middleware=middleware or ())
+        executor_mode = "tool-agent (native)"
+
+        def _invoke_executor(messages: list) -> list:
+            result = react_agent.invoke({"messages": messages})
+            return result.get("messages", [])
+
+    else:
+        # Prompted path: model cannot bind_tools; run the hand-rolled ReAct loop.
+        # Imported from IRIS so the implementation is shared, not duplicated.
+        from bili.iris.nodes.react_agent_node import (  # pylint: disable=import-outside-toplevel
+            _DEFAULT_MAX_REACT_ITERATIONS,
+            _build_prompted_react_loop,
+        )
+
+        if middleware:
+            LOGGER.warning(
+                "Agent '%s' has middleware configured but supports_tools=False; "
+                "middleware is only applicable on the native create_agent path "
+                "and will be ignored for the prompted ReAct path.",
+                agent.agent_id,
+            )
+
+        max_react_iterations = int(
+            agent.metadata.get("max_react_iterations", _DEFAULT_MAX_REACT_ITERATIONS)
+        )
+        prompted_loop = _build_prompted_react_loop(
+            llm_model=llm,
+            tools=tools,
+            max_react_iterations=max_react_iterations,
+        )
+        executor_mode = "tool-agent (prompted)"
+
+        def _invoke_executor(messages: list) -> list:
+            result = prompted_loop({"messages": messages})
+            return result.get("messages", [])
+
+    # ── Shared node callable ──────────────────────────────────────────────────
 
     def _agent_node(state: dict) -> dict:  # pylint: disable=too-many-locals
         start_time = time.time()
@@ -196,18 +271,18 @@ def _generate_tool_agent_node(
 
         _ensure_human_last(messages, agent)
 
-        # Invoke the react agent — it handles tool calls internally
-        result = react_agent.invoke({"messages": messages})
+        # Invoke via the pre-selected executor (native react_agent or prompted loop)
+        response_messages = _invoke_executor(messages)
 
         execution_ms = (time.time() - start_time) * 1000
         LOGGER.info(
-            "Agent node '%s' executed in %.2f ms (tool-agent)",
+            "Agent node '%s' executed in %.2f ms (%s)",
             agent.agent_id,
             execution_ms,
+            executor_mode,
         )
 
         # Extract the final response content
-        response_messages = result.get("messages", [])
         content = ""
         if response_messages:
             content = _normalise_content_value(response_messages[-1].content)

--- a/bili/aether/compiler/llm_resolver.py
+++ b/bili/aether/compiler/llm_resolver.py
@@ -254,6 +254,56 @@ def create_llm(agent: AgentSpec) -> Any:
     return build_fallback_llm(primary_llm=primary_llm, fallback_chain=fallback_chain)
 
 
+def resolve_supports_tools(model_name: str) -> bool:
+    """Return the ``supports_tools`` flag for *model_name* from ``LLM_MODELS``.
+
+    Checks the ``supports_tools`` top-level field on the matching model entry.
+    Returns ``True`` (the default for all API-backed models) when the entry is
+    not found in the catalog or when the entry does not declare the flag
+    explicitly.  Returns ``False`` only when the entry explicitly sets
+    ``"supports_tools": False``, as CLI and some legacy models do.
+
+    This is the same source that ``bili/iris/nodes/react_agent_node.py`` reads
+    via its ``supports_tools`` node-kwarg: AETHER uses this lookup to drive the
+    same 3-way path selection without requiring YAML authors to declare the flag.
+
+    Args:
+        model_name: The model identifier from ``AgentSpec.model_name``.
+            Can be a display name (``"GPT-4o"``) or a model ID
+            (``"gpt-4o"``).
+
+    Returns:
+        ``True`` if the model supports native ``bind_tools`` (use native
+        ``create_agent`` path); ``False`` if it does not (use prompted ReAct
+        path).
+    """
+    try:
+        from bili.iris.config.llm_config import (  # noqa: E402  pylint: disable=import-outside-toplevel
+            LLM_MODELS,
+        )
+    except ImportError:
+        LOGGER.debug(
+            "bili.iris.config.llm_config not available; "
+            "assuming supports_tools=True for '%s'",
+            model_name,
+        )
+        return True
+
+    for provider_info in LLM_MODELS.values():
+        for entry in provider_info.get("models", []):
+            if (
+                entry.get("model_id") == model_name
+                or entry.get("model_name") == model_name
+            ):
+                return entry.get("supports_tools", True)
+
+    LOGGER.debug(
+        "'%s' not found in LLM_MODELS; assuming supports_tools=True",
+        model_name,
+    )
+    return True
+
+
 def resolve_tools(agent: AgentSpec) -> list:
     """Resolve an ``AgentSpec``'s tool names to tool instances.
 

--- a/bili/aether/docs/compiler.md
+++ b/bili/aether/docs/compiler.md
@@ -118,15 +118,35 @@ Each compiled graph gets a dynamic `TypedDict` state schema. Base fields are alw
 
 ### Agent Nodes
 
-Agent nodes are generated in one of three modes based on `AgentSpec` configuration:
+Agent nodes are generated in one of four modes based on `AgentSpec` configuration and the
+model's capability flags:
 
-1. **Tool-enabled LLM node** — `model_name` set and `tools` configured. Uses `create_agent()` from `langchain.agents` with resolved tool instances. Middleware applies here.
+1. **Tool-enabled LLM node (native)** — `model_name` set, `tools` configured, and the model
+   supports `bind_tools` (i.e. `supports_tools: true` in `LLM_MODELS`, the default for all
+   API providers). Uses `create_agent()` from `langchain.agents` with resolved tool instances.
+   Middleware applies here.
 
-2. **Direct LLM node** — `model_name` set but no tools. Calls `llm.invoke(messages)` directly. Messages are filtered to compatible types (`AIMessage`, `HumanMessage`, `SystemMessage`).
+2. **Tool-enabled LLM node (prompted)** — `model_name` set, `tools` configured, and the model
+   does **not** support `bind_tools` (`supports_tools: false` in `LLM_MODELS`, set for CLI
+   models and some legacy providers). Uses the shared prompted ReAct loop from
+   `bili/iris/nodes/react_agent_node._build_prompted_react_loop`. Tools are described in a
+   system-message preamble; the model's text output is parsed for `Action:` / `Final Answer:`
+   markers. Works with any model that can follow text instructions. The iteration cap can be
+   tuned via `AgentSpec.metadata["max_react_iterations"]` (default 10). Middleware is not
+   applicable on this path.
 
-3. **Stub node** — `model_name` is `None`. Emits a placeholder `AIMessage` without LLM calls. Allows full compilation and graph execution without API keys. All example YAMLs use this mode.
+3. **Direct LLM node** — `model_name` set but no tools. Calls `llm.invoke(messages)` directly.
+   Messages are filtered to compatible types (`AIMessage`, `HumanMessage`, `SystemMessage`).
 
-Model resolution is handled by `llm_resolver.py`, which maps `model_name` to a `(provider_type, model_id)` pair by searching `bili.iris.config.llm_config.LLM_MODELS` and falling back to heuristic prefix-based detection. LLMs are created via `bili.iris.loaders.llm_loader.load_model()`. Tools are resolved via `bili.iris.loaders.tools_loader.initialize_tools()`.
+4. **Stub node** — `model_name` is `None`. Emits a placeholder `AIMessage` without LLM calls.
+   Allows full compilation and graph execution without API keys. All example YAMLs use this mode.
+
+Model resolution is handled by `llm_resolver.py`, which maps `model_name` to a
+`(provider_type, model_id)` pair by searching `bili.iris.config.llm_config.LLM_MODELS` and
+falling back to heuristic prefix-based detection. The `supports_tools` flag is also read from
+the `LLM_MODELS` entry to select native vs prompted path. LLMs are created via
+`bili.iris.loaders.llm_loader.load_model()`. Tools are resolved via
+`bili.iris.loaders.tools_loader.initialize_tools()`.
 
 Each agent node callable has an `.agent_spec` attribute for introspection:
 

--- a/bili/aether/tests/test_compiler.py
+++ b/bili/aether/tests/test_compiler.py
@@ -812,3 +812,260 @@ class TestEnsureHumanLast:
         _ensure_human_last(messages, agent)
         assert id(messages) == original_id
         assert len(messages) == 2
+
+
+# =========================================================================
+# PROMPTED TOOL-CALLING TESTS (supports_tools=False path, #304)
+# =========================================================================
+
+# Shared mock targets for resolve_supports_tools.
+# resolve_supports_tools is imported lazily from llm_resolver inside
+# _generate_llm_agent_node, so we patch it at the llm_resolver source.
+_MOCK_SUPPORTS_TOOLS = "bili.aether.compiler.llm_resolver.resolve_supports_tools"
+
+
+class TestPromptedToolCalling:
+    """Tests for the prompted ReAct path in AETHER agent_generator.
+
+    Verifies that an AETHER agent on a non-tool-calling model uses the shared
+    prompted ReAct loop from bili.iris.nodes.react_agent_node, not
+    create_agent / bind_tools, and that the native and no-tools paths are
+    unchanged.
+    """
+
+    def _make_mock_tool(self, name: str, return_value: str) -> MagicMock:
+        """Build a minimal LangChain-style tool mock."""
+        tool = MagicMock()
+        tool.name = name
+        tool.description = f"Mock tool: {name}"
+        tool.args_schema = None
+        tool.invoke.return_value = return_value
+        return tool
+
+    # ------------------------------------------------------------------
+    # Prompted path: non-tool-calling model with tools
+    # ------------------------------------------------------------------
+
+    def test_prompted_path_does_not_call_create_agent(self):
+        """A non-tool-calling model with tools must NOT invoke create_agent."""
+        agent = _agent("cli_agent", model_name="cli:claude", tools=["mock_tool"])
+        mock_tool = self._make_mock_tool("weather", "sunny")
+
+        with (
+            patch(_MOCK_CREATE) as mock_create_llm,
+            patch(_MOCK_TOOLS, return_value=[mock_tool]),
+            patch(_MOCK_SUPPORTS_TOOLS, return_value=False),
+            patch(
+                "bili.iris.nodes.react_agent_node.create_agent"
+            ) as patched_create_agent,
+        ):
+            mock_llm = MagicMock()
+            # Model returns a Final Answer on the first call
+            mock_llm.invoke.return_value = MagicMock(
+                content="Thought: done\nFinal Answer: The weather is sunny."
+            )
+            mock_create_llm.return_value = mock_llm
+
+            node_fn = generate_agent_node(agent)
+            node_fn({"messages": [], "agent_outputs": {}})
+            patched_create_agent.assert_not_called()
+
+    def test_prompted_path_tool_is_invoked(self):
+        """Prompted path must invoke the resolved tool when model requests it."""
+        agent = _agent("cli_agent", model_name="cli:claude", tools=["weather"])
+        weather_tool = self._make_mock_tool("weather", "clear skies")
+
+        with (
+            patch(_MOCK_CREATE) as mock_create_llm,
+            patch(_MOCK_TOOLS, return_value=[weather_tool]),
+            patch(_MOCK_SUPPORTS_TOOLS, return_value=False),
+        ):
+            mock_llm = MagicMock()
+            # First call: model requests the weather tool
+            # Second call: model produces the final answer
+            mock_llm.invoke.side_effect = [
+                MagicMock(
+                    content=(
+                        "Thought: I need the weather.\n"
+                        "Action: weather\n"
+                        'Action Input: {"location": "Denver"}'
+                    )
+                ),
+                MagicMock(
+                    content="Thought: Got it.\nFinal Answer: The weather is clear skies."
+                ),
+            ]
+            mock_create_llm.return_value = mock_llm
+
+            node_fn = generate_agent_node(agent)
+            result = node_fn({"messages": [], "agent_outputs": {}})
+
+            weather_tool.invoke.assert_called_once_with({"location": "Denver"})
+            assert result["current_agent"] == "cli_agent"
+            assert "clear skies" in result["messages"][0].content
+
+    def test_prompted_path_final_answer_returned(self):
+        """Prompted path returns the Final Answer content in the AETHER state update."""
+        agent = _agent("cli_agent", model_name="cli:claude", tools=["mock_tool"])
+        mock_tool = self._make_mock_tool("mock_tool", "some output")
+
+        with (
+            patch(_MOCK_CREATE) as mock_create_llm,
+            patch(_MOCK_TOOLS, return_value=[mock_tool]),
+            patch(_MOCK_SUPPORTS_TOOLS, return_value=False),
+        ):
+            mock_llm = MagicMock()
+            mock_llm.invoke.return_value = MagicMock(
+                content="Thought: Done.\nFinal Answer: Forty-two."
+            )
+            mock_create_llm.return_value = mock_llm
+
+            node_fn = generate_agent_node(agent)
+            result = node_fn({"messages": [], "agent_outputs": {}})
+
+            assert result["current_agent"] == "cli_agent"
+            assert result["messages"][0].content == "Forty-two."
+            output = result["agent_outputs"]["cli_agent"]
+            assert output["status"] == "completed"
+            assert output["message"] == "Forty-two."
+
+    def test_prompted_path_respects_max_react_iterations_from_metadata(self):
+        """max_react_iterations from agent.metadata caps the prompted loop."""
+        agent = _agent(
+            "cli_agent",
+            model_name="cli:claude",
+            tools=["mock_tool"],
+            metadata={"max_react_iterations": 2},
+        )
+        mock_tool = self._make_mock_tool("mock_tool", "result")
+
+        with (
+            patch(_MOCK_CREATE) as mock_create_llm,
+            patch(_MOCK_TOOLS, return_value=[mock_tool]),
+            patch(_MOCK_SUPPORTS_TOOLS, return_value=False),
+        ):
+            mock_llm = MagicMock()
+            # Always return an unparseable response — loop should cap at 2
+            mock_llm.invoke.return_value = MagicMock(content="I am confused.")
+            mock_create_llm.return_value = mock_llm
+
+            node_fn = generate_agent_node(agent)
+            result = node_fn({"messages": [], "agent_outputs": {}})
+
+            # With max_react_iterations=2 and _MAX_CONSECUTIVE_PARSE_FAILURES=3,
+            # the iteration cap fires first; the last model response is returned.
+            assert result["current_agent"] == "cli_agent"
+            assert mock_llm.invoke.call_count == 2
+
+    # ------------------------------------------------------------------
+    # Native path: tool-calling model with tools — unchanged
+    # ------------------------------------------------------------------
+
+    def test_native_path_still_uses_create_agent(self):
+        """A tool-capable model must use create_agent (native path unchanged)."""
+        agent = _agent("api_agent", model_name="gpt-4o", tools=["mock_tool"])
+        mock_tool = self._make_mock_tool("mock_tool", "output")
+        mock_react_agent = MagicMock()
+        mock_react_agent.invoke.return_value = {
+            "messages": [AIMessage(content="native result")]
+        }
+
+        langchain_stub = types.ModuleType("langchain")
+        agents_stub = types.ModuleType("langchain.agents")
+        mock_create_agent_fn = MagicMock(return_value=mock_react_agent)
+        agents_stub.create_agent = mock_create_agent_fn
+        langchain_stub.agents = agents_stub
+
+        with (
+            patch(_MOCK_CREATE) as mock_create_llm,
+            patch(_MOCK_TOOLS, return_value=[mock_tool]),
+            patch(_MOCK_SUPPORTS_TOOLS, return_value=True),
+            patch.dict(
+                sys.modules,
+                {"langchain": langchain_stub, "langchain.agents": agents_stub},
+            ),
+        ):
+            mock_create_llm.return_value = MagicMock()
+
+            node_fn = generate_agent_node(agent)
+
+            mock_create_agent_fn.assert_called_once()
+            result = node_fn({"messages": [], "agent_outputs": {}})
+            assert result["current_agent"] == "api_agent"
+            assert result["messages"][0].content == "native result"
+
+    # ------------------------------------------------------------------
+    # No-tools path — unchanged
+    # ------------------------------------------------------------------
+
+    def test_no_tools_path_unchanged(self):
+        """Agent without tools calls LLM directly regardless of supports_tools."""
+        agent = _agent("direct_agent", model_name="gpt-4o")
+
+        with (
+            patch(_MOCK_CREATE) as mock_create_llm,
+            patch(_MOCK_TOOLS, return_value=[]),
+            patch(_MOCK_SUPPORTS_TOOLS, return_value=False),
+        ):
+            mock_llm = MagicMock()
+            mock_llm.invoke.return_value = MagicMock(content="direct answer")
+            mock_create_llm.return_value = mock_llm
+
+            node_fn = generate_agent_node(agent)
+            result = node_fn({"messages": [], "agent_outputs": {}})
+
+            mock_llm.invoke.assert_called_once()
+            assert result["messages"][0].content == "direct answer"
+
+    # ------------------------------------------------------------------
+    # resolve_supports_tools
+    # ------------------------------------------------------------------
+
+    def test_resolve_supports_tools_returns_false_for_flagged_model(self):
+        """resolve_supports_tools returns False for a model with supports_tools=False."""
+        from bili.aether.compiler.llm_resolver import resolve_supports_tools
+
+        mock_models = {
+            "remote_aws_bedrock": {
+                "models": [
+                    {
+                        "model_name": "Amazon Titan Text G1 - Premier",
+                        "model_id": "amazon.titan-text-premier-v1:0",
+                        "supports_tools": False,
+                    },
+                ]
+            }
+        }
+        with patch("bili.iris.config.llm_config.LLM_MODELS", mock_models):
+            assert resolve_supports_tools("amazon.titan-text-premier-v1:0") is False
+            assert resolve_supports_tools("Amazon Titan Text G1 - Premier") is False
+
+    def test_resolve_supports_tools_defaults_to_true(self):
+        """resolve_supports_tools returns True when flag is absent or model unknown."""
+        from bili.aether.compiler.llm_resolver import resolve_supports_tools
+
+        mock_models = {
+            "remote_openai": {
+                "models": [
+                    {"model_name": "GPT-4o", "model_id": "gpt-4o"},
+                ]
+            }
+        }
+        with patch("bili.iris.config.llm_config.LLM_MODELS", mock_models):
+            # Entry present, no supports_tools key → default True
+            assert resolve_supports_tools("gpt-4o") is True
+            # Entry not in catalog → default True
+            assert resolve_supports_tools("unknown-model-xyz") is True
+
+    def test_resolve_supports_tools_returns_true_on_import_error(self):
+        """resolve_supports_tools returns True when LLM_MODELS cannot be imported."""
+        from bili.aether.compiler.llm_resolver import resolve_supports_tools
+
+        with patch(
+            "bili.iris.config.llm_config.LLM_MODELS",
+            side_effect=ImportError("no module"),
+            create=True,
+        ):
+            # Should not raise; defaults to True
+            result = resolve_supports_tools("any-model")
+            assert result is True


### PR DESCRIPTION
## Summary

- Adds 3-way path selection to AETHER's `_generate_tool_agent_node`, mirroring PR #210's update to `bili/iris/nodes/react_agent_node.py`: native `create_agent` for tool-capable models, a shared prompted ReAct loop for models with `supports_tools: false` (CLI and some legacy providers), and the unchanged direct-invoke no-tools path.
- Adds `resolve_supports_tools(model_name) -> bool` to `llm_resolver.py`, reading the `supports_tools` flag from `LLM_MODELS` so YAML authors need only set `model_name` -- path selection is automatic.
- Shares the prompted-loop implementation via direct import from `bili.iris.nodes.react_agent_node._build_prompted_react_loop`. No code is duplicated.

## Sharing approach

Direct import from `react_agent_node`: `_build_prompted_react_loop` and `_DEFAULT_MAX_REACT_ITERATIONS`. The AETHER state dict is compatible with the loop's `state["messages"]` / `state.get("llm_config", {})` access pattern, so no adapter layer is needed. A single `_invoke_executor` closure captures the path selection at construction time; the `_agent_node` callable is identical for both paths.

## Configuring the prompted path

Set `supports_tools: false` on the model's `LLM_MODELS` entry (already done for all CLI and legacy models). The iteration cap can be tuned per-agent:

```yaml
agents:
  - agent_id: cli_grader
    role: grader
    objective: Grade submissions using the provided rubric
    model_name: "cli:claude"
    tools: [grade_setup, grade_assess]
    metadata:
      max_react_iterations: 8   # optional; default 10
```

## Tests

9 new tests in `test_compiler.py::TestPromptedToolCalling`:
- Prompted path does not call `create_agent`
- Tool is invoked and observation fed back through the loop
- Final Answer content lands correctly in the AETHER state update (`messages`, `agent_outputs`, `current_agent`)
- `max_react_iterations` from `AgentSpec.metadata` caps the loop
- Native path unchanged for capable models
- No-tools path unchanged regardless of `supports_tools`
- `resolve_supports_tools` returns `False` for models with the flag set
- `resolve_supports_tools` defaults to `True` when flag is absent or model is unknown
- `resolve_supports_tools` returns `True` on import error (graceful degradation)

Coverage gate: PASS (98.4% overall, all 214 runtime files >= 90%).
Pylint: 9.97/10 (pre-existing `W0613` in `_extract_next_agent`, not introduced here).
All 3160 tests pass.

## Docs

`bili/aether/docs/compiler.md` and `bili/aether/README.md` updated: agent-node modes now enumerate all four variants (native tool, prompted tool, direct, stub) and clarify that middleware applies to the native path only.

## Completes #304

PR #210 covered IRIS (`react_agent_node.py`). PR #212 fixed the `Action Input` parser for nested args. This PR covers AETHER (`agent_generator.py`). #304 framework coverage is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpXRrbE4UhL22Usj6UdEVQ