### PR TITLE
feat(iris,aether): tool_strategy classification + catalog migration (#313)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -27,10 +27,10 @@ BiliCore is organized into three named components, each solving a distinct probl
 IRIS bridges users to LLMs, tools, and data sources. It provides a node-based workflow pipeline where each step (persona injection, tool execution, memory management, response normalization) is a composable node. Switch models mid-conversation, configure tools on the fly, and persist state across sessions.
 
 - **API providers:** AWS Bedrock, Google Vertex AI, Azure OpenAI, OpenAI, Anthropic (direct), Mistral AI, Cohere, Google Generative AI, DeepSeek, xAI (Grok), Groq
-- **CLI providers:** Claude Code CLI, OpenAI Codex CLI, Google Gemini CLI (subprocess via `supports_tools=False`), plus a generic CLI subprocess provider for any text-in/text-out LLM tool
+- **CLI providers:** Claude Code CLI, OpenAI Codex CLI, Google Gemini CLI (subprocess, `tool_strategy="mcp"`), plus a generic CLI subprocess provider for any text-in/text-out LLM tool
 - **Local providers:** llama.cpp (GGUF models), HuggingFace (GPTQ/transformers)
 - **Fallback engine:** `FallbackLLM` chains multiple providers so a transient error on the primary silently retries the next in the list
-- **Tool-calling modes:** native (bind_tools, all API providers) and prompted ReAct (hand-rolled loop for CLI and other text-only models — `supports_tools=False`)
+- **Tool-calling modes:** `native` (bind_tools, API providers), `facilitated` (prompted ReAct hand-rolled loop for text-only/local models), `mcp` (agentic CLI tools; plain path until MCP mechanism lands), `none` (no tool support — plain path)
 - **Tools:** FAISS vector search, OpenSearch, weather APIs, web search, extensible tool registry
 - **Middleware:** Summarization, model call limiting, custom middleware
 - **Checkpointers:** MongoDB, PostgreSQL, in-memory — all with queryable conversation management

--- a/bili/aether/compiler/agent_generator.py
+++ b/bili/aether/compiler/agent_generator.py
@@ -3,22 +3,28 @@
 When an ``AgentSpec`` has ``model_name`` set, the generated node makes
 real LLM calls using bili-core's ``llm_loader``.  If the agent also has
 ``tools`` configured, the node execution path is selected based on the
-model's ``supports_tools`` flag (sourced from ``LLM_MODELS``), mirroring
-the 3-way selection in ``bili/iris/nodes/react_agent_node.py``:
+model's ``tool_strategy`` (sourced from ``LLM_MODELS`` via
+:func:`~bili.aether.compiler.llm_resolver.resolve_tool_strategy`),
+mirroring the routing in ``bili/iris/nodes/react_agent_node.py``:
 
-1. **Native tool-calling** (``supports_tools=True``, the default for API
+1. **Native tool-calling** (``tool_strategy="native"``, the default for API
    providers): uses ``langchain.agents.create_agent`` + ``bind_tools``.
 
-2. **Prompted tool-calling** (``supports_tools=False``, set for CLI and
-   some legacy models): uses the shared
-   :func:`~bili.iris.nodes.react_agent_node._build_prompted_react_loop`
+2. **Prompted tool-calling** (``tool_strategy="facilitated"``): uses the
+   shared :func:`~bili.iris.nodes.react_agent_node._build_prompted_react_loop`
    factory imported from IRIS.  Tools are described in a system-message
    preamble; the model's text output is parsed for ``Action:`` /
    ``Final Answer:`` markers.  Works with any model that can follow text
-   instructions, including ``CliLLM`` instances that do not implement
-   ``bind_tools``.
+   instructions.
 
-3. **No tools**: calls ``llm.invoke()`` directly (unchanged).
+3. **MCP / agentic CLI** (``tool_strategy="mcp"``): interim behaviour --
+   tools are dropped and the model runs tool-less until the MCP mechanism
+   (#311) is in place.
+
+4. **No-tool model** (``tool_strategy="none"``): the model has no tool
+   support; tools are dropped and the model runs tool-less.
+
+5. **No tools configured**: calls ``llm.invoke()`` directly (unchanged).
 
 The prompted-loop implementation is shared with IRIS via a direct import
 from ``bili.iris.nodes.react_agent_node`` — no code is duplicated.
@@ -130,20 +136,20 @@ def _generate_llm_agent_node(agent: AgentSpec) -> Callable[[dict], dict]:
     # pylint: disable=import-outside-toplevel
     from bili.aether.compiler.llm_resolver import (
         create_llm,
-        resolve_supports_tools,
+        resolve_tool_strategy,
         resolve_tools,
     )
 
     llm = create_llm(agent)
     tools = resolve_tools(agent)
     middleware = _resolve_middleware(agent)
-    supports_tools = (
-        resolve_supports_tools(agent.model_name) if agent.model_name else True
+    tool_strategy = (
+        resolve_tool_strategy(agent.model_name) if agent.model_name else "native"
     )
 
     if tools:
         return _generate_tool_agent_node(
-            agent, llm, tools, middleware, supports_tools=supports_tools
+            agent, llm, tools, middleware, tool_strategy=tool_strategy
         )
 
     if middleware:
@@ -161,23 +167,28 @@ def _generate_tool_agent_node(
     llm: object,
     tools: List,
     middleware: Optional[List] = None,
-    supports_tools: bool = True,
+    tool_strategy: str = "native",
 ) -> Callable[[dict], dict]:
-    """Create a node for tool-enabled agents, selecting native or prompted path.
+    """Create a node for tool-enabled agents, selecting the execution path by strategy.
 
-    When ``supports_tools`` is ``True`` (the default for API-backed models),
-    delegates to ``langchain.agents.create_agent`` — the same native path as
-    before.  When ``supports_tools`` is ``False`` (CLI models, some legacy
-    providers), uses the shared prompted ReAct loop imported from
-    ``bili/iris/nodes/react_agent_node.py`` instead.  Middleware is forwarded
-    to ``create_agent()`` on the native path; it is not applicable on the
-    prompted path and is silently ignored there.
+    ``tool_strategy`` is the authoritative routing key:
 
-    ``max_react_iterations`` for the prompted path can be tuned via
+    - ``"native"`` (default for API-backed models): delegates to
+      ``langchain.agents.create_agent`` + ``bind_tools``.  Middleware is
+      forwarded to ``create_agent()``.
+    - ``"facilitated"``: uses the shared prompted ReAct loop imported from
+      ``bili/iris/nodes/react_agent_node.py``.  Middleware is not applicable
+      on this path and is silently ignored.
+    - ``"mcp"`` or ``"none"``: tools are dropped and the agent runs on the
+      direct-LLM path.  ``"mcp"`` is the interim behaviour until the MCP
+      mechanism (#311) is in place; ``"none"`` covers models that reject tool
+      kwargs entirely.
+
+    ``max_react_iterations`` for the ``"facilitated"`` path can be tuned via
     ``agent.metadata["max_react_iterations"]``; the default is 10.
     """
     # ── Build the executor at node-construction time ──────────────────────────
-    if supports_tools:
+    if tool_strategy == "native":
         from langchain.agents import (  # pylint: disable=import-error,import-outside-toplevel
             create_agent,
         )
@@ -189,7 +200,7 @@ def _generate_tool_agent_node(
             result = react_agent.invoke({"messages": messages})
             return result.get("messages", [])
 
-    else:
+    elif tool_strategy == "facilitated":
         # Prompted path: model cannot bind_tools; run the hand-rolled ReAct loop.
         # Imported from IRIS so the implementation is shared, not duplicated.
         from bili.iris.nodes.react_agent_node import (  # pylint: disable=import-outside-toplevel
@@ -199,7 +210,7 @@ def _generate_tool_agent_node(
 
         if middleware:
             LOGGER.warning(
-                "Agent '%s' has middleware configured but supports_tools=False; "
+                "Agent '%s' has middleware configured but tool_strategy='facilitated'; "
                 "middleware is only applicable on the native create_agent path "
                 "and will be ignored for the prompted ReAct path.",
                 agent.agent_id,
@@ -218,6 +229,17 @@ def _generate_tool_agent_node(
         def _invoke_executor(messages: list) -> list:
             result = prompted_loop({"messages": messages})
             return result.get("messages", [])
+
+    else:
+        # "mcp" or "none": drop tools; delegate to the direct-LLM node.
+        # This is an interim path -- "mcp" models are agentic CLIs that
+        # self-orchestrate; "none" models reject tool kwargs entirely.
+        LOGGER.debug(
+            "Agent '%s': tool_strategy='%s' -- dropping tools; routing to direct-LLM node.",
+            agent.agent_id,
+            tool_strategy,
+        )
+        return _generate_direct_llm_node(agent, llm)
 
     # ── Shared node callable ──────────────────────────────────────────────────
 

--- a/bili/aether/compiler/llm_resolver.py
+++ b/bili/aether/compiler/llm_resolver.py
@@ -254,28 +254,40 @@ def create_llm(agent: AgentSpec) -> Any:
     return build_fallback_llm(primary_llm=primary_llm, fallback_chain=fallback_chain)
 
 
-def resolve_supports_tools(model_name: str) -> bool:
-    """Return the ``supports_tools`` flag for *model_name* from ``LLM_MODELS``.
+def resolve_tool_strategy(model_name: str) -> str:
+    """Return the ``tool_strategy`` for *model_name* from ``LLM_MODELS``.
 
-    Checks the ``supports_tools`` top-level field on the matching model entry.
-    Returns ``True`` (the default for all API-backed models) when the entry is
-    not found in the catalog or when the entry does not declare the flag
-    explicitly.  Returns ``False`` only when the entry explicitly sets
-    ``"supports_tools": False``, as CLI and some legacy models do.
+    The ``tool_strategy`` field classifies how agents should invoke tools for a
+    given model:
 
-    This is the same source that ``bili/iris/nodes/react_agent_node.py`` reads
-    via its ``supports_tools`` node-kwarg: AETHER uses this lookup to drive the
-    same 3-way path selection without requiring YAML authors to declare the flag.
+    - ``"native"``     -- the model implements ``bind_tools``; use
+                          ``create_agent`` + LangChain tool-calling.
+    - ``"facilitated"`` -- the model cannot bind tools natively; route to the
+                           prompted ReAct loop (hand-rolled Thought/Action/
+                           Observation cycle described in the system message).
+    - ``"mcp"``        -- the model is an agentic CLI best consumed as an MCP
+                           server; until the MCP mechanism lands (#311) it runs
+                           on the tool-less plain path so the model can self-
+                           orchestrate.
+    - ``"none"``       -- the model has no tool support at all (e.g. reasoning
+                           models that reject extra kwargs); runs tool-less.
+
+    Fall-back behaviour when the field is absent from the catalog entry:
+
+    - If the entry has ``"supports_tools": False`` the strategy is inferred as
+      ``"facilitated"`` (preserves pre-migration behaviour).
+    - If the entry has ``"supports_tools": True`` or omits the field entirely,
+      the strategy defaults to ``"native"``.
+    - If the model is not in the catalog at all, ``"native"`` is returned so
+      unknown API models continue to work as before.
 
     Args:
         model_name: The model identifier from ``AgentSpec.model_name``.
-            Can be a display name (``"GPT-4o"``) or a model ID
-            (``"gpt-4o"``).
+            Can be a display name (e.g. ``"GPT-4o"``) or a model ID
+            (e.g. ``"gpt-4o"``).
 
     Returns:
-        ``True`` if the model supports native ``bind_tools`` (use native
-        ``create_agent`` path); ``False`` if it does not (use prompted ReAct
-        path).
+        One of ``"native"``, ``"facilitated"``, ``"mcp"``, or ``"none"``.
     """
     try:
         from bili.iris.config.llm_config import (  # noqa: E402  pylint: disable=import-outside-toplevel
@@ -284,10 +296,10 @@ def resolve_supports_tools(model_name: str) -> bool:
     except ImportError:
         LOGGER.debug(
             "bili.iris.config.llm_config not available; "
-            "assuming supports_tools=True for '%s'",
+            "assuming tool_strategy='native' for '%s'",
             model_name,
         )
-        return True
+        return "native"
 
     for provider_info in LLM_MODELS.values():
         for entry in provider_info.get("models", []):
@@ -295,13 +307,34 @@ def resolve_supports_tools(model_name: str) -> bool:
                 entry.get("model_id") == model_name
                 or entry.get("model_name") == model_name
             ):
-                return entry.get("supports_tools", True)
+                if "tool_strategy" in entry:
+                    return entry["tool_strategy"]
+                # Backward-compat: infer from legacy supports_tools flag.
+                return "native" if entry.get("supports_tools", True) else "facilitated"
 
     LOGGER.debug(
-        "'%s' not found in LLM_MODELS; assuming supports_tools=True",
+        "'%s' not found in LLM_MODELS; assuming tool_strategy='native'",
         model_name,
     )
-    return True
+    return "native"
+
+
+def resolve_supports_tools(model_name: str) -> bool:
+    """Return whether *model_name* supports native ``bind_tools``.
+
+    This is a backward-compatible convenience wrapper around
+    :func:`resolve_tool_strategy`.  Callers that only need a boolean — e.g.
+    legacy code or the Streamlit UI — can continue using this function without
+    change.  Prefer :func:`resolve_tool_strategy` for new code.
+
+    Args:
+        model_name: The model identifier from ``AgentSpec.model_name``.
+
+    Returns:
+        ``True`` when the resolved strategy is ``"native"``; ``False``
+        otherwise.
+    """
+    return resolve_tool_strategy(model_name) == "native"
 
 
 def resolve_tools(agent: AgentSpec) -> list:

--- a/bili/aether/tests/test_compiler.py
+++ b/bili/aether/tests/test_compiler.py
@@ -818,9 +818,12 @@ class TestEnsureHumanLast:
 # PROMPTED TOOL-CALLING TESTS (supports_tools=False path, #304)
 # =========================================================================
 
-# Shared mock targets for resolve_supports_tools.
-# resolve_supports_tools is imported lazily from llm_resolver inside
+# Shared mock targets for resolve_tool_strategy.
+# resolve_tool_strategy is imported lazily from llm_resolver inside
 # _generate_llm_agent_node, so we patch it at the llm_resolver source.
+_MOCK_TOOL_STRATEGY = "bili.aether.compiler.llm_resolver.resolve_tool_strategy"
+
+# Backward-compat alias: tests that still call the wrapper function patch here.
 _MOCK_SUPPORTS_TOOLS = "bili.aether.compiler.llm_resolver.resolve_supports_tools"
 
 
@@ -847,14 +850,14 @@ class TestPromptedToolCalling:
     # ------------------------------------------------------------------
 
     def test_prompted_path_does_not_call_create_agent(self):
-        """A non-tool-calling model with tools must NOT invoke create_agent."""
+        """A facilitated-strategy model with tools must NOT invoke create_agent."""
         agent = _agent("cli_agent", model_name="cli:claude", tools=["mock_tool"])
         mock_tool = self._make_mock_tool("weather", "sunny")
 
         with (
             patch(_MOCK_CREATE) as mock_create_llm,
             patch(_MOCK_TOOLS, return_value=[mock_tool]),
-            patch(_MOCK_SUPPORTS_TOOLS, return_value=False),
+            patch(_MOCK_TOOL_STRATEGY, return_value="facilitated"),
             patch(
                 "bili.iris.nodes.react_agent_node.create_agent"
             ) as patched_create_agent,
@@ -878,7 +881,7 @@ class TestPromptedToolCalling:
         with (
             patch(_MOCK_CREATE) as mock_create_llm,
             patch(_MOCK_TOOLS, return_value=[weather_tool]),
-            patch(_MOCK_SUPPORTS_TOOLS, return_value=False),
+            patch(_MOCK_TOOL_STRATEGY, return_value="facilitated"),
         ):
             mock_llm = MagicMock()
             # First call: model requests the weather tool
@@ -912,7 +915,7 @@ class TestPromptedToolCalling:
         with (
             patch(_MOCK_CREATE) as mock_create_llm,
             patch(_MOCK_TOOLS, return_value=[mock_tool]),
-            patch(_MOCK_SUPPORTS_TOOLS, return_value=False),
+            patch(_MOCK_TOOL_STRATEGY, return_value="facilitated"),
         ):
             mock_llm = MagicMock()
             mock_llm.invoke.return_value = MagicMock(
@@ -942,7 +945,7 @@ class TestPromptedToolCalling:
         with (
             patch(_MOCK_CREATE) as mock_create_llm,
             patch(_MOCK_TOOLS, return_value=[mock_tool]),
-            patch(_MOCK_SUPPORTS_TOOLS, return_value=False),
+            patch(_MOCK_TOOL_STRATEGY, return_value="facilitated"),
         ):
             mock_llm = MagicMock()
             # Always return an unparseable response — loop should cap at 2
@@ -979,7 +982,7 @@ class TestPromptedToolCalling:
         with (
             patch(_MOCK_CREATE) as mock_create_llm,
             patch(_MOCK_TOOLS, return_value=[mock_tool]),
-            patch(_MOCK_SUPPORTS_TOOLS, return_value=True),
+            patch(_MOCK_TOOL_STRATEGY, return_value="native"),
             patch.dict(
                 sys.modules,
                 {"langchain": langchain_stub, "langchain.agents": agents_stub},
@@ -999,13 +1002,13 @@ class TestPromptedToolCalling:
     # ------------------------------------------------------------------
 
     def test_no_tools_path_unchanged(self):
-        """Agent without tools calls LLM directly regardless of supports_tools."""
+        """Agent without tools calls LLM directly regardless of tool_strategy."""
         agent = _agent("direct_agent", model_name="gpt-4o")
 
         with (
             patch(_MOCK_CREATE) as mock_create_llm,
             patch(_MOCK_TOOLS, return_value=[]),
-            patch(_MOCK_SUPPORTS_TOOLS, return_value=False),
+            patch(_MOCK_TOOL_STRATEGY, return_value="facilitated"),
         ):
             mock_llm = MagicMock()
             mock_llm.invoke.return_value = MagicMock(content="direct answer")
@@ -1069,3 +1072,158 @@ class TestPromptedToolCalling:
             # Should not raise; defaults to True
             result = resolve_supports_tools("any-model")
             assert result is True
+
+    # ------------------------------------------------------------------
+    # resolve_tool_strategy
+    # ------------------------------------------------------------------
+
+    def test_resolve_tool_strategy_returns_field_when_present(self):
+        """resolve_tool_strategy reads the tool_strategy field directly."""
+        from bili.aether.compiler.llm_resolver import resolve_tool_strategy
+
+        mock_models = {
+            "remote_openai": {
+                "models": [
+                    {
+                        "model_name": "OpenAI GPT-4o Omni",
+                        "model_id": "gpt-4o",
+                        "tool_strategy": "native",
+                        "supports_tools": True,
+                    },
+                ]
+            },
+            "remote_deepseek": {
+                "models": [
+                    {
+                        "model_name": "DeepSeek Reasoner",
+                        "model_id": "deepseek-reasoner",
+                        "tool_strategy": "none",
+                        "supports_tools": False,
+                    },
+                ]
+            },
+        }
+        with patch("bili.iris.config.llm_config.LLM_MODELS", mock_models):
+            assert resolve_tool_strategy("gpt-4o") == "native"
+            assert resolve_tool_strategy("deepseek-reasoner") == "none"
+            # Lookup by display name also works.
+            assert resolve_tool_strategy("OpenAI GPT-4o Omni") == "native"
+
+    def test_resolve_tool_strategy_infers_from_supports_tools_when_field_absent(self):
+        """resolve_tool_strategy infers from supports_tools when tool_strategy absent."""
+        from bili.aether.compiler.llm_resolver import resolve_tool_strategy
+
+        mock_models = {
+            "remote_aws_bedrock": {
+                "models": [
+                    {
+                        "model_name": "Legacy True",
+                        "model_id": "legacy-true",
+                        "supports_tools": True,
+                    },
+                    {
+                        "model_name": "Legacy False",
+                        "model_id": "legacy-false",
+                        "supports_tools": False,
+                    },
+                ]
+            }
+        }
+        with patch("bili.iris.config.llm_config.LLM_MODELS", mock_models):
+            assert resolve_tool_strategy("legacy-true") == "native"
+            assert resolve_tool_strategy("legacy-false") == "facilitated"
+
+    def test_resolve_tool_strategy_defaults_to_native_for_unknown_model(self):
+        """resolve_tool_strategy defaults to 'native' when model is not in catalog."""
+        from bili.aether.compiler.llm_resolver import resolve_tool_strategy
+
+        mock_models = {"remote_openai": {"models": []}}
+        with patch("bili.iris.config.llm_config.LLM_MODELS", mock_models):
+            assert resolve_tool_strategy("unknown-model-xyz") == "native"
+
+    def test_resolve_tool_strategy_returns_native_on_import_error(self):
+        """resolve_tool_strategy defaults to 'native' when LLM_MODELS cannot be imported."""
+        from bili.aether.compiler.llm_resolver import resolve_tool_strategy
+
+        with patch(
+            "bili.iris.config.llm_config.LLM_MODELS",
+            side_effect=ImportError("no module"),
+            create=True,
+        ):
+            result = resolve_tool_strategy("any-model")
+            assert result == "native"
+
+    def test_resolve_tool_strategy_mcp_and_none_values(self):
+        """resolve_tool_strategy returns 'mcp' and 'none' for the new strategy values."""
+        from bili.aether.compiler.llm_resolver import resolve_tool_strategy
+
+        mock_models = {
+            "cli_claude_code": {
+                "models": [
+                    {
+                        "model_name": "Claude Code CLI",
+                        "model_id": "cli:claude_code",
+                        "tool_strategy": "mcp",
+                        "supports_tools": False,
+                    },
+                ]
+            },
+            "remote_openai": {
+                "models": [
+                    {
+                        "model_name": "OpenAI o1-mini",
+                        "model_id": "o1-mini",
+                        "tool_strategy": "none",
+                        "supports_tools": False,
+                    },
+                ]
+            },
+        }
+        with patch("bili.iris.config.llm_config.LLM_MODELS", mock_models):
+            assert resolve_tool_strategy("cli:claude_code") == "mcp"
+            assert resolve_tool_strategy("o1-mini") == "none"
+
+    # ------------------------------------------------------------------
+    # mcp and none routing in _generate_tool_agent_node
+    # ------------------------------------------------------------------
+
+    def test_mcp_strategy_drops_tools_and_uses_direct_llm(self):
+        """An 'mcp' strategy drops tools and routes to the direct-LLM node."""
+        agent = _agent("cli_agent", model_name="cli:claude_code", tools=["mock_tool"])
+        mock_tool = self._make_mock_tool("mock_tool", "some output")
+
+        with (
+            patch(_MOCK_CREATE) as mock_create_llm,
+            patch(_MOCK_TOOLS, return_value=[mock_tool]),
+            patch(_MOCK_TOOL_STRATEGY, return_value="mcp"),
+        ):
+            mock_llm = MagicMock()
+            mock_llm.invoke.return_value = MagicMock(content="direct mcp answer")
+            mock_create_llm.return_value = mock_llm
+
+            node_fn = generate_agent_node(agent)
+            result = node_fn({"messages": [], "agent_outputs": {}})
+
+            # Direct LLM path: llm.invoke was called; result carries the response.
+            mock_llm.invoke.assert_called_once()
+            assert result["current_agent"] == "cli_agent"
+
+    def test_none_strategy_drops_tools_and_uses_direct_llm(self):
+        """A 'none' strategy drops tools and routes to the direct-LLM node."""
+        agent = _agent("reasoner", model_name="deepseek-reasoner", tools=["mock_tool"])
+        mock_tool = self._make_mock_tool("mock_tool", "some output")
+
+        with (
+            patch(_MOCK_CREATE) as mock_create_llm,
+            patch(_MOCK_TOOLS, return_value=[mock_tool]),
+            patch(_MOCK_TOOL_STRATEGY, return_value="none"),
+        ):
+            mock_llm = MagicMock()
+            mock_llm.invoke.return_value = MagicMock(content="reasoner answer")
+            mock_create_llm.return_value = mock_llm
+
+            node_fn = generate_agent_node(agent)
+            result = node_fn({"messages": [], "agent_outputs": {}})
+
+            mock_llm.invoke.assert_called_once()
+            assert result["current_agent"] == "reasoner"

--- a/bili/iris/config/llm_config.py
+++ b/bili/iris/config/llm_config.py
@@ -58,6 +58,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Amazon Nova Premier",
@@ -71,6 +73,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Amazon Nova Lite",
@@ -84,6 +88,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Amazon Nova Micro",
@@ -97,6 +103,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             # Amazon Titan Models (3)
             # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-text.html
@@ -113,6 +121,7 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "none",
                 "supports_tools": False,
             },
             {
@@ -127,6 +136,7 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "none",
                 "supports_tools": False,
             },
             {
@@ -141,6 +151,7 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "none",
                 "supports_tools": False,
             },
             # AI21 Labs Models (2)
@@ -158,6 +169,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "AI21 Jamba 1.5 Mini",
@@ -172,6 +185,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             # Anthropic Models (10)
             # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html
@@ -188,6 +203,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Anthropic Claude 3.5 Haiku",
@@ -201,6 +218,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Anthropic Claude 3 Opus",
@@ -214,6 +233,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Anthropic Claude Opus 4",
@@ -227,6 +248,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Anthropic Claude Opus 4.1",
@@ -240,6 +263,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Anthropic Claude 3 Sonnet",
@@ -253,6 +278,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Anthropic Claude 3.5 Sonnet",
@@ -266,6 +293,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Anthropic Claude 3.5 Sonnet v2",
@@ -279,6 +308,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Anthropic Claude 3.7 Sonnet",
@@ -292,6 +323,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Anthropic Claude Sonnet 4.6",
@@ -305,6 +338,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             # Cohere Models (2)
             # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-cohere-command.html
@@ -322,6 +357,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 500,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Cohere Command R+",
@@ -335,6 +372,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 500,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             # DeepSeek Models (1)
             # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-deepseek.html
@@ -349,6 +388,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             # Meta LLama Models (11)
             # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html
@@ -364,6 +405,7 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
             },
             {
@@ -377,6 +419,7 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
             },
             {
@@ -391,6 +434,7 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
             },
             {
@@ -405,6 +449,7 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
             },
             {
@@ -419,6 +464,7 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
             },
             {
@@ -433,6 +479,7 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
             },
             {
@@ -447,6 +494,7 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
             },
             {
@@ -461,6 +509,7 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
             },
             {
@@ -475,6 +524,7 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
             },
             {
@@ -489,6 +539,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                # TODO: verify Llama 4 bind_tools on Bedrock Converse API; may upgrade to "native"
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
             },
             {
@@ -503,6 +555,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 50,
+                # TODO: verify Llama 4 bind_tools on Bedrock Converse API; may upgrade to "native"
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
             },
             # Minstral AI Models (5)
@@ -520,6 +574,7 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
             },
             {
@@ -533,6 +588,7 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
             },
             {
@@ -547,6 +603,7 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 200,
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
             },
             {
@@ -561,6 +618,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 200,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Mistral Pixtral Large",
@@ -573,6 +632,7 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
                 "supports_tools": True,
             },
             # TwelveLabs Models (1)
@@ -588,6 +648,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
         ],
     },
@@ -618,6 +680,8 @@ LLM_MODELS = {
                 "supports_thinking_budget": True,
                 "thinking_budget_max": 24576,
                 "thinking_budget_default": 0,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Gemini 2.5 Flash",
@@ -637,6 +701,8 @@ LLM_MODELS = {
                 "supports_thinking_budget": True,
                 "thinking_budget_max": 24576,
                 "thinking_budget_default": 0,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Gemini 2.5 Flash Lite",
@@ -656,6 +722,8 @@ LLM_MODELS = {
                 "supports_thinking_budget": True,
                 "thinking_budget_max": 24576,
                 "thinking_budget_default": 0,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Gemini 2.0 Flash",
@@ -669,6 +737,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 40,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Gemini 2.0 Flash Lite",
@@ -682,6 +752,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 40,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Gemini 1.5 Pro 002",
@@ -695,6 +767,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 40,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Gemini 1.5 Pro",
@@ -708,6 +782,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 40,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Gemini 1.5 Flash",
@@ -721,6 +797,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 40,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Gemini 1.5 Flash 002",
@@ -734,6 +812,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 40,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
             {
                 "model_name": "Gemini 1.0 Pro",
@@ -747,6 +827,8 @@ LLM_MODELS = {
                 "supports_top_p": True,
                 "supports_top_k": True,
                 "top_k_max": 40,
+                "tool_strategy": "native",
+                "supports_tools": True,
             },
         ],
     },
@@ -774,6 +856,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "kwargs": {
                     "api_version": "2024-08-01-preview",
                 },
@@ -789,6 +873,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "kwargs": {
                     "api_version": "2024-08-01-preview",
                 },
@@ -804,6 +890,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "kwargs": {
                     "api_version": "2024-08-01-preview",
                 },
@@ -819,6 +907,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "kwargs": {
                     "api_version": "2024-08-01-preview",
                 },
@@ -834,6 +924,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "kwargs": {
                     "api_version": "2024-08-01-preview",
                 },
@@ -849,6 +941,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "kwargs": {
                     "api_version": "2024-08-01-preview",
                 },
@@ -864,6 +958,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "kwargs": {
                     "api_version": "2025-01-01-preview",
                 },
@@ -879,10 +975,11 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "none",
+                "supports_tools": False,
                 "kwargs": {
                     "api_version": "2025-01-01-preview",
                 },
-                "supports_tools": False,
             },
             {
                 "model_name": "Azure OpenAI o3",
@@ -895,6 +992,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": False,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "kwargs": {
                     "api_version": "2025-01-01-preview",
                 },
@@ -910,6 +1009,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": False,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "kwargs": {
                     "api_version": "2025-01-01-preview",
                 },
@@ -925,6 +1026,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": False,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "kwargs": {
                     "api_version": "2025-01-01-preview",
                 },
@@ -940,6 +1043,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": False,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "kwargs": {
                     "api_version": "2025-01-01-preview",
                 },
@@ -955,6 +1060,7 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
                 "kwargs": {
                     "api_version": "2024-08-01-preview",
@@ -971,6 +1077,7 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
                 "kwargs": {
                     "api_version": "2024-08-01-preview",
@@ -996,6 +1103,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 3,
                 "max_retries_max": 10,
@@ -1011,6 +1120,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 3,
                 "max_retries_max": 10,
@@ -1026,6 +1137,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 3,
                 "max_retries_max": 10,
@@ -1041,6 +1154,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 3,
                 "max_retries_max": 10,
@@ -1056,6 +1171,7 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "none",
                 "supports_tools": False,
                 "supports_max_retries": True,
                 "max_retries_default": 3,
@@ -1072,6 +1188,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": False,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 3,
                 "max_retries_max": 10,
@@ -1087,6 +1205,7 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
                 "supports_max_retries": True,
                 "max_retries_default": 3,
@@ -1118,6 +1237,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": True,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1133,6 +1254,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": True,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1148,6 +1271,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": True,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1163,6 +1288,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": True,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1192,6 +1319,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1207,6 +1336,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1222,6 +1353,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1251,6 +1384,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": True,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1266,6 +1401,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": True,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1281,6 +1418,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": True,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1317,6 +1456,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": True,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1332,6 +1473,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": True,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1347,6 +1490,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": True,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1377,6 +1522,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1392,6 +1539,7 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": False,
                 "supports_top_k": False,
+                "tool_strategy": "none",
                 "supports_tools": False,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
@@ -1422,6 +1570,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1437,6 +1587,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1466,6 +1618,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1481,6 +1635,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1496,6 +1652,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1511,6 +1669,8 @@ LLM_MODELS = {
                 "supports_max_output_tokens": True,
                 "supports_top_p": True,
                 "supports_top_k": False,
+                "tool_strategy": "native",
+                "supports_tools": True,
                 "supports_max_retries": True,
                 "max_retries_default": 2,
                 "max_retries_max": 10,
@@ -1548,7 +1708,9 @@ LLM_MODELS = {
                 "supports_top_p": False,
                 "supports_top_k": False,
                 # CLI tools run as a subprocess -- tool-calling via the
-                # LangChain bind_tools() API is not available.
+                # LangChain bind_tools() API is not available.  These models
+                # are agentic CLIs best driven as MCP servers (#311).
+                "tool_strategy": "mcp",
                 "supports_tools": False,
             },
         ],
@@ -1581,6 +1743,7 @@ LLM_MODELS = {
                 "supports_max_output_tokens": False,
                 "supports_top_p": False,
                 "supports_top_k": False,
+                "tool_strategy": "mcp",
                 "supports_tools": False,
             },
         ],
@@ -1603,6 +1766,7 @@ LLM_MODELS = {
                 "supports_max_output_tokens": False,
                 "supports_top_p": False,
                 "supports_top_k": False,
+                "tool_strategy": "mcp",
                 "supports_tools": False,
             },
         ],
@@ -1625,6 +1789,7 @@ LLM_MODELS = {
                 "supports_max_output_tokens": False,
                 "supports_top_p": False,
                 "supports_top_k": False,
+                "tool_strategy": "mcp",
                 "supports_tools": False,
             },
         ],
@@ -1652,6 +1817,7 @@ LLM_MODELS = {
                 # If you wanted to manually use tools, you can create the LLM and bind
                 # tool calls differently than create_react_agent does in the default
                 # implementation in bili.loaders.langchain_loader.load_langgraph_agent
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
             },
         ],
@@ -1677,6 +1843,7 @@ LLM_MODELS = {
                 # If you wanted to manually use tools, you can create the LLM and bind
                 # tool calls differently than create_react_agent does in the default
                 # implementation in bili.loaders.langchain_loader.load_langgraph_agent
+                "tool_strategy": "facilitated",
                 "supports_tools": False,
             },
         ],

--- a/bili/iris/nodes/react_agent_node.py
+++ b/bili/iris/nodes/react_agent_node.py
@@ -476,36 +476,51 @@ def build_react_agent_node(
 ):
     """Construct a REACT agent node, selecting the appropriate execution mode.
 
-    Three modes are available, selected automatically:
+    Four modes are available, selected by ``tool_strategy`` (or the legacy
+    ``supports_tools`` kwarg):
 
-    **Native tool-calling** (``tools`` is not ``None`` and ``supports_tools`` is
-    ``True`` or omitted):
+    **Native tool-calling** (``tool_strategy="native"``, the default):
         Builds a compiled LangGraph sub-graph via ``create_agent`` + ``bind_tools``.
         Requires the model to implement ``BaseChatModel.bind_tools`` (all major API
         providers do).
 
-    **Prompted tool-calling** (``tools`` is not ``None`` and ``supports_tools=False``
-    is passed via ``**kwargs``):
+    **Prompted tool-calling** (``tool_strategy="facilitated"``):
         Runs a hand-rolled ReAct loop inside the node.  Tools are described in a
         system-message preamble; the model's text output is parsed for
         ``Action:`` / ``Final Answer:`` markers.  Compatible with any model that
-        can follow text instructions, including CLI-backed models that do not
-        implement ``bind_tools``.  Does not call ``create_agent`` and never invokes
-        ``bind_tools``.
+        can follow text instructions.  Does not call ``create_agent`` and never
+        invokes ``bind_tools``.
 
-        Extra ``**kwargs`` for this mode:
+    **MCP / agentic CLI** (``tool_strategy="mcp"``):
+        Interim behaviour until the MCP mechanism is implemented: tools are dropped
+        and the model runs on the plain tool-less path so it can self-orchestrate.
+        Passing ``bind_tools`` kwargs to an agentic CLI raises; dropping tools is
+        the safe interim behaviour.
 
-        - ``supports_tools`` (``bool``, default ``True``): set ``False`` to engage
-          the prompted path.
-        - ``max_react_iterations`` (``int``, default 10): cap on
-          Thought/Action/Observation iterations.
+    **No-tool model** (``tool_strategy="none"``):
+        The model has no tool support (e.g. some reasoning models).  Tools are
+        dropped and the model runs on the plain tool-less path.
 
     **Tool-less fallback** (``tools`` is ``None``):
         Calls the model directly, filtering ToolMessages from history for
         compatibility with models that reject them.
 
-    :param tools: List of tools for the agent.  ``None`` engages the tool-less
-        fallback regardless of ``supports_tools``.
+    Backward compatibility: the legacy ``supports_tools`` (``bool``) kwarg is
+    still accepted.  When ``tool_strategy`` is absent, the router infers the
+    strategy: ``supports_tools=True`` (or absent) maps to ``"native"``; ``False``
+    maps to ``"facilitated"``.  Prefer passing ``tool_strategy`` explicitly.
+
+    Extra ``**kwargs`` recognised:
+
+    - ``tool_strategy`` (``str``): ``"native"`` | ``"facilitated"`` | ``"mcp"`` |
+      ``"none"`` -- the authoritative routing key.
+    - ``supports_tools`` (``bool``): legacy convenience; ignored when
+      ``tool_strategy`` is provided.
+    - ``max_react_iterations`` (``int``, default 10): iteration cap for the
+      prompted (``"facilitated"``) path.
+
+    :param tools: List of tools for the agent.  ``None`` (or a strategy of
+        ``"mcp"``/``"none"``) engages the tool-less path.
     :type tools: list[Tool] or None
 
     :param state: State schema (must subclass ``AgentState``).  Used only by the
@@ -518,29 +533,32 @@ def build_react_agent_node(
         path.  Ignored on the prompted and fallback paths.
     :type middleware: list or None
 
-    :param kwargs: Additional node configuration.  Recognised keys:
-
-        - ``supports_tools`` (``bool``): capability flag; see above.
-        - ``max_react_iterations`` (``int``): iteration cap for the prompted path.
+    :param kwargs: Additional node configuration; see recognised keys above.
 
     :return: A compiled ``CompiledStateGraph`` (native path) or a plain callable
         ``(state: dict) -> dict`` (prompted and fallback paths).
     :rtype: CompiledStateGraph or Callable
     """
-    supports_tools = kwargs.get("supports_tools", True)
+    # Resolve tool_strategy, falling back to the legacy supports_tools bool.
+    tool_strategy = kwargs.get("tool_strategy")
+    if tool_strategy is None:
+        tool_strategy = (
+            "native" if kwargs.get("supports_tools", True) else "facilitated"
+        )
+
     max_react_iterations = kwargs.get(
         "max_react_iterations", _DEFAULT_MAX_REACT_ITERATIONS
     )
 
     LOGGER.debug(
-        "Using model: %s | Tools provided: %s | supports_tools: %s | Middleware count: %s",
+        "Using model: %s | Tools provided: %s | tool_strategy: %s | Middleware count: %s",
         getattr(llm_model, "__class__", None),
         tools is not None,
-        supports_tools,
+        tool_strategy,
         len(middleware) if middleware else 0,
     )
 
-    if tools is not None and supports_tools:
+    if tools is not None and tool_strategy == "native":
         # Native path: the model implements bind_tools; delegate to create_agent.
         LOGGER.debug(
             "Native tool-calling path: creating REACT agent with tools: %s", tools
@@ -552,7 +570,7 @@ def build_react_agent_node(
             middleware=middleware or (),
         )
 
-    elif tools is not None and not supports_tools:
+    elif tools is not None and tool_strategy == "facilitated":
         # Prompted path: the model cannot bind_tools; run the ReAct loop ourselves.
         LOGGER.debug(
             "Prompted tool-calling path: model does not support bind_tools; "
@@ -566,8 +584,22 @@ def build_react_agent_node(
             max_react_iterations=max_react_iterations,
         )
 
-    else:
-        # Tool-less fallback: no tools provided; call the model directly.
+    elif tools is not None and tool_strategy in ("mcp", "none"):
+        # MCP/none interim path: drop tools; let the model run plain.
+        # "mcp" models are agentic CLIs that self-orchestrate; "none" models
+        # reject tool kwargs entirely.  Both run tool-less until the MCP
+        # mechanism is in place.
+        LOGGER.debug(
+            "Tool-less interim path for strategy '%s': dropping %d tool(s); "
+            "model runs plain.",
+            tool_strategy,
+            len(tools),
+        )
+        tools = None
+        # Fall through to the tool-less branch below.
+
+    if tools is None:
+        # Tool-less fallback: no tools provided (or dropped above); call the model directly.
         LOGGER.debug(
             "Tool-less fallback path: no tools provided; invoking the LLM directly "
             "and converting the state to a format the LLM can understand."

--- a/bili/iris/nodes/tests/test_react_agent_node.py
+++ b/bili/iris/nodes/tests/test_react_agent_node.py
@@ -768,3 +768,103 @@ class TestAutoSelection:
         mock_prompted_factory.assert_called_once()
         call_kwargs = mock_prompted_factory.call_args.kwargs
         assert call_kwargs["max_react_iterations"] == 5
+
+
+class TestToolStrategyRouting:
+    """Verify tool_strategy kwarg routing in build_react_agent_node.
+
+    These tests exercise the tool_strategy parameter directly.  The legacy
+    supports_tools tests in TestAutoSelection continue to cover the backward-
+    compat fallback path.
+    """
+
+    @patch("bili.iris.nodes.react_agent_node.create_agent")
+    def test_native_strategy_calls_create_agent(self, mock_create_agent):
+        """tool_strategy='native' -> create_agent called (same as supports_tools=True)."""
+        mock_create_agent.return_value = MagicMock()
+        tool = _make_tool("t")
+
+        build_react_agent_node(
+            tools=[tool], llm_model=MagicMock(), tool_strategy="native"
+        )
+
+        mock_create_agent.assert_called_once()
+
+    @patch("bili.iris.nodes.react_agent_node.create_agent")
+    def test_facilitated_strategy_skips_create_agent(self, mock_create_agent):
+        """tool_strategy='facilitated' -> create_agent NOT called; callable returned."""
+        tool = _make_tool("t")
+
+        result = build_react_agent_node(
+            tools=[tool], llm_model=MagicMock(), tool_strategy="facilitated"
+        )
+
+        mock_create_agent.assert_not_called()
+        assert callable(result)
+
+    @patch("bili.iris.nodes.react_agent_node.create_agent")
+    def test_mcp_strategy_drops_tools_runs_plain(self, mock_create_agent):
+        """tool_strategy='mcp' -> tools dropped, model runs tool-less."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = AIMessage(content="mcp plain")
+        tool = _make_tool("t")
+
+        result = build_react_agent_node(
+            tools=[tool], llm_model=mock_llm, tool_strategy="mcp"
+        )
+
+        mock_create_agent.assert_not_called()
+        assert callable(result)
+        # Invoke the returned callable to confirm it runs the tool-less path.
+        state = {"messages": [HumanMessage(content="hi")]}
+        out = result(state)
+        assert "messages" in out
+        mock_llm.invoke.assert_called_once()
+
+    @patch("bili.iris.nodes.react_agent_node.create_agent")
+    def test_none_strategy_drops_tools_runs_plain(self, mock_create_agent):
+        """tool_strategy='none' -> tools dropped, model runs tool-less."""
+        mock_llm = MagicMock()
+        mock_llm.invoke.return_value = AIMessage(content="none plain")
+        tool = _make_tool("t")
+
+        result = build_react_agent_node(
+            tools=[tool], llm_model=mock_llm, tool_strategy="none"
+        )
+
+        mock_create_agent.assert_not_called()
+        assert callable(result)
+        state = {"messages": [HumanMessage(content="hello")]}
+        out = result(state)
+        assert "messages" in out
+        mock_llm.invoke.assert_called_once()
+
+    @patch("bili.iris.nodes.react_agent_node.create_agent")
+    def test_tool_strategy_takes_precedence_over_supports_tools(
+        self, mock_create_agent
+    ):
+        """When tool_strategy is explicit, supports_tools is ignored."""
+        tool = _make_tool("t")
+
+        # tool_strategy='facilitated' must win even though supports_tools=True.
+        result = build_react_agent_node(
+            tools=[tool],
+            llm_model=MagicMock(),
+            tool_strategy="facilitated",
+            supports_tools=True,
+        )
+
+        mock_create_agent.assert_not_called()
+        assert callable(result)
+
+    @patch("bili.iris.nodes.react_agent_node.create_agent")
+    def test_supports_tools_false_still_routes_facilitated(self, mock_create_agent):
+        """Legacy supports_tools=False infers 'facilitated' when tool_strategy absent."""
+        tool = _make_tool("t")
+
+        result = build_react_agent_node(
+            tools=[tool], llm_model=MagicMock(), supports_tools=False
+        )
+
+        mock_create_agent.assert_not_called()
+        assert callable(result)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -230,10 +230,12 @@ The configuration module holds declarative metadata for every supported LLM mode
 | `cli_codex` | OpenAI Codex CLI preset (`codex exec`) |
 | `cli_gemini_cli` | Google Gemini CLI preset (`gemini -p`) |
 
-Each model entry carries a `supports_tools` boolean (default `True`). CLI and
-local models set it to `False`; callers pass it as `supports_tools` in
-`node_kwargs` to auto-select the native or prompted ReAct path in
-`build_react_agent_node`.
+Each model entry carries a `tool_strategy` field (one of `"native"`,
+`"facilitated"`, `"mcp"`, `"none"`) and a derived `supports_tools` boolean
+(`True` only when `tool_strategy == "native"`). The strategy drives automatic
+path selection in `build_react_agent_node`. Pass `tool_strategy` explicitly in
+`node_kwargs` to override the catalog value; the legacy `supports_tools` kwarg
+is still accepted as a backward-compatible fallback.
 
 Factory pattern initialization via `llm_loader.py`.
 
@@ -248,15 +250,20 @@ START → persona_summary → datetime → react_agent → timestamp → trim_su
 
 **Tool-calling modes in `react_agent_node.py`:**
 
-`build_react_agent_node` selects one of three execution paths automatically based on `node_kwargs`:
+`build_react_agent_node` selects the execution path from `tool_strategy` in `node_kwargs` (or infers it from the legacy `supports_tools` bool):
 
-| Condition | Path | Mechanism |
+| `tool_strategy` | Condition | Mechanism |
 |---|---|---|
-| `tools` provided + `supports_tools=True` (default) | Native | `create_agent` via `model.bind_tools` — all API providers |
-| `tools` provided + `supports_tools=False` | Prompted ReAct | Hand-rolled Action/Observation loop injected into system message — CLI, local, and text-only models |
-| `tools=None` | Tool-less fallback | Direct `llm_model.invoke` call, no tool dispatch |
+| `"native"` (default) | `tools` provided | `create_agent` via `model.bind_tools` — all API providers |
+| `"facilitated"` | `tools` provided | Hand-rolled Action/Observation loop injected into system message — local and text-only models |
+| `"mcp"` | `tools` provided | Tools dropped; model runs plain (interim until MCP mechanism lands) — agentic CLI tools |
+| `"none"` | `tools` provided | Tools dropped; model runs plain — models that reject tool kwargs (e.g. some reasoning models) |
+| any | `tools=None` | Direct `llm_model.invoke` call, no tool dispatch |
 
-Set `supports_tools=False` in `node_kwargs` for CLI presets (`cli_claude_code`, `cli_codex`, `cli_gemini_cli`), local models (`local_llamacpp`, `local_huggingface`), or any model that cannot call `bind_tools`. Both paths accept the same agent definition; the node selects the path at runtime.
+AETHER resolves `tool_strategy` automatically from the catalog via
+`resolve_tool_strategy(model_name)`. IRIS callers can pass `tool_strategy`
+explicitly in `node_kwargs`; the legacy `supports_tools` kwarg remains
+accepted for backward compatibility.
 
 ### 5. Fallback Engine (`bili/iris/providers/fallback.py`) -- IRIS
 

--- a/docs/STREAMLIT.md
+++ b/docs/STREAMLIT.md
@@ -279,7 +279,7 @@ The Streamlit application uses `st.session_state` extensively to maintain state 
 | Variable | Type | Description |
 |----------|------|-------------|
 | `selected_tools` | `list[str]` | List of enabled tool names |
-| `supports_tools` | `bool` | Whether selected model supports tools |
+| `supports_tools` | `bool` | Whether selected model supports native tool-calling (derived from `tool_strategy` in the catalog) |
 | `{tool}_enabled` | `bool` | Enable flag for each tool |
 | `{tool}_prompt` | `str` | Custom prompt for each tool |
 | `{tool}_{param}` | `varies` | Tool-specific parameters |
@@ -1075,7 +1075,7 @@ graph_definition.insert(index, custom_node(edges=["next_node"]))
 | Configuration not loading | Check console for errors, verify API credentials |
 | Authentication loop | Clear browser cookies, check auth provider config |
 | Memory issues with large conversations | Reduce `k` value or use `trim` strategy |
-| Tools not appearing | Verify `supports_tools` for selected model |
+| Tools not appearing | Check `tool_strategy` for selected model in the catalog (`supports_tools` is derived from it) |
 
 ### Debug Mode
 


### PR DESCRIPTION
## Summary

Replaces the binary `supports_tools` flag with a richer `tool_strategy` enum
(`"native" | "facilitated" | "mcp" | "none"`) on every LLM_MODELS entry and
routes both the IRIS and AETHER agent nodes off it.

The binary flag collapsed three fundamentally different categories into two:
API tool-calling models, agentic CLI tools (which self-orchestrate), and
text-only models that follow prompted ReAct. A two-value bool cannot express
that distinction accurately.

## Changes

### `bili/iris/config/llm_config.py`
Add `tool_strategy` to all 97 catalog entries; keep `supports_tools` as an
explicit derived field (`True` iff strategy == `"native"`) for backward
compatibility with callers that read it directly.

| Strategy | Count | Examples |
|---|---|---|
| `"native"` | 69 | All API providers (Bedrock Claude/Nova/Cohere/AI21, Gemini, Azure, OpenAI, Anthropic, Mistral, Cohere, Grok, Groq) |
| `"facilitated"` | 18 | Meta Llama 3–4 Bedrock (conservative), Mistral 7B/Large/Small Bedrock, GPT-3.5, LlamaCpp, HuggingFace |
| `"mcp"` | 4 | Claude Code CLI, Codex CLI, Gemini CLI, generic CLI |
| `"none"` | 6 | Amazon Titan G1 (×3), Azure o1-mini, OpenAI o1-mini, DeepSeek Reasoner |

### `bili/aether/compiler/llm_resolver.py`
- Add `resolve_tool_strategy(model_name) -> str`: authoritative catalog lookup
  with legacy-flag inference fallback and `"native"` default for unknowns.
- Make `resolve_supports_tools` a one-liner: `return resolve_tool_strategy(...) == "native"`.

### `bili/iris/nodes/react_agent_node.py`
Update `build_react_agent_node` to read `tool_strategy` from `node_kwargs`
with `supports_tools` backward-compat fallback:
- `"native"` → create_agent path
- `"facilitated"` → prompted ReAct loop
- `"mcp"` or `"none"` → drop tools, run plain (interim until #311)

### `bili/aether/compiler/agent_generator.py`
Import `resolve_tool_strategy`; rename `_generate_tool_agent_node` param from
`supports_tools: bool` to `tool_strategy: str`; route `"mcp"`/`"none"` to
`_generate_direct_llm_node`.

### Tests
3774 existing tests continue to pass. Updated `TestPromptedToolCalling` to
patch `resolve_tool_strategy`. New tests: `resolve_tool_strategy` unit tests
(field present, legacy fallback, unknown model, import error, mcp/none values),
mcp/none routing in AETHER, new `TestToolStrategyRouting` class in IRIS node
tests (native/facilitated/mcp/none kwargs, precedence, backward compat).

### Docs
README, `docs/ARCHITECTURE.md`, `docs/STREAMLIT.md` updated to enumerate the
four strategy values and remove stale `supports_tools=False` guidance.

## Test plan

- [x] `python -m pytest -q --tb=no -k "not pipeline_agents"` — 3774 pass
- [x] `python scripts/check_coverage.py` — all 214 runtime files >= 90%
- [x] `pre-commit run` on all modified files — Black, isort, autoflake, pylint all pass