### PR TITLE
fix: review-followup cleanup (UnboundLocalError guard, [all] extra, CLI preset docs, import-error test)

### DIFF
--- a/bili/aether/compiler/llm_resolver.py
+++ b/bili/aether/compiler/llm_resolver.py
@@ -327,6 +327,11 @@ def resolve_supports_tools(model_name: str) -> bool:
     legacy code or the Streamlit UI — can continue using this function without
     change.  Prefer :func:`resolve_tool_strategy` for new code.
 
+    Note: this function inspects only the primary *model_name*.  When a
+    ``FallbackLLM`` chain mixes a tool-capable primary with a non-tool-capable
+    fallback, this function reports the primary's capability only; the fallback
+    model's strategy is not checked here.
+
     Args:
         model_name: The model identifier from ``AgentSpec.model_name``.
 

--- a/bili/aether/tests/test_compiler.py
+++ b/bili/aether/tests/test_compiler.py
@@ -1061,15 +1061,18 @@ class TestPromptedToolCalling:
             assert resolve_supports_tools("unknown-model-xyz") is True
 
     def test_resolve_supports_tools_returns_true_on_import_error(self):
-        """resolve_supports_tools returns True when LLM_MODELS cannot be imported."""
+        """resolve_supports_tools returns True when bili.iris.config.llm_config is absent.
+
+        Setting sys.modules["bili.iris.config.llm_config"] = None forces Python's
+        import machinery to raise ImportError on the lazy ``from bili.iris.config...
+        import LLM_MODELS`` inside resolve_tool_strategy, exercising the real
+        except-ImportError branch.  The previous patch of the module attribute did
+        not trigger that branch (the import succeeded from cache).
+        """
         from bili.aether.compiler.llm_resolver import resolve_supports_tools
 
-        with patch(
-            "bili.iris.config.llm_config.LLM_MODELS",
-            side_effect=ImportError("no module"),
-            create=True,
-        ):
-            # Should not raise; defaults to True
+        with patch.dict(sys.modules, {"bili.iris.config.llm_config": None}):
+            # Should not raise; ImportError path defaults to True (via "native").
             result = resolve_supports_tools("any-model")
             assert result is True
 

--- a/bili/iris/config/llm_config.py
+++ b/bili/iris/config/llm_config.py
@@ -620,9 +620,6 @@ LLM_MODELS = {
             # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-mistral-large-2407.html
             # https://docs.mistral.ai/getting-started/models/models_overview/
             # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-mistral-text-completion.html
-            # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-mistral-large-2407.html
-            # https://docs.mistral.ai/getting-started/models/models_overview/
-            # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-mistral-text-completion.html
             {
                 # Superseded by Mistral Large 2407 and Large 3. Kept for existing deployments.
                 "model_name": "Mistral Large",

--- a/bili/iris/nodes/react_agent_node.py
+++ b/bili/iris/nodes/react_agent_node.py
@@ -558,6 +558,11 @@ def build_react_agent_node(
         len(middleware) if middleware else 0,
     )
 
+    # Routing branches set 'agent'; the ValueError branch raises, so 'agent'
+    # is guaranteed to be bound on all non-raising exit paths.  pylint cannot
+    # deduce this from the if/elif chain, so we initialize it here.
+    agent = None
+
     if tools is not None and tool_strategy == "native":
         # Native path: the model implements bind_tools; delegate to create_agent.
         LOGGER.debug(
@@ -597,6 +602,16 @@ def build_react_agent_node(
         )
         tools = None
         # Fall through to the tool-less branch below.
+
+    elif tools is not None:
+        # A non-canonical tool_strategy value was passed with tools set.
+        # Without this guard, none of the branches above would assign 'agent',
+        # causing an UnboundLocalError on 'return agent'.  Raise early with a
+        # clear message so misconfigured callers see the problem immediately.
+        raise ValueError(
+            f"Unknown tool_strategy={tool_strategy!r}.  "
+            f"Expected one of 'native', 'facilitated', 'mcp', or 'none'."
+        )
 
     if tools is None:
         # Tool-less fallback: no tools provided (or dropped above); call the model directly.

--- a/bili/iris/nodes/tests/test_react_agent_node.py
+++ b/bili/iris/nodes/tests/test_react_agent_node.py
@@ -868,3 +868,21 @@ class TestToolStrategyRouting:
 
         mock_create_agent.assert_not_called()
         assert callable(result)
+
+    @patch("bili.iris.nodes.react_agent_node.create_agent")
+    def test_unknown_strategy_with_tools_raises_value_error(self, mock_create_agent):
+        """A non-canonical tool_strategy with tools raises ValueError, not UnboundLocalError.
+
+        Before the guard was added, an unknown strategy value combined with a
+        non-None tools list would silently skip all routing branches and then
+        reach ``return agent`` with ``agent`` unbound, producing an opaque
+        UnboundLocalError.  The guard now raises a clear ValueError instead.
+        """
+        tool = _make_tool("t")
+
+        import pytest  # pylint: disable=import-outside-toplevel
+
+        with pytest.raises(ValueError, match="Unknown tool_strategy"):
+            build_react_agent_node(
+                tools=[tool], llm_model=MagicMock(), tool_strategy="bogus_strategy"
+            )

--- a/bili/iris/providers/cli_presets.py
+++ b/bili/iris/providers/cli_presets.py
@@ -82,8 +82,22 @@ class CliPreset:
     :param prompt_via: How the rendered prompt is delivered to the process.
         ``"arg"`` (default for most CLIs -- appended as a positional argument),
         ``"stdin"``, or ``"file"``.
+
+        **Security note:** ``"arg"`` exposes the full prompt text as a
+        command-line argument.  On shared or multi-user hosts, process listings
+        (``ps aux``, ``/proc/<pid>/cmdline``) may reveal prompt content to
+        other users.  Use ``"stdin"`` instead when the CLI supports it and
+        prompt confidentiality matters.
+
     :param message_format: How the LangChain message list is rendered before
         delivery.  ``"last"`` (default) sends only the final human message.
+
+        **Note:** ``"last"`` silently drops all prior conversation turns.
+        This is intentional for single-shot CLI tools that have no session
+        state, but it means a CLI-backed model used in a multi-turn
+        conversation will not see its own earlier responses.  If conversation
+        continuity matters, set ``message_format="all"`` (if the CLI supports
+        multi-turn input) or maintain context in the prompt itself.
     :param output_format: How the subprocess stdout is parsed.  ``"text"``
         (default) returns the raw stripped output; ``"json"`` parses JSON and
         extracts the value at ``json_path``.

--- a/bili/iris/providers/cli_presets.py
+++ b/bili/iris/providers/cli_presets.py
@@ -96,8 +96,10 @@ class CliPreset:
         This is intentional for single-shot CLI tools that have no session
         state, but it means a CLI-backed model used in a multi-turn
         conversation will not see its own earlier responses.  If conversation
-        continuity matters, set ``message_format="all"`` (if the CLI supports
-        multi-turn input) or maintain context in the prompt itself.
+        continuity matters, use ``"roles"`` (renders each turn as
+        ``Human: … / Assistant: …`` lines) or ``"chatml"`` (ChatML
+        ``<|im_start|>`` / ``<|im_end|>`` tokens) where the CLI accepts
+        structured multi-turn input.
     :param output_format: How the subprocess stdout is parsed.  ``"text"``
         (default) returns the raw stripped output; ``"json"`` parses JSON and
         extracts the value at ``json_path``.

--- a/setup.py
+++ b/setup.py
@@ -263,15 +263,19 @@ _EXTRAS = {
     ],
 }
 
-# [all] is composed from every individual extra above.  This single source of
+# [all] is composed from every RUNTIME extra above.  This single source of
 # truth means a pin bump in one extra propagates automatically; no separate
-# copy to forget.  The [all-providers] bundle is omitted to avoid duplicating
-# the individual provider entries it already mirrors.
+# copy to forget.  Two extras are excluded:
+#   [all-providers] -- omitted to avoid duplicating individual provider entries.
+#   [dev]           -- excluded because [all] is a runtime bundle; development
+#                      tooling (pylint, black, pytest, …) should not be pulled
+#                      in as transitive dependencies by consumers that install
+#                      bili-core[all].  Install [dev] separately when needed.
 _EXTRAS["all"] = sorted(
     {
         pkg
         for key, pkgs in _EXTRAS.items()
-        if key not in ("all-providers",)
+        if key not in ("all-providers", "dev")
         for pkg in pkgs
     }
 )


### PR DESCRIPTION
## Summary

Five deferred review findings across PRs #206, #209, #214, #215, and #216
fixed in one pass.  None changes public API or runtime behaviour for
correctly-configured callers.

### 1. UnboundLocalError guard in `build_react_agent_node` (#215)

**Problem:** When a non-canonical `tool_strategy` string is passed alongside
a non-`None` `tools` list, every routing branch in the `if/elif` chain is
skipped, leaving the local variable `agent` unbound.  The subsequent
`return agent` raises a confusing `UnboundLocalError` instead of pointing to
the mis-configuration.

**Fix:** Add `elif tools is not None: raise ValueError(...)` as the final
routing branch so callers see a clear error message with the expected values.
Initialise `agent = None` before the routing block to satisfy pylint static
analysis (the init is dead code in practice because the ValueError branch
is exhaustive for any `tools is not None` case not matched earlier).

**Test added:** `TestToolStrategyRouting::test_unknown_strategy_with_tools_raises_value_error`
confirms `ValueError` (not `UnboundLocalError`) is raised.

### 2. Remove `[dev]` from `[all]` extra composition (#206)

`[all]` is a runtime convenience bundle.  Development tooling (pylint, black,
pytest, mongomock, …) was being pulled in as transitive dependencies for any
consumer that installed `bili-core[all]`.  The exclusion set now covers both
`"all-providers"` and `"dev"`.

### 3. CLI preset docstring: `prompt_via` and `message_format` notes (#209)

- `CliPreset.prompt_via` (`"arg"` default): added a **Security note** that
  `"arg"` exposes the full prompt text as a command-line argument visible in
  process listings (`ps aux`, `/proc/<pid>/cmdline`) on shared/multi-user
  hosts, and recommends `"stdin"` where the CLI supports it.
- `CliPreset.message_format` (`"last"` default): added a **Note** that
  `"last"` silently discards prior conversation turns, which is intentional
  for stateless one-shot CLIs but can silently break multi-turn workflows if
  the caller assumes history is forwarded.

### 4. Fix import-error test + add docstring note (#214)

**Problem:** `test_resolve_supports_tools_returns_true_on_import_error`
patched the `LLM_MODELS` attribute with `side_effect=ImportError`.  Because
Python had already cached `bili.iris.config.llm_config` in `sys.modules`,
the `from bili.iris.config.llm_config import LLM_MODELS` statement inside
`resolve_tool_strategy` never raised — the `except ImportError` branch was
never executed.

**Fix:** Replace with `patch.dict(sys.modules, {"bili.iris.config.llm_config": None})`,
which causes Python's import machinery to raise `ImportError` at the `from …
import` statement inside the `try` block.

**Docstring note added to `resolve_supports_tools`:** clarifies that it
inspects only the primary `model_name`; fallback-chain models are not checked.

### 5. Dedupe Mistral section-header comment block (#216)

Three reference URLs in the `# Mistral AI Models` comment were listed twice
in a row.  Remove the duplicate block.

## Test impact

| Test file | Before | After |
|---|---|---|
| `test_react_agent_node.py` | existing | +1 test for ValueError path |
| `test_compiler.py` | 1 test (non-exercising) | 1 test (now exercises real except-ImportError branch) |

All 3809 tests pass.  Coverage gate: 214/214 runtime files >= 90% (overall 98.4%).

## Files changed

- `bili/iris/nodes/react_agent_node.py` — ValueError guard + `agent = None` init
- `bili/iris/nodes/tests/test_react_agent_node.py` — new ValueError test
- `setup.py` — exclude `"dev"` from `[all]` composition
- `bili/iris/providers/cli_presets.py` — docstring security/behaviour notes
- `bili/aether/compiler/llm_resolver.py` — docstring note on primary-only lookup
- `bili/aether/tests/test_compiler.py` — import-error test corrected
- `bili/iris/config/llm_config.py` — remove duplicate Mistral URL block