### PR TITLE
feat(checkpointers,aether): local-file JSONL checkpointer + default-on AETHER checkpointing + audit view (#300)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ BiliCore is structured around three major components:
 
 The core single-agent pipeline for retrieval-augmented generation:
 
-1. **Checkpointers** (`bili/iris/checkpointers/`): State persistence layer supporting MongoDB, PostgreSQL, and memory storage. All checkpointers implement a queryable interface for conversation management with both sync and async APIs.
+1. **Checkpointers** (`bili/iris/checkpointers/`): State persistence layer supporting MongoDB, PostgreSQL, local-file JSONL, and in-memory storage (4 backends). All checkpointers implement a queryable interface for conversation management with both sync and async APIs. Set `JSONL_CHECKPOINT_PATH` to activate the JSONL backend without a database server.
 
 2. **LLM Configuration** (`bili/iris/config/`): 97 model configurations across 17 provider types (11 remote API: AWS Bedrock, Google Vertex AI, Azure OpenAI, OpenAI, Anthropic, Mistral AI, Cohere, Google Generative AI, DeepSeek, xAI, Groq; 3 CLI presets: Claude Code, Codex, Gemini CLI; generic CLI subprocess; local: llama.cpp, HuggingFace). Uses factory pattern for model initialization. Each entry declares `supports_tools` (default `True`); set `False` to route through the prompted ReAct path instead of native `bind_tools`.
 

--- a/bili/aether/README.md
+++ b/bili/aether/README.md
@@ -817,6 +817,18 @@ agents:
 
 ### Checkpointer Configuration
 
+> **Behavior change (v5.1+):** `checkpoint_enabled: true` (the default) now always attaches a
+> checkpointer — even when no `user_id` is passed to `MASExecutor`. In earlier releases, omitting
+> `user_id` left the graph with no checkpointer, so `thread_id` had no persistence effect. Now,
+> two `run()` calls on the same `MASExecutor` instance passing the **same explicit `thread_id`**
+> will share and accumulate state (`agent_outputs`, `communication_log`). Runs that do **not**
+> supply a `thread_id` still receive an auto-generated `execution_id` per call and are unaffected.
+>
+> **Migration guidance:** If you relied on the previous no-checkpointer behaviour for stateless
+> local runs, either (a) pass a distinct `thread_id` per logically-separate run so executions
+> stay isolated, or (b) set `checkpoint_enabled: false` in your `MASConfig` to opt out
+> entirely. All existing code that already provided a `user_id` is unchanged.
+
 The `checkpoint_config` dict in `MASConfig` controls which checkpointer backend is used when compiling the graph. The factory maps `config["type"]` to a bili-core checkpointer:
 
 | Type | Backend | Notes |
@@ -825,7 +837,7 @@ The `checkpoint_config` dict in `MASConfig` controls which checkpointer backend 
 | `jsonl` / `file` | `JSONLCheckpointSaver` | Local file — no server required; set `path` key or `JSONL_CHECKPOINT_PATH` env var |
 | `postgres` / `pg` | `PruningPostgresSaver` | Requires `POSTGRES_CONNECTION_STRING` env var |
 | `mongo` / `mongodb` | `PruningMongoDBSaver` | Requires `MONGO_CONNECTION_STRING` env var |
-| `auto` | Auto-detected | Tries postgres, then mongo, then jsonl, then memory (based on env vars) |
+| `auto` | Auto-detected | Tries postgres, then mongo, then memory (based on env vars) |
 
 Additional keys are forwarded to the checkpointer constructor:
 
@@ -837,6 +849,8 @@ checkpoint_config:
 ```
 
 **Always-on default:** When `checkpoint_enabled: true` (the default), AETHER always attaches a checkpointer — even without a `user_id`. Without a `user_id`, the executor uses `_create_checkpointer_local()` which reads `checkpoint_config` directly. This means a plain `jsonl` config persists run state to disk with no database server and no user identity required.
+
+**JSONL file growth:** The default `keep_last_n: -1` retains full checkpoint history, which is ideal for a durable audit trail but grows the file and in-memory index as O(supersteps × full_state). For long-lived or high-frequency runs, set `keep_last_n` to a finite value (e.g. `10`) to cap file size and first-load time.
 
 **Fallback behaviour:** If the requested backend is unavailable (missing dependency or env var), the factory falls back to `MemorySaver` with a warning. The graph always compiles successfully.
 

--- a/bili/aether/README.md
+++ b/bili/aether/README.md
@@ -822,17 +822,21 @@ The `checkpoint_config` dict in `MASConfig` controls which checkpointer backend 
 | Type | Backend | Notes |
 |------|---------|-------|
 | `memory` (default) | `QueryableMemorySaver` | In-memory, no persistence across restarts |
+| `jsonl` / `file` | `JSONLCheckpointSaver` | Local file — no server required; set `path` key or `JSONL_CHECKPOINT_PATH` env var |
 | `postgres` / `pg` | `PruningPostgresSaver` | Requires `POSTGRES_CONNECTION_STRING` env var |
 | `mongo` / `mongodb` | `PruningMongoDBSaver` | Requires `MONGO_CONNECTION_STRING` env var |
-| `auto` | Auto-detected | Tries postgres, then mongo, then memory (based on env vars) |
+| `auto` | Auto-detected | Tries postgres, then mongo, then jsonl, then memory (based on env vars) |
 
 Additional keys are forwarded to the checkpointer constructor:
 
 ```yaml
 checkpoint_config:
-  type: postgres
-  keep_last_n: 10      # Prune to last 10 checkpoints per thread
+  type: jsonl
+  path: /var/data/run.jsonl  # optional; defaults to JSONL_CHECKPOINT_PATH env var
+  keep_last_n: 10            # prune to last 10 checkpoints per thread
 ```
+
+**Always-on default:** When `checkpoint_enabled: true` (the default), AETHER always attaches a checkpointer — even without a `user_id`. Without a `user_id`, the executor uses `_create_checkpointer_local()` which reads `checkpoint_config` directly. This means a plain `jsonl` config persists run state to disk with no database server and no user identity required.
 
 **Fallback behaviour:** If the requested backend is unavailable (missing dependency or env var), the factory falls back to `MemorySaver` with a warning. The graph always compiles successfully.
 
@@ -844,6 +848,22 @@ from bili.iris.checkpointers.pg_checkpointer import get_pg_checkpointer
 compiled = compile_mas(config)
 graph = compiled.compile_graph(checkpointer=get_pg_checkpointer(keep_last_n=5))
 ```
+
+### Audit View
+
+`audit_view()` builds a human-readable timeline from a MAS run's checkpoint history. It iterates `checkpointer.list()` in chronological order, diffs `agent_outputs` and `communication_log` between consecutive supersteps, and returns one entry per superstep where something changed.
+
+```python
+from bili.iris.checkpointers.jsonl_checkpointer import get_jsonl_checkpointer
+from bili.aether.runtime import audit_view
+
+saver = get_jsonl_checkpointer(path="run.jsonl")
+timeline = audit_view(saver, thread_id="run-001")
+for step in timeline:
+    print(step["ts"], step["agent_id"], step["output_summary"])
+```
+
+Each entry contains: `step` (1-based), `ts` (ISO-8601), `checkpoint_id`, `agent_id`, `output_summary` (first 200 chars), `messages_sent` (new `communication_log` entries this step), and `raw_agent_outputs` (delta). Works with any checkpointer that exposes `list()` — JSONL, Postgres, Mongo, or in-memory.
 
 ### Per-Agent Middleware
 

--- a/bili/aether/integration/checkpointer_factory.py
+++ b/bili/aether/integration/checkpointer_factory.py
@@ -17,6 +17,8 @@ _TYPE_ALIASES: dict[str, str] = {
     "mongo": "mongo",
     "mongodb": "mongo",
     "auto": "auto",
+    "jsonl": "jsonl",  # Local-file JSONL saver — no database server required
+    "file": "jsonl",  # Alias for "jsonl"
 }
 
 
@@ -55,6 +57,7 @@ def create_checkpointer_from_config(
         "postgres": _create_postgres_checkpointer,
         "mongo": _create_mongo_checkpointer,
         "auto": _create_auto_checkpointer,
+        "jsonl": _create_jsonl_checkpointer,
     }
     return dispatch[checkpoint_type](config, user_id=user_id)
 
@@ -196,6 +199,48 @@ def _create_auto_checkpointer(
     except ImportError:
         LOGGER.warning(
             "bili.iris.checkpointers.checkpointer_functions not available; "
+            "falling back to memory"
+        )
+    return _create_memory_checkpointer(user_id=user_id)
+
+
+def _create_jsonl_checkpointer(
+    config: dict[str, Any] | None = None, user_id: str | None = None
+) -> Any:
+    """Create a local-file JSONL checkpointer (no database server required).
+
+    Args:
+        config: Dict with optional keys:
+            - ``"path"``: Absolute path to the JSONL file.  Defaults to
+              the ``JSONL_CHECKPOINT_PATH`` env var or
+              ``~/.bili/checkpoints/aether.jsonl``.
+            - ``"keep_last_n"``: Pruning limit (``-1`` = unlimited).
+        user_id: Optional user identifier for thread ownership validation.
+
+    Returns:
+        A ``JSONLCheckpointSaver`` instance.
+    """
+    config = config or {}
+    path = config.get("path")
+    keep_last_n = config.get("keep_last_n", -1)
+    try:
+        from bili.iris.checkpointers.jsonl_checkpointer import (  # pylint: disable=import-outside-toplevel
+            JSONLCheckpointSaver,
+        )
+
+        saver = JSONLCheckpointSaver(
+            path=path, keep_last_n=keep_last_n, user_id=user_id
+        )
+        LOGGER.info(
+            "Created JSONLCheckpointSaver (path=%s, keep_last_n=%d%s)",
+            saver.path,
+            keep_last_n,
+            f", user_id={user_id}" if user_id else "",
+        )
+        return saver
+    except ImportError:  # pragma: no cover  # ImportError only in broken installs
+        LOGGER.warning(
+            "bili.iris.checkpointers.jsonl_checkpointer not available; "
             "falling back to memory"
         )
     return _create_memory_checkpointer(user_id=user_id)

--- a/bili/aether/integration/checkpointer_factory.py
+++ b/bili/aether/integration/checkpointer_factory.py
@@ -163,6 +163,10 @@ def _create_auto_checkpointer(
     Forwards keep_last_n and user_id parameters if specified.
     Mirrors the logic from bili.iris.checkpointers.checkpointer_functions.get_checkpointer
     but passes arguments correctly.
+
+    Note: JSONL is intentionally excluded from auto-detection here.  The 'auto'
+    type targets server-backed stores (Postgres, Mongo); callers that want the
+    local-file backend should declare ``type: jsonl`` explicitly.
     """
     config = config or {}
     keep_last_n = config.get("keep_last_n", 5)

--- a/bili/aether/runtime/__init__.py
+++ b/bili/aether/runtime/__init__.py
@@ -1,7 +1,7 @@
 """AETHER runtime — agent communication protocol.
 
 Provides structured inter-agent messaging through declared channels,
-with JSONL logging and LangGraph state integration.
+with LangGraph state integration and checkpoint-backed audit views.
 
 Key classes:
     ``Message``              — Pydantic model for a single message.
@@ -13,8 +13,12 @@ Key classes:
     ``BroadcastChannel``     — One-to-many messaging.
     ``RequestResponseChannel`` — Bidirectional request/response.
     ``ChannelManager``       — Top-level orchestrator for all channels.
+
+Key functions:
+    ``audit_view``           — Human-readable timeline from checkpoint history.
 """
 
+from bili.aether.runtime.audit import audit_view
 from bili.aether.runtime.channel_manager import ChannelManager
 from bili.aether.runtime.channels import (
     BroadcastChannel,
@@ -41,6 +45,7 @@ from bili.aether.runtime.streaming import StreamEvent, StreamEventType, StreamFi
 __all__ = [
     "AgentExecutionResult",
     "BroadcastChannel",
+    "audit_view",
     "ChannelManager",
     "CommunicationChannel",
     "CommunicationLogger",

--- a/bili/aether/runtime/audit.py
+++ b/bili/aether/runtime/audit.py
@@ -154,10 +154,10 @@ def audit_view(
             else:
                 serialized_messages.append({"raw": str(msg)})
 
-        # Extract timestamp from checkpoint metadata or the checkpoint dict itself
-        ts: Optional[str] = None
-        metadata = tup.metadata or {}
-        ts = metadata.get("ts") or checkpoint.get("ts")
+        # Extract timestamp from the checkpoint dict.
+        # LangGraph metadata does not carry a "ts" field; the source of truth
+        # is checkpoint["ts"] set at put() time.
+        ts: Optional[str] = checkpoint.get("ts")
 
         timeline.append(
             {

--- a/bili/aether/runtime/audit.py
+++ b/bili/aether/runtime/audit.py
@@ -1,0 +1,177 @@
+"""
+Module: audit
+
+Human-readable audit view over a multi-agent checkpoint history.
+
+Given a checkpointer and a thread_id, ``audit_view()`` iterates the
+checkpoint sequence produced by a single MAS run and returns a structured
+timeline showing which agent acted at each superstep, what it produced, and
+which inter-agent messages it sent.
+
+This is a read-only, zero-side-effect utility — it calls only
+``checkpointer.list()`` and deserializes the returned tuples.
+
+Functions:
+    - audit_view(checkpointer, thread_id, checkpoint_ns)
+
+Example::
+
+    from bili.iris.checkpointers.jsonl_checkpointer import get_jsonl_checkpointer
+    from bili.aether.runtime.audit import audit_view
+
+    saver = get_jsonl_checkpointer(path="run.jsonl")
+    timeline = audit_view(saver, thread_id="run-001")
+    for step in timeline:
+        print(step["ts"], step["agent_id"], step["output_summary"])
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+LOGGER = logging.getLogger(__name__)
+
+
+def audit_view(
+    checkpointer: Any,
+    thread_id: str,
+    checkpoint_ns: str = "",
+) -> List[Dict[str, Any]]:
+    """Build a human-readable timeline from a MAS run's checkpoint history.
+
+    Iterates ``checkpointer.list()`` for *thread_id* in chronological order,
+    diffs ``agent_outputs`` and ``communication_log`` between consecutive
+    supersteps, and emits one entry per superstep where something changed.
+
+    Args:
+        checkpointer: Any object with a ``list(config)`` method that yields
+            ``CheckpointTuple`` objects (e.g. ``JSONLCheckpointSaver``,
+            ``QueryableMemorySaver``, ``PruningPostgresSaver``).
+        thread_id: Thread ID of the run to inspect.
+        checkpoint_ns: Checkpoint namespace (empty string for MAS runs).
+
+    Returns:
+        A list of step dicts in chronological order (oldest first):
+
+        .. code-block:: python
+
+            [
+                {
+                    "step":           int,          # 1-based superstep index
+                    "ts":             str | None,   # ISO-8601 timestamp from checkpoint
+                    "checkpoint_id":  str,
+                    "agent_id":       str | None,   # which agent acted this step
+                    "output_summary": str | None,   # first 200 chars of agent output
+                    "messages_sent":  list[dict],   # new communication_log entries
+                    "raw_agent_outputs": dict,      # full agent_outputs delta
+                },
+                ...
+            ]
+
+        Returns an empty list if no checkpoints exist for the thread_id.
+
+    Raises:
+        TypeError: If *checkpointer* does not expose a ``list()`` method.
+    """
+    config: Dict[str, Any] = {
+        "configurable": {
+            "thread_id": thread_id,
+            "checkpoint_ns": checkpoint_ns,
+        }
+    }
+
+    # list() yields most-recent-first; reverse for chronological order
+    try:
+        tuples = list(checkpointer.list(config))
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        LOGGER.error(
+            "audit_view: failed to list checkpoints for thread '%s': %s",
+            thread_id,
+            exc,
+        )
+        raise
+
+    if not tuples:
+        LOGGER.debug("audit_view: no checkpoints found for thread '%s'", thread_id)
+        return []
+
+    # Reverse to chronological order (oldest superstep first)
+    tuples = list(reversed(tuples))
+
+    timeline: List[Dict[str, Any]] = []
+    prev_agent_outputs: Dict[str, Any] = {}
+    prev_comm_log: List[Any] = []
+
+    for step_idx, tup in enumerate(tuples, start=1):
+        checkpoint = tup.checkpoint or {}
+        channel_values: Dict[str, Any] = checkpoint.get("channel_values", {})
+
+        current_agent_outputs: Dict[str, Any] = channel_values.get("agent_outputs", {})
+        current_comm_log: List[Any] = channel_values.get("communication_log", [])
+
+        # Diff agent_outputs: find keys that are new or changed this step
+        changed_outputs: Dict[str, Any] = {}
+        for agent_id, output in current_agent_outputs.items():
+            if (
+                agent_id not in prev_agent_outputs
+                or prev_agent_outputs[agent_id] != output
+            ):
+                changed_outputs[agent_id] = output
+
+        # Diff communication_log: find entries appended this step
+        new_messages: List[Any] = current_comm_log[len(prev_comm_log) :]
+
+        # Identify the acting agent (the one that changed outputs this step)
+        acting_agent: Optional[str] = channel_values.get("current_agent")
+        if acting_agent is None and changed_outputs:
+            acting_agent = next(iter(changed_outputs))
+
+        # Summarise the acting agent's output
+        output_summary: Optional[str] = None
+        if acting_agent and acting_agent in changed_outputs:
+            raw_output = changed_outputs[acting_agent]
+            if isinstance(raw_output, dict):
+                text = (
+                    raw_output.get("message")
+                    or raw_output.get("content")
+                    or raw_output.get("response")
+                    or str(raw_output)
+                )
+            else:
+                text = str(raw_output)
+            output_summary = text[:200] if text else None
+
+        # Serialize messages_sent to plain dicts (they may be dataclasses)
+        serialized_messages: List[Dict[str, Any]] = []
+        for msg in new_messages:
+            if isinstance(msg, dict):
+                serialized_messages.append(msg)
+            elif hasattr(msg, "to_log_dict"):
+                serialized_messages.append(msg.to_log_dict())
+            elif hasattr(msg, "__dict__"):
+                serialized_messages.append(vars(msg))
+            else:
+                serialized_messages.append({"raw": str(msg)})
+
+        # Extract timestamp from checkpoint metadata or the checkpoint dict itself
+        ts: Optional[str] = None
+        metadata = tup.metadata or {}
+        ts = metadata.get("ts") or checkpoint.get("ts")
+
+        timeline.append(
+            {
+                "step": step_idx,
+                "ts": ts,
+                "checkpoint_id": tup.config["configurable"].get("checkpoint_id"),
+                "agent_id": acting_agent,
+                "output_summary": output_summary,
+                "messages_sent": serialized_messages,
+                "raw_agent_outputs": changed_outputs,
+            }
+        )
+
+        prev_agent_outputs = dict(current_agent_outputs)
+        prev_comm_log = list(current_comm_log)
+
+    return timeline

--- a/bili/aether/runtime/executor.py
+++ b/bili/aether/runtime/executor.py
@@ -120,6 +120,9 @@ class MASExecutor:  # pylint: disable=too-many-instance-attributes
         self._runtime_context = runtime_context
         self._compiled_mas = None
         self._compiled_graph = None
+        # Populated by initialize(); used by run/stream methods to decide
+        # whether to inject a thread_id into invoke_config.
+        self._checkpointer = None
 
     # ------------------------------------------------------------------
     # Properties
@@ -145,8 +148,18 @@ class MASExecutor:  # pylint: disable=too-many-instance-attributes
         Calls ``compile_mas()`` (which validates the config) and then
         ``compile_graph()`` to produce the executable graph.
 
-        If ``user_id`` was provided to ``__init__()``, creates a checkpointer
-        with multi-tenant security enabled.
+        Checkpointer attachment (mirrors IRIS always-on behaviour):
+        - ``checkpoint_enabled=True`` (the default) always attaches a
+          checkpointer, even without ``user_id``:
+            - With ``user_id``: ownership-validating saver keyed to that user.
+            - Without ``user_id``: configured backend (default: memory).
+        - ``checkpoint_enabled=False``: explicit opt-out; no saver attached
+          (HITL override still applies).
+        - HITL: a ``MemorySaver`` is always attached when human-interrupt
+          nodes are present, even when ``checkpoint_enabled=False``.
+
+        After initialization, ``self._checkpointer`` reflects whether a
+        checkpointer is actually attached (``None`` = no persistence).
 
         Raises:
             ValueError: If config validation fails.
@@ -168,31 +181,49 @@ class MASExecutor:  # pylint: disable=too-many-instance-attributes
                 a.agent_id for a in self._config.agents if getattr(a, "is_human", False)
             ]
 
-        # Create checkpointer — required for HITL resumption even when
-        # checkpoint_enabled is False in the config.
+        # Always-on checkpointing: attach a checkpointer whenever
+        # checkpoint_enabled=True, regardless of whether user_id is set.
+        # checkpoint_enabled=False is the explicit opt-out.
         checkpointer = None
-        if self._user_id and self._config.checkpoint_enabled:
-            checkpointer = self._create_checkpointer_with_user_id()
-        elif human_nodes and not self._config.checkpoint_enabled:
-            # HITL requires a checkpointer so state can be resumed after the
-            # interrupt.  Fall back to an in-process MemorySaver.
+        if self._config.checkpoint_enabled:
+            if self._user_id:
+                # Multi-tenant: ownership-validating saver keyed to this user
+                checkpointer = self._create_checkpointer_with_user_id()
+            else:
+                # Local / single-instance: configured backend, no ownership
+                # validation
+                checkpointer = self._create_checkpointer_local()
+
+        # HITL override: state resumption requires a checkpointer even when
+        # checkpoint_enabled=False.  Fall back to an in-process MemorySaver.
+        if human_nodes and checkpointer is None:
             from langgraph.checkpoint.memory import (  # pylint: disable=import-outside-toplevel
                 MemorySaver,
             )
 
             checkpointer = MemorySaver()
+            LOGGER.info(
+                "HITL mode: attaching MemorySaver for state resumption "
+                "(checkpoint_enabled=False)"
+            )
 
+        self._checkpointer = checkpointer
         self._compiled_graph = self._compiled_mas.compile_graph(
             checkpointer=checkpointer,
             interrupt_before=human_nodes,
         )
 
         LOGGER.info(
-            "MASExecutor initialized for '%s' (%d agents, %s workflow%s)",
+            "MASExecutor initialized for '%s' (%d agents, %s workflow%s%s)",
             self._config.mas_id,
             len(self._config.agents),
             self._config.workflow_type.value,
             f", user_id={self._user_id}" if self._user_id else "",
+            (
+                ", checkpointer={}".format(type(checkpointer).__name__)
+                if checkpointer
+                else ", checkpointer=None"
+            ),
         )
 
     # ------------------------------------------------------------------
@@ -239,7 +270,7 @@ class MASExecutor:  # pylint: disable=too-many-instance-attributes
 
         # Build invoke config
         invoke_config: Dict[str, Any] = {"recursion_limit": self._config.max_iterations}
-        if self._config.checkpoint_enabled:
+        if self._checkpointer is not None:
             effective_thread_id = self._construct_thread_id(thread_id, execution_id)
             invoke_config["configurable"] = {"thread_id": effective_thread_id}
 
@@ -269,8 +300,8 @@ class MASExecutor:  # pylint: disable=too-many-instance-attributes
             final_state
         )
 
-        checkpoint_saved = self._config.checkpoint_enabled
-        # JSONL logging deprecated - communication now persists in checkpointer state
+        checkpoint_saved = self._checkpointer is not None
+        # Communication now persists in checkpointer state
         comm_log_path = None
 
         result = MASExecutionResult(
@@ -342,7 +373,7 @@ class MASExecutor:  # pylint: disable=too-many-instance-attributes
         initial_state = self._build_initial_state(input_data)
 
         invoke_config: Dict[str, Any] = {"recursion_limit": self._config.max_iterations}
-        if self._config.checkpoint_enabled:
+        if self._checkpointer is not None:
             effective_thread_id = self._construct_thread_id(thread_id, execution_id)
             invoke_config["configurable"] = {"thread_id": effective_thread_id}
 
@@ -434,8 +465,7 @@ class MASExecutor:  # pylint: disable=too-many-instance-attributes
 
         invoke_config: Dict[str, Any] = {"recursion_limit": self._config.max_iterations}
         effective_thread_id: Optional[str] = None
-        needs_checkpoint = self._config.checkpoint_enabled or self._config.human_in_loop
-        if needs_checkpoint:
+        if self._checkpointer is not None:
             effective_thread_id = self._construct_thread_id(thread_id, execution_id)
             invoke_config["configurable"] = {"thread_id": effective_thread_id}
 
@@ -523,8 +553,7 @@ class MASExecutor:  # pylint: disable=too-many-instance-attributes
 
         invoke_config: Dict[str, Any] = {"recursion_limit": self._config.max_iterations}
         effective_thread_id: Optional[str] = None
-        needs_checkpoint = self._config.checkpoint_enabled or self._config.human_in_loop
-        if needs_checkpoint:
+        if self._checkpointer is not None:
             effective_thread_id = self._construct_thread_id(thread_id, execution_id)
             invoke_config["configurable"] = {"thread_id": effective_thread_id}
 
@@ -669,7 +698,7 @@ class MASExecutor:  # pylint: disable=too-many-instance-attributes
         initial_state = self._build_initial_state(input_data)
 
         invoke_config: Dict[str, Any] = {"recursion_limit": self._config.max_iterations}
-        if self._config.checkpoint_enabled:
+        if self._checkpointer is not None:
             effective_thread_id = self._construct_thread_id(thread_id, execution_id)
             invoke_config["configurable"] = {"thread_id": effective_thread_id}
 
@@ -915,6 +944,42 @@ class MASExecutor:  # pylint: disable=too-many-instance-attributes
     # ==================================================================
     # Internal helpers
     # ==================================================================
+
+    def _create_checkpointer_local(self) -> Any:
+        """Create a checkpointer for local/single-instance runs (no user_id).
+
+        Uses the MASConfig's ``checkpoint_config`` to select the backend but
+        does NOT set ``user_id``, so thread ownership validation is disabled.
+        Falls back to ``MemorySaver`` if the factory is unavailable.
+
+        Returns:
+            A checkpointer instance without ownership validation.
+        """
+        try:
+            from bili.aether.integration.checkpointer_factory import (  # pylint: disable=import-outside-toplevel
+                create_checkpointer_from_config,
+            )
+
+            checkpointer = create_checkpointer_from_config(
+                self._config.checkpoint_config, user_id=None
+            )
+            LOGGER.info(
+                "Created local checkpointer (type=%s) for always-on persistence",
+                type(checkpointer).__name__,
+            )
+            return checkpointer
+
+        except ImportError:
+            LOGGER.warning(
+                "Checkpointer factory not available; "
+                "falling back to MemorySaver for local checkpointing"
+            )
+
+        from langgraph.checkpoint.memory import (  # pylint: disable=import-error,import-outside-toplevel
+            MemorySaver,
+        )
+
+        return MemorySaver()
 
     def _create_checkpointer_with_user_id(self) -> Any:
         """Create a checkpointer with multi-tenant security enabled.

--- a/bili/aether/schema/mas_config.py
+++ b/bili/aether/schema/mas_config.py
@@ -232,8 +232,12 @@ class MASConfig(BaseModel):
         description=(
             "Checkpoint backend configuration. Supported types: "
             "'memory' (default), 'postgres'/'pg', 'mongo'/'mongodb', "
-            "'auto' (env-based detection). Additional keys like "
-            "'keep_last_n' are forwarded to the checkpointer constructor."
+            "'jsonl'/'file' (local JSONL file — no server required; "
+            "set 'path' key to override the default path; "
+            "activated automatically via JSONL_CHECKPOINT_PATH env var), "
+            "'auto' (env-based detection of postgres/mongo/jsonl/memory). "
+            "Additional keys like 'keep_last_n' are forwarded to the "
+            "checkpointer constructor."
         ),
     )
 

--- a/bili/aether/tests/test_executor_always_on_checkpointing.py
+++ b/bili/aether/tests/test_executor_always_on_checkpointing.py
@@ -1,0 +1,572 @@
+"""Tests for always-on AETHER checkpointing (PR #300).
+
+Covers the behavioral matrix added when MASExecutor.initialize() was changed
+to attach a checkpointer regardless of whether a user_id is present:
+
+    checkpoint_enabled=True  + user_id → full checkpointer (existing behaviour)
+    checkpoint_enabled=True  + no user_id → JSONL or memory fallback (NEW)
+    checkpoint_enabled=False + user_id → no checkpointer (existing behaviour)
+    checkpoint_enabled=False + no user_id → no checkpointer (existing behaviour)
+    human_in_loop + checkpoint_enabled=False → MemorySaver override (existing)
+
+Also tests audit_view() over the MASExecutor + JSONLCheckpointSaver stack.
+"""
+
+# pylint: disable=missing-function-docstring, protected-access
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from bili.aether.runtime.audit import audit_view
+from bili.aether.runtime.executor import MASExecutor
+from bili.aether.schema import AgentSpec, MASConfig, WorkflowType
+from bili.iris.checkpointers.jsonl_checkpointer import JSONLCheckpointSaver
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _agent(agent_id: str, **kwargs) -> AgentSpec:
+    defaults = {"role": "test_role", "objective": f"Objective for {agent_id}"}
+    defaults.update(kwargs)
+    return AgentSpec(agent_id=agent_id, **defaults)
+
+
+def _seq_config(
+    mas_id: str = "test_ck",
+    n_agents: int = 2,
+    checkpoint_enabled: bool = True,
+    checkpoint_config: dict | None = None,
+    **kwargs,
+) -> MASConfig:
+    agents = [_agent(f"agent_{i}") for i in range(n_agents)]
+    cfg = {
+        "mas_id": mas_id,
+        "name": "Test Checkpointing MAS",
+        "workflow_type": WorkflowType.SEQUENTIAL,
+        "agents": agents,
+        "checkpoint_enabled": checkpoint_enabled,
+        "checkpoint_config": checkpoint_config or {"type": "memory"},
+    }
+    cfg.update(kwargs)
+    return MASConfig(**cfg)
+
+
+# ---------------------------------------------------------------------------
+# initialize() behavioural matrix
+# ---------------------------------------------------------------------------
+
+
+class TestInitializeBehavioralMatrix:
+    """Always-on checkpointing: checkpointer is attached when enabled."""
+
+    def test_checkpoint_enabled_with_user_id_attaches_checkpointer(self, tmp_path):
+        """checkpoint_enabled=True + user_id → _checkpointer is not None."""
+        config = _seq_config(checkpoint_enabled=True)
+        executor = MASExecutor(config, user_id="alice@test.com")
+        executor.initialize()
+        assert executor._checkpointer is not None
+
+    def test_checkpoint_enabled_without_user_id_attaches_checkpointer(
+        self, tmp_path, monkeypatch
+    ):
+        """checkpoint_enabled=True + no user_id → _checkpointer is not None (NEW)."""
+        config = _seq_config(
+            checkpoint_enabled=True,
+            checkpoint_config={"type": "memory"},
+        )
+        executor = MASExecutor(config, user_id=None)
+        executor.initialize()
+        assert executor._checkpointer is not None
+
+    def test_checkpoint_disabled_with_user_id_no_checkpointer(self):
+        """checkpoint_enabled=False + user_id → _checkpointer remains None."""
+        config = _seq_config(checkpoint_enabled=False)
+        executor = MASExecutor(config, user_id="alice@test.com")
+        executor.initialize()
+        assert executor._checkpointer is None
+
+    def test_checkpoint_disabled_without_user_id_no_checkpointer(self):
+        """checkpoint_enabled=False + no user_id → _checkpointer remains None."""
+        config = _seq_config(checkpoint_enabled=False)
+        executor = MASExecutor(config, user_id=None)
+        executor.initialize()
+        assert executor._checkpointer is None
+
+    def test_human_in_loop_always_gets_checkpointer(self):
+        """human_in_loop=True with is_human agents attaches MemorySaver even when disabled."""
+        # HITL override requires at least one agent with is_human=True so that
+        # human_nodes is non-empty inside initialize().
+        human_agent = AgentSpec(
+            agent_id="human_reviewer",
+            role="human",
+            objective="Review agent output before proceeding",
+            is_human=True,
+        )
+        ai_agent = AgentSpec(
+            agent_id="agent_0", role="test_role", objective="Produce output for review"
+        )
+        config = MASConfig(
+            mas_id="hitl_test",
+            name="HITL Test",
+            workflow_type=WorkflowType.SEQUENTIAL,
+            agents=[ai_agent, human_agent],
+            checkpoint_enabled=False,
+            checkpoint_config={"type": "memory"},
+            human_in_loop=True,
+            human_escalation_condition="False",
+        )
+        executor = MASExecutor(config, user_id=None)
+        executor.initialize()
+        assert executor._checkpointer is not None
+
+    def test_jsonl_backend_attached_via_config(self, tmp_path):
+        """checkpoint_config type='jsonl' → JSONLCheckpointSaver is attached."""
+        path = str(tmp_path / "test.jsonl")
+        config = _seq_config(
+            checkpoint_enabled=True,
+            checkpoint_config={"type": "jsonl", "path": path},
+        )
+        executor = MASExecutor(config, user_id=None)
+        executor.initialize()
+        assert isinstance(executor._checkpointer, JSONLCheckpointSaver)
+        assert executor._checkpointer.path == path
+
+    def test_file_alias_backend_attached_via_config(self, tmp_path):
+        """checkpoint_config type='file' → JSONLCheckpointSaver is attached."""
+        path = str(tmp_path / "test.jsonl")
+        config = _seq_config(
+            checkpoint_enabled=True,
+            checkpoint_config={"type": "file", "path": path},
+        )
+        executor = MASExecutor(config, user_id=None)
+        executor.initialize()
+        assert isinstance(executor._checkpointer, JSONLCheckpointSaver)
+
+    def test_initialize_is_idempotent(self):
+        """Calling initialize() twice does not raise."""
+        config = _seq_config(checkpoint_enabled=True)
+        executor = MASExecutor(config)
+        executor.initialize()
+        executor.initialize()
+        assert executor._checkpointer is not None
+
+
+# ---------------------------------------------------------------------------
+# _create_checkpointer_local helper
+# ---------------------------------------------------------------------------
+
+
+class TestCreateCheckpointerLocal:
+    """_create_checkpointer_local() returns a usable checkpointer for no-user-id runs."""
+
+    def test_returns_checkpointer(self, tmp_path):
+        config = _seq_config(
+            checkpoint_enabled=True,
+            checkpoint_config={"type": "memory"},
+        )
+        executor = MASExecutor(config, user_id=None)
+        checkpointer = executor._create_checkpointer_local()
+        assert checkpointer is not None
+
+    def test_jsonl_path_forwarded(self, tmp_path):
+        path = str(tmp_path / "local.jsonl")
+        config = _seq_config(
+            checkpoint_enabled=True,
+            checkpoint_config={"type": "jsonl", "path": path},
+        )
+        executor = MASExecutor(config, user_id=None)
+        checkpointer = executor._create_checkpointer_local()
+        assert isinstance(checkpointer, JSONLCheckpointSaver)
+        assert checkpointer.path == path
+
+
+# ---------------------------------------------------------------------------
+# JSONL env-var tier in get_checkpointer()
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointerFunctionsJSONLTier:
+    """get_checkpointer() and get_async_checkpointer() honour JSONL_CHECKPOINT_PATH."""
+
+    def test_jsonl_tier_returns_jsonl_saver(self, tmp_path, monkeypatch):
+        """With JSONL_CHECKPOINT_PATH set and no PG/Mongo, get_checkpointer() returns JSONL."""
+        from bili.iris.checkpointers.checkpointer_functions import get_checkpointer
+
+        path = str(tmp_path / "env.jsonl")
+        monkeypatch.setenv("JSONL_CHECKPOINT_PATH", path)
+        monkeypatch.delenv("POSTGRES_CONNECTION_STRING", raising=False)
+        monkeypatch.delenv("MONGODB_URI", raising=False)
+
+        saver = get_checkpointer()
+        assert isinstance(saver, JSONLCheckpointSaver)
+        assert saver.path == path
+
+    def test_jsonl_tier_async(self, tmp_path, monkeypatch):
+        """get_async_checkpointer() also returns JSONLCheckpointSaver when env var set."""
+        import asyncio
+
+        from bili.iris.checkpointers.checkpointer_functions import (
+            get_async_checkpointer,
+        )
+
+        path = str(tmp_path / "env_async.jsonl")
+        monkeypatch.setenv("JSONL_CHECKPOINT_PATH", path)
+        monkeypatch.delenv("POSTGRES_CONNECTION_STRING", raising=False)
+        monkeypatch.delenv("MONGODB_URI", raising=False)
+
+        saver = asyncio.run(get_async_checkpointer())
+        assert isinstance(saver, JSONLCheckpointSaver)
+
+
+# ---------------------------------------------------------------------------
+# AETHER checkpointer_factory jsonl / file aliases
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointerFactoryAliases:
+    """create_checkpointer_from_config handles 'jsonl' and 'file' aliases."""
+
+    def test_jsonl_alias(self, tmp_path):
+        from bili.aether.integration.checkpointer_factory import (
+            create_checkpointer_from_config,
+        )
+
+        path = str(tmp_path / "alias.jsonl")
+        saver = create_checkpointer_from_config({"type": "jsonl", "path": path})
+        assert isinstance(saver, JSONLCheckpointSaver)
+
+    def test_file_alias(self, tmp_path):
+        from bili.aether.integration.checkpointer_factory import (
+            create_checkpointer_from_config,
+        )
+
+        path = str(tmp_path / "alias_file.jsonl")
+        saver = create_checkpointer_from_config({"type": "file", "path": path})
+        assert isinstance(saver, JSONLCheckpointSaver)
+
+    def test_keep_last_n_forwarded(self, tmp_path):
+        from bili.aether.integration.checkpointer_factory import (
+            create_checkpointer_from_config,
+        )
+
+        path = str(tmp_path / "prune.jsonl")
+        saver = create_checkpointer_from_config(
+            {"type": "jsonl", "path": path, "keep_last_n": 5}
+        )
+        assert saver.keep_last_n == 5
+
+    def test_user_id_forwarded(self, tmp_path):
+        from bili.aether.integration.checkpointer_factory import (
+            create_checkpointer_from_config,
+        )
+
+        path = str(tmp_path / "uid.jsonl")
+        saver = create_checkpointer_from_config(
+            {"type": "jsonl", "path": path}, user_id="alice@test.com"
+        )
+        assert saver.user_id == "alice@test.com"
+
+
+# ---------------------------------------------------------------------------
+# audit_view() tests
+# ---------------------------------------------------------------------------
+
+
+def _mk_checkpoint(cp_id, agent_id=None, msg=None, ts=None):
+    """Build a minimal checkpoint dict for audit_view tests."""
+    agent_outputs = (
+        {agent_id: {"message": msg or f"output from {agent_id}"}} if agent_id else {}
+    )
+    return {
+        "id": cp_id,
+        "ts": ts or "2024-01-01T00:00:00+00:00",
+        "v": 1,
+        "channel_values": {
+            "messages": [],
+            "agent_outputs": agent_outputs,
+            "communication_log": [],
+        },
+        "channel_versions": {},
+        "versions_seen": {},
+        "pending_sends": [],
+    }
+
+
+def _mk_config(thread_id, cp_id=None, ns=""):
+    cfg = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ns}}
+    if cp_id:
+        cfg["configurable"]["checkpoint_id"] = cp_id
+    return cfg
+
+
+def _mk_metadata(ts=None):
+    return {"source": "test", "step": 0, "writes": {}, "ts": ts}
+
+
+class TestAuditView:
+    """audit_view() builds a readable timeline from checkpoint history."""
+
+    def test_empty_thread_returns_empty_list(self, tmp_path):
+        """audit_view on a thread with no checkpoints returns []."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "audit.jsonl"))
+        result = audit_view(saver, thread_id="nonexistent")
+        assert result == []
+
+    def test_single_superstep_timeline(self, tmp_path):
+        """A single checkpoint produces a one-entry timeline."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "audit.jsonl"))
+        saver.put(
+            _mk_config("run-1"),
+            _mk_checkpoint("cp-1", agent_id="agent_0"),
+            _mk_metadata("2024-01-01T00:00:00+00:00"),
+            {},
+        )
+        timeline = audit_view(saver, thread_id="run-1")
+        assert len(timeline) == 1
+        assert timeline[0]["step"] == 1
+        assert timeline[0]["agent_id"] == "agent_0"
+
+    def test_output_summary_truncated_to_200_chars(self, tmp_path):
+        """output_summary is at most 200 characters."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "audit.jsonl"))
+        long_output = "x" * 500
+        ck = _mk_checkpoint("cp-1")
+        ck["channel_values"]["agent_outputs"] = {"agent_0": {"message": long_output}}
+        saver.put(_mk_config("run-1"), ck, _mk_metadata(), {})
+        timeline = audit_view(saver, thread_id="run-1")
+        assert timeline[0]["output_summary"] is not None
+        assert len(timeline[0]["output_summary"]) <= 200
+
+    def test_two_supersteps_delta(self, tmp_path):
+        """Second step shows only the newly changed agent_outputs delta."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "audit.jsonl"))
+        # Step 1: agent_0 acts
+        ck1 = _mk_checkpoint("cp-1", agent_id="agent_0", msg="first")
+        saver.put(_mk_config("run-1"), ck1, _mk_metadata(), {})
+
+        # Step 2: agent_1 acts (agent_0 output unchanged)
+        ck2 = _mk_checkpoint("cp-1")
+        ck2["id"] = "cp-2"
+        ck2["channel_values"]["agent_outputs"] = {
+            "agent_0": {"message": "first"},  # unchanged
+            "agent_1": {"message": "second"},  # new
+        }
+        saver.put(_mk_config("run-1", "cp-1"), ck2, _mk_metadata(), {})
+
+        timeline = audit_view(saver, thread_id="run-1")
+        assert len(timeline) == 2
+        # Step 2 only shows agent_1 in raw_agent_outputs
+        step2 = timeline[1]
+        assert "agent_1" in step2["raw_agent_outputs"]
+        assert "agent_0" not in step2["raw_agent_outputs"]
+
+    def test_communication_log_diff(self, tmp_path):
+        """messages_sent shows only newly appended communication_log entries."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "audit.jsonl"))
+        ck1 = _mk_checkpoint("cp-1")
+        ck1["channel_values"]["communication_log"] = [{"from": "agent_0", "msg": "A"}]
+        saver.put(_mk_config("run-1"), ck1, _mk_metadata(), {})
+
+        ck2 = _mk_checkpoint("cp-1")
+        ck2["id"] = "cp-2"
+        ck2["channel_values"]["communication_log"] = [
+            {"from": "agent_0", "msg": "A"},
+            {"from": "agent_1", "msg": "B"},
+        ]
+        saver.put(_mk_config("run-1", "cp-1"), ck2, _mk_metadata(), {})
+
+        timeline = audit_view(saver, thread_id="run-1")
+        step1 = timeline[0]
+        step2 = timeline[1]
+        assert len(step1["messages_sent"]) == 1
+        assert step1["messages_sent"][0]["msg"] == "A"
+        assert len(step2["messages_sent"]) == 1
+        assert step2["messages_sent"][0]["msg"] == "B"
+
+    def test_chronological_order(self, tmp_path):
+        """Timeline is chronological (oldest first)."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "audit.jsonl"))
+        for i in range(4):
+            ck = _mk_checkpoint(f"cp-{i}")
+            saver.put(_mk_config("run-1"), ck, _mk_metadata(), {})
+        timeline = audit_view(saver, thread_id="run-1")
+        steps = [e["step"] for e in timeline]
+        assert steps == sorted(steps)
+        assert steps[0] == 1
+
+    def test_checkpoint_id_in_timeline_entry(self, tmp_path):
+        """Each timeline entry includes checkpoint_id."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "audit.jsonl"))
+        saver.put(
+            _mk_config("run-1"),
+            _mk_checkpoint("cp-sentinel"),
+            _mk_metadata(),
+            {},
+        )
+        timeline = audit_view(saver, thread_id="run-1")
+        # checkpoint_id comes from config configurable, not checkpoint.id
+        assert timeline[0]["checkpoint_id"] is not None
+
+    def test_output_summary_uses_content_key(self, tmp_path):
+        """output_summary falls back to 'content' key when 'message' is absent."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "audit.jsonl"))
+        ck = _mk_checkpoint("cp-1")
+        ck["channel_values"]["agent_outputs"] = {"agent_0": {"content": "response"}}
+        saver.put(_mk_config("run-1"), ck, _mk_metadata(), {})
+        timeline = audit_view(saver, thread_id="run-1")
+        assert timeline[0]["output_summary"] == "response"
+
+    def test_output_summary_non_dict_agent_output(self, tmp_path):
+        """output_summary handles a raw string agent output."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "audit.jsonl"))
+        ck = _mk_checkpoint("cp-1")
+        ck["channel_values"]["agent_outputs"] = {"agent_0": "plain string output"}
+        saver.put(_mk_config("run-1"), ck, _mk_metadata(), {})
+        timeline = audit_view(saver, thread_id="run-1")
+        assert timeline[0]["output_summary"] == "plain string output"
+
+    def test_ts_extracted_from_checkpoint(self, tmp_path):
+        """ts is extracted from the checkpoint dict when not in metadata."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "audit.jsonl"))
+        ck = _mk_checkpoint("cp-1")
+        ck["ts"] = "2024-06-01T12:00:00+00:00"
+        saver.put(
+            _mk_config("run-1"), ck, {"source": "test", "step": 0, "writes": {}}, {}
+        )
+        timeline = audit_view(saver, thread_id="run-1")
+        assert timeline[0]["ts"] == "2024-06-01T12:00:00+00:00"
+
+    def test_message_serialization_to_log_dict(self):
+        """messages_sent: items with to_log_dict() are serialized via that method.
+
+        Uses a mock saver to bypass JSONL encoding; the to_log_dict path is
+        exercised in the audit_view serialization loop.
+        """
+        from langgraph.checkpoint.base import CheckpointTuple
+
+        msg = MagicMock()
+        msg.to_log_dict.return_value = {"from": "agent_0", "msg": "via_to_log_dict"}
+
+        ck = _mk_checkpoint("cp-1")
+        ck["channel_values"]["communication_log"] = [msg]
+
+        tup = CheckpointTuple(
+            config={"configurable": {"thread_id": "run-1", "checkpoint_id": "cp-1"}},
+            checkpoint=ck,
+            metadata=_mk_metadata(),
+            parent_config=None,
+            pending_writes=[],
+        )
+        mock_saver = MagicMock()
+        mock_saver.list.return_value = [tup]
+
+        timeline = audit_view(mock_saver, thread_id="run-1")
+        assert len(timeline) == 1
+        assert timeline[0]["messages_sent"][0]["msg"] == "via_to_log_dict"
+
+    def test_audit_view_raises_on_checkpointer_error(self, tmp_path):
+        """audit_view propagates errors from list()."""
+        saver = MagicMock()
+        saver.list.side_effect = RuntimeError("list failed")
+        with pytest.raises(RuntimeError, match="list failed"):
+            audit_view(saver, thread_id="run-1")
+
+    def test_messages_sent_dict_passthrough(self, tmp_path):
+        """communication_log entries that are already dicts are passed through unchanged."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "audit.jsonl"))
+        ck = _mk_checkpoint("cp-1")
+        ck["channel_values"]["communication_log"] = [
+            {"from": "a", "to": "b", "text": "hi"}
+        ]
+        saver.put(_mk_config("run-1"), ck, _mk_metadata(), {})
+        timeline = audit_view(saver, thread_id="run-1")
+        assert timeline[0]["messages_sent"][0]["text"] == "hi"
+
+    def test_messages_sent_raw_fallback(self, tmp_path):
+        """communication_log entries with no to_log_dict / __dict__ are str-wrapped."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "audit.jsonl"))
+        ck = _mk_checkpoint("cp-1")
+        # A simple int has neither to_log_dict nor a useful __dict__
+        ck["channel_values"]["communication_log"] = [42]
+        saver.put(_mk_config("run-1"), ck, _mk_metadata(), {})
+        timeline = audit_view(saver, thread_id="run-1")
+        # Serialization to JSONL converts int to encoded blob; timeline still has entry
+        assert isinstance(timeline[0]["messages_sent"], list)
+
+
+# ---------------------------------------------------------------------------
+# audit_view with mock saver (tests that bypass JSONL encode/decode path)
+# ---------------------------------------------------------------------------
+
+
+class TestAuditViewMockSaver:
+    """audit_view() called directly on a mock saver that yields CheckpointTuples."""
+
+    def _make_tuple(self, cp_id, thread_id, agent_id=None, comm_entries=None):
+        """Build a minimal CheckpointTuple-compatible object."""
+        from langgraph.checkpoint.base import CheckpointTuple  # type: ignore
+
+        agent_outputs = {agent_id: {"message": f"out-{agent_id}"}} if agent_id else {}
+        checkpoint = {
+            "id": cp_id,
+            "ts": "2024-01-01T00:00:00+00:00",
+            "v": 1,
+            "channel_values": {
+                "messages": [],
+                "agent_outputs": agent_outputs,
+                "communication_log": comm_entries or [],
+            },
+            "channel_versions": {},
+            "versions_seen": {},
+            "pending_sends": [],
+        }
+        config = {"configurable": {"thread_id": thread_id, "checkpoint_id": cp_id}}
+        return CheckpointTuple(
+            config=config,
+            checkpoint=checkpoint,
+            metadata={"source": "test", "step": 0, "writes": {}},
+            parent_config=None,
+            pending_writes=[],
+        )
+
+    def test_current_agent_from_channel_values(self):
+        """acting_agent is read from channel_values.current_agent when present."""
+        mock_saver = MagicMock()
+        tup = self._make_tuple("cp-1", "t1", agent_id="agent_0")
+        # Inject current_agent explicitly
+        tup.checkpoint["channel_values"]["current_agent"] = "agent_explicit"
+        mock_saver.list.return_value = [tup]
+
+        timeline = audit_view(mock_saver, thread_id="t1")
+        assert timeline[0]["agent_id"] == "agent_explicit"
+
+    def test_two_supersteps_chronological(self):
+        """list() output (most-recent-first) is reversed to chronological in timeline."""
+        mock_saver = MagicMock()
+        tup1 = self._make_tuple("cp-1", "t1", agent_id="agent_0")
+        tup2 = self._make_tuple("cp-2", "t1", agent_id="agent_1")
+        # list() returns most-recent first (cp-2, cp-1)
+        mock_saver.list.return_value = [tup2, tup1]
+
+        timeline = audit_view(mock_saver, thread_id="t1")
+        assert len(timeline) == 2
+        assert timeline[0]["step"] == 1
+        assert timeline[1]["step"] == 2
+
+    def test_communication_log_hasattr_dict_fallback(self):
+        """comm_log entries with __dict__ are serialized via vars()."""
+        mock_saver = MagicMock()
+
+        class _Msg:
+            def __init__(self):
+                self.from_agent = "a"
+                self.content = "hi"
+
+        tup = self._make_tuple("cp-1", "t1", comm_entries=[_Msg()])
+        mock_saver.list.return_value = [tup]
+
+        timeline = audit_view(mock_saver, thread_id="t1")
+        assert timeline[0]["messages_sent"][0]["from_agent"] == "a"

--- a/bili/iris/checkpointers/checkpointer_functions.py
+++ b/bili/iris/checkpointers/checkpointer_functions.py
@@ -1,41 +1,33 @@
 """
 Module: checkpointer_functions
 
-This module provides functions to manage checkpointing for conversation states
-within a Streamlit application. It includes functions to initialize and manage
-a Postgres connection pool, determine the appropriate checkpointer, and create
-a state configuration for conversation tracking.
+This module provides functions to manage checkpointing for conversation states.
+It determines the appropriate checkpointer backend based on available
+environment variables and returns a ready-to-use checkpointer instance.
 
 Functions:
     - get_checkpointer():
-      Determines and returns the appropriate checkpointer (PostgresSaver,
-      MongoDBSaver, or MemorySaver).
+      Determines and returns the appropriate checkpointer using a
+      priority cascade:
+        1. PostgreSQL (POSTGRES_CONNECTION_STRING)
+        2. MongoDB (MONGO_CONNECTION_STRING)
+        3. JSONL / local-file (JSONL_CHECKPOINT_PATH) — no database server
+        4. In-memory QueryableMemorySaver (fallback)
+
+    - get_async_checkpointer():
+      Async variant of get_checkpointer() for streaming operations.
 
 Dependencies:
-    - streamlit: Provides the Streamlit library for building web applications.
-    - langgraph.checkpoint.memory: Imports MemorySaver for in-memory
-      checkpointing.
-    - langgraph.checkpoint.mongodb: Imports MongoDBSaver for MongoDB-based
-      checkpointing.
-    - langgraph.checkpoint.postgres: Imports PostgresSaver for Postgres-based
-      checkpointing.
-    - bili.streamlit.checkpointer.mongo_checkpointer: Imports functions to get
-      MongoDB client and checkpointer.
-    - bili.streamlit.checkpointer.pg_checkpointer: Imports functions to get
-      Postgres connection pool and checkpointer.
-    - bili.utils.logging_utils: Imports get_logger for logging purposes.
+    - bili.iris.checkpointers.pg_checkpointer: PostgreSQL-backed saver.
+    - bili.iris.checkpointers.mongo_checkpointer: MongoDB-backed saver.
+    - bili.iris.checkpointers.jsonl_checkpointer: Local-file JSONL saver
+      (no server required; triggered by JSONL_CHECKPOINT_PATH env var).
+    - bili.iris.checkpointers.memory_checkpointer: QueryableMemorySaver fallback.
+    - bili.utils.logging_utils: Logging.
 
 Usage:
-    This module is intended to be used within a Streamlit application to manage
-    checkpointing of conversation states. It provides functions to initialize
-    and manage a Postgres connection pool, determine the appropriate
-    checkpointer, and create a state configuration for conversation tracking.
+    from bili.iris.checkpointers.checkpointer_functions import get_checkpointer
 
-Example:
-    from bili.streamlit.checkpointer.checkpointer_functions import \
-        get_checkpointer, get_state_config
-
-    # Get the appropriate checkpointer
     checkpointer = get_checkpointer()
 
 """
@@ -60,52 +52,59 @@ LOGGER = get_logger(__name__)
 def get_checkpointer():
     """
     Determine and return the appropriate checkpointer instance for conversation
-    state checkpointing. The function first attempts to acquire a PostgreSQL
-    checkpointer, then a MongoDB checkpointer, and finally defaults to an in-memory
-    checkpointer if no database persistence options are available. The process
-    is logged for debugging purposes.
+    state checkpointing.
 
-    :returns: An instance of the checkpointer based on availability. The following
-        instances can be returned:
+    Priority cascade:
+        1. PostgreSQL if ``POSTGRES_CONNECTION_STRING`` is set.
+        2. MongoDB if ``MONGO_CONNECTION_STRING`` is set.
+        3. Local-file JSONL if ``JSONL_CHECKPOINT_PATH`` is set — persists to
+           disk without any database server.
+        4. In-memory ``QueryableMemorySaver`` as the zero-config fallback.
 
-        - PostgreSQL checkpointer if available.
-        - MongoDB checkpointer if PostgreSQL is not available.
-        - Memory checkpointer as a fallback if both PostgreSQL and MongoDB are
-          unavailable.
-
+    :returns: A checkpointer instance selected by the cascade above.
     :rtype: Checkpointer
     """
-    # if POSTGRES_CONNECTION_STRING exists, use PostgresSaver
+    # Priority 1: PostgreSQL
     if os.getenv("POSTGRES_CONNECTION_STRING"):
         LOGGER.debug("Using PostgresSaver for conversation state checkpointing.")
         return get_pg_checkpointer()
 
-    # if MONGO_CONNECTION_STRING exists, use MongoDBSaver
+    # Priority 2: MongoDB
     if os.getenv("MONGO_CONNECTION_STRING"):
         LOGGER.debug("Using MongoDBSaver for conversation state checkpointing.")
         return get_mongo_checkpointer()
 
-    # If no database persistence is available, use QueryableMemorySaver as a fallback
+    # Priority 3: Local-file JSONL (no server required)
+    if os.getenv("JSONL_CHECKPOINT_PATH"):
+        from bili.iris.checkpointers.jsonl_checkpointer import (  # pylint: disable=import-outside-toplevel
+            get_jsonl_checkpointer,
+        )
+
+        LOGGER.debug(
+            "Using JSONLCheckpointSaver for conversation state checkpointing "
+            "(path=%s).",
+            os.getenv("JSONL_CHECKPOINT_PATH"),
+        )
+        return get_jsonl_checkpointer()
+
+    # Priority 4: In-memory fallback
     LOGGER.debug("Using QueryableMemorySaver for conversation state checkpointing.")
     return QueryableMemorySaver()
 
 
 async def get_async_checkpointer():
     """
-    Determine and return the appropriate async checkpointer instance for streaming
-    operations. Supports async PostgreSQL, MongoDB, and Memory checkpointers.
+    Determine and return the appropriate async checkpointer instance for
+    streaming operations.
 
-    The priority order matches get_checkpointer():
-    1. PostgreSQL if POSTGRES_CONNECTION_STRING is set
-    2. MongoDB if MONGO_CONNECTION_STRING is set
-    3. MemorySaver as fallback (inherently async-compatible)
+    Priority cascade matches ``get_checkpointer()``:
+        1. PostgreSQL if ``POSTGRES_CONNECTION_STRING`` is set.
+        2. MongoDB if ``MONGO_CONNECTION_STRING`` is set.
+        3. Local-file JSONL if ``JSONL_CHECKPOINT_PATH`` is set.
+        4. In-memory ``QueryableMemorySaver`` as the zero-config fallback.
 
-    :returns: An async checkpointer instance based on availability.
-        - Async PostgreSQL checkpointer if POSTGRES_CONNECTION_STRING is available.
-        - Async MongoDB checkpointer if MONGO_CONNECTION_STRING is available.
-        - MemorySaver as fallback (works in async contexts).
-
-    :rtype: AsyncPostgresSaver | PruningMongoDBSaver | MemorySaver
+    :returns: An async-compatible checkpointer instance.
+    :rtype: AsyncPostgresSaver | PruningMongoDBSaver | JSONLCheckpointSaver | QueryableMemorySaver
     """
     # Priority 1: PostgreSQL async checkpointer
     if os.getenv("POSTGRES_CONNECTION_STRING"):
@@ -117,7 +116,19 @@ async def get_async_checkpointer():
         LOGGER.debug("Using MongoDBSaver for streaming operations.")
         return await get_async_mongo_checkpointer()
 
-    # Priority 3: Memory checkpointer (inherently async-compatible, no await needed)
+    # Priority 3: JSONL local-file (async methods delegate via asyncio.to_thread)
+    if os.getenv("JSONL_CHECKPOINT_PATH"):
+        from bili.iris.checkpointers.jsonl_checkpointer import (  # pylint: disable=import-outside-toplevel
+            get_async_jsonl_checkpointer,
+        )
+
+        LOGGER.debug(
+            "Using JSONLCheckpointSaver for streaming operations (path=%s).",
+            os.getenv("JSONL_CHECKPOINT_PATH"),
+        )
+        return await get_async_jsonl_checkpointer()
+
+    # Priority 4: In-memory fallback (inherently async-compatible)
     LOGGER.debug(
         "Using QueryableMemorySaver for streaming operations (async-compatible fallback)."
     )

--- a/bili/iris/checkpointers/jsonl_checkpointer.py
+++ b/bili/iris/checkpointers/jsonl_checkpointer.py
@@ -1,0 +1,989 @@
+"""
+Module: jsonl_checkpointer
+
+Local-file checkpoint saver that persists every graph superstep to an
+append-only JSONL file.  No database server is required — the file is the
+only dependency.
+
+Designed for single-process, multi-thread usage (multiple concurrent runs on
+different thread_ids within one process are fully safe thanks to an in-process
+RLock).  Multi-process file locking is explicitly out of scope; if concurrent
+processes need a shared store, use the PostgreSQL or MongoDB savers instead.
+
+Classes:
+    - JSONLCheckpointSaver:
+      Implements the full BaseCheckpointSaver contract (sync + async) backed
+      by a local JSONL file.  Also implements QueryableCheckpointerMixin and
+      VersionedCheckpointerMixin so it is a drop-in peer of
+      PruningPostgresSaver / PruningMongoDBSaver.
+
+Factories:
+    - get_jsonl_checkpointer(path, keep_last_n, user_id)
+    - get_async_jsonl_checkpointer(path, keep_last_n, user_id)
+
+On-disk format
+--------------
+Two record types are interleaved in one JSONL file (one JSON object per line):
+
+Checkpoint record (record_type == "checkpoint")::
+
+    {
+      "record_type": "checkpoint",
+      "thread_id":   "<str>",
+      "checkpoint_ns": "<str>",
+      "checkpoint_id": "<str>",
+      "parent_checkpoint_id": "<str | null>",
+      "ts": "<ISO-8601 UTC>",
+      "checkpoint": {"type": "<serde type>", "data": "<base64 bytes>"},
+      "metadata":   {"type": "<serde type>", "data": "<base64 bytes>"},
+      "format_version": <int>
+    }
+
+Write record (record_type == "write")::
+
+    {
+      "record_type": "write",
+      "thread_id":   "<str>",
+      "checkpoint_ns": "<str>",
+      "checkpoint_id": "<str>",
+      "task_id":     "<str>",
+      "task_path":   "<str>",
+      "idx":         <int>,
+      "channel":     "<str>",
+      "value":       {"type": "<serde type>", "data": "<base64 bytes>"}
+    }
+
+The ``checkpoint`` blob is the FULL LangGraph checkpoint dict including
+``channel_values``, serialized using ``self.serde.dumps_typed``.  This
+deliberately stores the complete superstep state in each record, trading
+file size for simplicity and auditability — every line is self-contained.
+
+Example:
+    from bili.iris.checkpointers.jsonl_checkpointer import get_jsonl_checkpointer
+
+    saver = get_jsonl_checkpointer(path="~/.bili/aether.jsonl")
+"""
+
+import asyncio
+import base64
+import json
+import os
+import threading
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterator, List, Optional, Sequence
+
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+    WRITES_IDX_MAP,
+    BaseCheckpointSaver,
+    ChannelVersions,
+    Checkpoint,
+    CheckpointMetadata,
+    CheckpointTuple,
+    get_checkpoint_id,
+    get_checkpoint_metadata,
+)
+
+from bili.iris.checkpointers.base_checkpointer import QueryableCheckpointerMixin
+from bili.iris.checkpointers.versioning import (
+    CURRENT_FORMAT_VERSION,
+    VersionedCheckpointerMixin,
+)
+from bili.utils.logging_utils import get_logger
+
+LOGGER = get_logger(__name__)
+
+# Default file path when neither argument nor env var is provided
+_DEFAULT_PATH = os.path.expanduser("~/.bili/checkpoints/aether.jsonl")
+
+
+def _encode(saver: "JSONLCheckpointSaver", value: Any) -> Dict[str, str]:
+    """Serialize *value* using saver.serde and return a JSON-safe envelope."""
+    type_str, raw_bytes = saver.serde.dumps_typed(value)
+    return {"type": type_str, "data": base64.b64encode(raw_bytes).decode("ascii")}
+
+
+def _decode(saver: "JSONLCheckpointSaver", envelope: Dict[str, str]) -> Any:
+    """Deserialize a JSON-safe envelope using saver.serde."""
+    raw_bytes = base64.b64decode(envelope["data"])
+    return saver.serde.loads_typed((envelope["type"], raw_bytes))
+
+
+class JSONLCheckpointSaver(
+    VersionedCheckpointerMixin,
+    QueryableCheckpointerMixin,
+    BaseCheckpointSaver,
+):
+    """Local-file checkpoint saver backed by an append-only JSONL file.
+
+    Every graph superstep produces one ``checkpoint`` record in the file;
+    intermediate writes produce ``write`` records.  A lazy in-memory index
+    is built on first access.  All write paths hold a ``threading.RLock``
+    so concurrent calls from multiple threads (one per agent execution) are
+    safe within a single process.
+
+    Args:
+        path: Absolute or ``~``-prefixed path to the ``.jsonl`` file.
+            Defaults to ``JSONL_CHECKPOINT_PATH`` env var, then
+            ``~/.bili/checkpoints/aether.jsonl``.
+        keep_last_n: Number of most recent checkpoints to retain per
+            ``(thread_id, checkpoint_ns)`` pair.  ``-1`` disables pruning.
+        user_id: When set, enables thread ownership validation — every
+            ``put``/``get_tuple`` call checks that the thread_id matches
+            ``user_id`` or ``{user_id}_*``.
+    """
+
+    # Identifies this checkpointer type in the migration registry
+    checkpointer_type: str = "jsonl"
+    format_version: int = CURRENT_FORMAT_VERSION
+
+    def __init__(
+        self,
+        path: Optional[str] = None,
+        *,
+        keep_last_n: int = -1,
+        user_id: Optional[str] = None,
+    ) -> None:
+        super().__init__()
+        resolved = path or os.environ.get("JSONL_CHECKPOINT_PATH") or _DEFAULT_PATH
+        self._path: str = os.path.expanduser(resolved)
+        self.keep_last_n = keep_last_n
+        self.user_id = user_id
+
+        self._lock = threading.RLock()
+        self._loaded = False
+
+        # (thread_id, ns) -> list[checkpoint_record_dict], append-ordered
+        self._checkpoints: Dict[tuple, List[Dict[str, Any]]] = defaultdict(list)
+        # (thread_id, ns, checkpoint_id) -> list[write_record_dict]
+        self._writes: Dict[tuple, List[Dict[str, Any]]] = defaultdict(list)
+
+        LOGGER.info(
+            "JSONLCheckpointSaver initialised (path=%s, keep_last_n=%d%s)",
+            self._path,
+            keep_last_n,
+            f", user_id={user_id}" if user_id else "",
+        )
+
+    # ------------------------------------------------------------------
+    # Public path property
+    # ------------------------------------------------------------------
+
+    @property
+    def path(self) -> str:
+        """Absolute path to the backing JSONL file."""
+        return self._path
+
+    # ------------------------------------------------------------------
+    # In-memory index management
+    # ------------------------------------------------------------------
+
+    def _ensure_loaded(self) -> None:
+        """Load the JSONL file into the in-memory index (idempotent)."""
+        with self._lock:
+            if self._loaded:
+                return
+            self._load_from_disk()
+            self._loaded = True
+
+    def _load_from_disk(self) -> None:
+        """Read all records from the JSONL file and populate the index."""
+        if not os.path.exists(self._path):
+            LOGGER.debug("JSONL file not yet created: %s", self._path)
+            return
+
+        loaded_checkpoints = 0
+        loaded_writes = 0
+        errors = 0
+
+        with open(self._path, "r", encoding="utf-8") as fh:
+            for lineno, raw in enumerate(fh, start=1):
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    record = json.loads(raw)
+                except json.JSONDecodeError:
+                    LOGGER.warning(
+                        "Skipping malformed JSON on line %d of %s", lineno, self._path
+                    )
+                    errors += 1
+                    continue
+
+                rt = record.get("record_type")
+                if rt == "checkpoint":
+                    key = (record["thread_id"], record.get("checkpoint_ns", ""))
+                    self._checkpoints[key].append(record)
+                    loaded_checkpoints += 1
+                elif rt == "write":
+                    key = (
+                        record["thread_id"],
+                        record.get("checkpoint_ns", ""),
+                        record["checkpoint_id"],
+                    )
+                    self._writes[key].append(record)
+                    loaded_writes += 1
+                else:
+                    LOGGER.debug(
+                        "Unknown record_type '%s' on line %d; skipped", rt, lineno
+                    )
+
+        LOGGER.info(
+            "Loaded %d checkpoints, %d writes from %s (%d errors)",
+            loaded_checkpoints,
+            loaded_writes,
+            self._path,
+            errors,
+        )
+
+    def _append_record(self, record: Dict[str, Any]) -> None:
+        """Append one JSON record to the file (caller must hold self._lock)."""
+        dir_path = os.path.dirname(self._path)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
+        with open(self._path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    # ------------------------------------------------------------------
+    # Pruning
+    # ------------------------------------------------------------------
+
+    def _prune(self, thread_id: str, checkpoint_ns: str) -> None:
+        """Remove old checkpoints beyond keep_last_n (caller holds lock)."""
+        if self.keep_last_n < 0:
+            return
+        key = (thread_id, checkpoint_ns)
+        records = self._checkpoints.get(key, [])
+        if len(records) <= self.keep_last_n:
+            return
+
+        # Keep the most recent keep_last_n by insertion order
+        to_remove = records[: len(records) - self.keep_last_n]
+        kept = records[len(records) - self.keep_last_n :]
+        self._checkpoints[key] = kept
+
+        # Remove associated writes
+        for rec in to_remove:
+            wkey = (thread_id, checkpoint_ns, rec["checkpoint_id"])
+            self._writes.pop(wkey, None)
+
+        # Rewrite the file from the in-memory index (compact)
+        self._rewrite_file()
+
+    def _rewrite_file(self) -> None:
+        """Rewrite the entire JSONL file from the in-memory index (caller holds lock)."""
+        dir_path = os.path.dirname(self._path)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
+        tmp_path = self._path + ".tmp"
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as fh:
+                for records in self._checkpoints.values():
+                    for rec in records:
+                        fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+                for write_list in self._writes.values():
+                    for rec in write_list:
+                        fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+            os.replace(tmp_path, self._path)
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Clean up temp file on failure
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+            raise
+
+    # ------------------------------------------------------------------
+    # BaseCheckpointSaver sync interface
+    # ------------------------------------------------------------------
+
+    def get_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        """Return the requested checkpoint tuple, or None if not found.
+
+        Args:
+            config: Runnable config with ``thread_id`` (and optionally
+                ``checkpoint_id`` and ``checkpoint_ns``).
+
+        Returns:
+            ``CheckpointTuple`` with full channel_values, or ``None``.
+
+        Raises:
+            PermissionError: If user_id is set and thread_id is foreign.
+        """
+        self._ensure_loaded()
+        thread_id: str = config["configurable"]["thread_id"]
+        checkpoint_ns: str = config["configurable"].get("checkpoint_ns", "")
+        self._validate_thread_ownership(thread_id)
+
+        with self._lock:
+            records = self._checkpoints.get((thread_id, checkpoint_ns), [])
+            if not records:
+                return None
+
+            checkpoint_id = get_checkpoint_id(config)
+            if checkpoint_id:
+                record = next(
+                    (r for r in records if r["checkpoint_id"] == checkpoint_id), None
+                )
+            else:
+                record = records[-1]  # most recent by insertion order
+
+            if record is None:
+                return None
+
+            checkpoint: Checkpoint = _decode(self, record["checkpoint"])
+            metadata: CheckpointMetadata = _decode(self, record["metadata"])
+
+            wkey = (thread_id, checkpoint_ns, record["checkpoint_id"])
+            write_records = self._writes.get(wkey, [])
+            pending_writes = [
+                (w["task_id"], w["channel"], _decode(self, w["value"]))
+                for w in write_records
+            ]
+
+            parent_config: Optional[RunnableConfig] = None
+            if record.get("parent_checkpoint_id"):
+                parent_config = {
+                    "configurable": {
+                        "thread_id": thread_id,
+                        "checkpoint_ns": checkpoint_ns,
+                        "checkpoint_id": record["parent_checkpoint_id"],
+                    }
+                }
+
+            return CheckpointTuple(
+                config={
+                    "configurable": {
+                        "thread_id": thread_id,
+                        "checkpoint_ns": checkpoint_ns,
+                        "checkpoint_id": record["checkpoint_id"],
+                    }
+                },
+                checkpoint=checkpoint,
+                metadata=metadata,
+                pending_writes=pending_writes,
+                parent_config=parent_config,
+            )
+
+    def list(  # pylint: disable=redefined-builtin
+        self,
+        config: Optional[RunnableConfig],
+        *,
+        filter: Optional[Dict[str, Any]] = None,
+        before: Optional[RunnableConfig] = None,
+        limit: Optional[int] = None,
+    ) -> Iterator[CheckpointTuple]:
+        """Yield checkpoint tuples matching the criteria, most recent first.
+
+        Args:
+            config: Base config for filtering (uses ``thread_id``).  If
+                ``None``, all threads are listed.
+            filter: Metadata key/value pairs that must all match.
+            before: Yield only checkpoints whose checkpoint_id is
+                lexicographically less than the checkpoint_id in *before*.
+            limit: Maximum number of tuples to yield.
+
+        Yields:
+            ``CheckpointTuple`` objects, most-recent first.
+        """
+        self._ensure_loaded()
+
+        with self._lock:
+            if config:
+                thread_id = config["configurable"]["thread_id"]
+                thread_ids = [thread_id]
+                config_ns = config["configurable"].get("checkpoint_ns", "")
+            else:
+                all_keys = list(self._checkpoints.keys())
+                thread_ids = list({k[0] for k in all_keys})
+                config_ns = None
+
+            before_id = get_checkpoint_id(before) if before else None
+            remaining = limit
+
+            for tid in thread_ids:
+                namespaces = (
+                    [config_ns]
+                    if config_ns is not None
+                    else [k[1] for k in self._checkpoints if k[0] == tid]
+                )
+
+                for ns in namespaces:
+                    records = self._checkpoints.get((tid, ns), [])
+                    # Most recent first
+                    for record in reversed(records):
+                        cid = record["checkpoint_id"]
+
+                        if before_id and cid >= before_id:
+                            continue
+
+                        checkpoint: Checkpoint = _decode(self, record["checkpoint"])
+                        metadata: CheckpointMetadata = _decode(self, record["metadata"])
+
+                        if filter and not all(
+                            metadata.get(k) == v for k, v in filter.items()
+                        ):
+                            continue
+
+                        if remaining is not None and remaining <= 0:
+                            return
+                        if remaining is not None:
+                            remaining -= 1
+
+                        wkey = (tid, ns, cid)
+                        write_records = self._writes.get(wkey, [])
+                        pending_writes = [
+                            (w["task_id"], w["channel"], _decode(self, w["value"]))
+                            for w in write_records
+                        ]
+
+                        parent_config: Optional[RunnableConfig] = None
+                        if record.get("parent_checkpoint_id"):
+                            parent_config = {
+                                "configurable": {
+                                    "thread_id": tid,
+                                    "checkpoint_ns": ns,
+                                    "checkpoint_id": record["parent_checkpoint_id"],
+                                }
+                            }
+
+                        yield CheckpointTuple(
+                            config={
+                                "configurable": {
+                                    "thread_id": tid,
+                                    "checkpoint_ns": ns,
+                                    "checkpoint_id": cid,
+                                }
+                            },
+                            checkpoint=checkpoint,
+                            metadata=metadata,
+                            pending_writes=pending_writes,
+                            parent_config=parent_config,
+                        )
+
+    def put(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        """Persist a checkpoint and return the updated config.
+
+        Args:
+            config: Current runnable configuration.
+            checkpoint: Checkpoint dict including ``channel_values``.
+            metadata: Checkpoint metadata.
+            new_versions: Channel versions as of this write (passed through
+                for API compatibility; values are embedded in the serialized
+                checkpoint blob).
+
+        Returns:
+            Updated ``RunnableConfig`` with the checkpoint_id.
+
+        Raises:
+            PermissionError: If user_id is set and thread_id is foreign.
+        """
+        self._ensure_loaded()
+        thread_id: str = config["configurable"]["thread_id"]
+        checkpoint_ns: str = config["configurable"].get("checkpoint_ns", "")
+        parent_checkpoint_id: Optional[str] = config["configurable"].get(
+            "checkpoint_id"
+        )
+        checkpoint_id: str = checkpoint["id"]
+
+        self._validate_thread_ownership(thread_id)
+
+        versioned_metadata = dict(metadata) if metadata else {}
+        versioned_metadata["format_version"] = self.format_version
+
+        record: Dict[str, Any] = {
+            "record_type": "checkpoint",
+            "thread_id": thread_id,
+            "checkpoint_ns": checkpoint_ns,
+            "checkpoint_id": checkpoint_id,
+            "parent_checkpoint_id": parent_checkpoint_id,
+            "ts": checkpoint.get("ts", datetime.now(timezone.utc).isoformat()),
+            "checkpoint": _encode(self, checkpoint),
+            "metadata": _encode(
+                self, get_checkpoint_metadata(config, versioned_metadata)
+            ),
+            "format_version": self.format_version,
+        }
+
+        with self._lock:
+            self._append_record(record)
+            key = (thread_id, checkpoint_ns)
+            self._checkpoints[key].append(record)
+            self._prune(thread_id, checkpoint_ns)
+
+        LOGGER.debug(
+            "Saved checkpoint %s for thread %s (ns=%s)",
+            checkpoint_id,
+            thread_id,
+            checkpoint_ns,
+        )
+
+        return {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint_id,
+            }
+        }
+
+    def put_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        """Persist intermediate writes for a checkpoint.
+
+        Args:
+            config: Runnable configuration identifying the checkpoint.
+            writes: Sequence of ``(channel, value)`` tuples.
+            task_id: Identifier of the task producing the writes.
+            task_path: Task path for structured tracing (passed through).
+        """
+        self._ensure_loaded()
+        thread_id: str = config["configurable"]["thread_id"]
+        checkpoint_ns: str = config["configurable"].get("checkpoint_ns", "")
+        checkpoint_id: str = config["configurable"]["checkpoint_id"]
+
+        self._validate_thread_ownership(thread_id)
+
+        wkey = (thread_id, checkpoint_ns, checkpoint_id)
+
+        with self._lock:
+            existing = {
+                (w["task_id"], w["idx"]): True for w in self._writes.get(wkey, [])
+            }
+
+            for idx, (channel, value) in enumerate(writes):
+                real_idx = WRITES_IDX_MAP.get(channel, idx)
+                if real_idx >= 0 and (task_id, real_idx) in existing:
+                    continue
+
+                record: Dict[str, Any] = {
+                    "record_type": "write",
+                    "thread_id": thread_id,
+                    "checkpoint_ns": checkpoint_ns,
+                    "checkpoint_id": checkpoint_id,
+                    "task_id": task_id,
+                    "task_path": task_path,
+                    "idx": real_idx,
+                    "channel": channel,
+                    "value": _encode(self, value),
+                }
+                self._append_record(record)
+                self._writes[wkey].append(record)
+                existing[(task_id, real_idx)] = True
+
+    # ------------------------------------------------------------------
+    # BaseCheckpointSaver async interface
+    # ------------------------------------------------------------------
+
+    async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        """Async version of get_tuple (delegates to sync via thread pool)."""
+        return await asyncio.to_thread(self.get_tuple, config)
+
+    async def alist(
+        self,
+        config: Optional[RunnableConfig],
+        *,
+        filter: Optional[Dict[str, Any]] = None,
+        before: Optional[RunnableConfig] = None,
+        limit: Optional[int] = None,
+    ):
+        """Async version of list — collects sync results and yields them."""
+        results = await asyncio.to_thread(
+            lambda: list(self.list(config, filter=filter, before=before, limit=limit))
+        )
+        for item in results:
+            yield item
+
+    async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        """Async version of put (delegates to sync via thread pool)."""
+        return await asyncio.to_thread(
+            self.put, config, checkpoint, metadata, new_versions
+        )
+
+    async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        """Async version of put_writes (delegates to sync via thread pool)."""
+        await asyncio.to_thread(self.put_writes, config, writes, task_id, task_path)
+
+    # ------------------------------------------------------------------
+    # QueryableCheckpointerMixin implementation
+    # ------------------------------------------------------------------
+
+    def get_user_threads(
+        self,
+        user_identifier: str,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """Return thread metadata for all threads belonging to *user_identifier*.
+
+        Threads are matched when ``thread_id == user_identifier`` or
+        ``thread_id.startswith(f"{user_identifier}_")``.
+
+        Args:
+            user_identifier: User email or ID.
+            limit: Maximum number of threads to return.
+            offset: Number of threads to skip.
+
+        Returns:
+            List of thread dicts (thread_id, conversation_id, checkpoint_count,
+            message_count, first_message, last_message, title, tags,
+            last_updated).
+        """
+        self._ensure_loaded()
+
+        with self._lock:
+            matching_keys = [
+                k
+                for k in self._checkpoints
+                if k[0] == user_identifier or k[0].startswith(f"{user_identifier}_")
+            ]
+
+        threads = []
+        for key in matching_keys:
+            tid = key[0]
+            with self._lock:
+                records = list(self._checkpoints.get(key, []))
+            if not records:
+                continue
+
+            latest_record = records[-1]
+            conversation_id = tid.split("_", 1)[1] if "_" in tid else "default"
+
+            checkpoint_obj = None
+            try:
+                checkpoint_obj = _decode(self, latest_record["checkpoint"])
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+
+            first_message = None
+            last_message = None
+            message_count = 0
+            title = None
+            tags: List[str] = []
+
+            if checkpoint_obj:
+                channel_values = checkpoint_obj.get("channel_values", {})
+                messages = channel_values.get("messages", [])
+                title = channel_values.get("title")
+                tags = channel_values.get("tags", [])
+                if messages:
+                    message_count = len(messages)
+                    for msg in messages:
+                        if hasattr(msg, "content") and msg.content:
+                            if msg.__class__.__name__ == "HumanMessage":
+                                content = msg.content
+                                if isinstance(content, list):
+                                    content = " ".join(
+                                        p.get("text", "")
+                                        for p in content
+                                        if isinstance(p, dict)
+                                        and p.get("type") == "text"
+                                    )
+                                if first_message is None:
+                                    first_message = content
+                                last_message = content
+
+            threads.append(
+                {
+                    "thread_id": tid,
+                    "conversation_id": conversation_id,
+                    "last_updated": latest_record.get("ts"),
+                    "checkpoint_count": len(records),
+                    "message_count": message_count,
+                    "first_message": first_message,
+                    "last_message": last_message,
+                    "title": title,
+                    "tags": tags,
+                }
+            )
+
+        # Sort most-recent first
+        threads.sort(key=lambda t: t["last_updated"] or "", reverse=True)
+
+        if offset > 0 or limit is not None:
+            end = offset + limit if limit is not None else None
+            threads = threads[offset:end]
+
+        return threads
+
+    def get_thread_messages(
+        self,
+        thread_id: str,
+        limit: Optional[int] = None,
+        offset: int = 0,
+        message_types: Optional[List[str]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return messages from the latest checkpoint for *thread_id*.
+
+        Args:
+            thread_id: Thread to read.
+            limit: Maximum number of messages to return.
+            offset: Number of messages to skip.
+            message_types: Filter to specific message class names.
+
+        Returns:
+            List of ``{role, content, timestamp}`` dicts.
+        """
+        self._validate_thread_ownership(thread_id)
+        config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+        tup = self.get_tuple(config)
+        if not tup or not tup.checkpoint:
+            return []
+
+        channel_values = tup.checkpoint.get("channel_values", {})
+        raw_messages = channel_values.get("messages", [])
+
+        messages = []
+        for msg in raw_messages:
+            msg_class = (
+                msg.__class__.__name__ if hasattr(msg, "__class__") else "unknown"
+            )
+
+            if message_types is not None and msg_class not in message_types:
+                continue
+
+            content = msg.content if hasattr(msg, "content") else str(msg)
+            if isinstance(content, list):
+                content = " ".join(
+                    p.get("text", "")
+                    for p in content
+                    if isinstance(p, dict) and p.get("type") == "text"
+                )
+
+            if msg_class == "AIMessage":
+                content = self._strip_thinking_blocks(content)
+                if not content:
+                    continue
+
+            role_map = {
+                "HumanMessage": "user",
+                "AIMessage": "assistant",
+                "SystemMessage": "system",
+                "ToolMessage": "tool",
+                "FunctionMessage": "function",
+            }
+            messages.append(
+                {
+                    "role": role_map.get(msg_class, "unknown"),
+                    "content": content,
+                    "timestamp": None,
+                }
+            )
+
+        if offset > 0 or limit is not None:
+            end = offset + limit if limit is not None else None
+            messages = messages[offset:end]
+
+        return messages
+
+    def delete_thread(self, thread_id: str) -> bool:
+        """Remove all checkpoints and writes for *thread_id* from index and file.
+
+        Args:
+            thread_id: Thread to delete.
+
+        Returns:
+            ``True`` if any records were removed.
+        """
+        self._validate_thread_ownership(thread_id)
+        self._ensure_loaded()
+
+        with self._lock:
+            keys_to_delete = [k for k in self._checkpoints if k[0] == thread_id]
+            if not keys_to_delete:
+                return False
+
+            for k in keys_to_delete:
+                del self._checkpoints[k]
+
+            write_keys = [k for k in self._writes if k[0] == thread_id]
+            for k in write_keys:
+                del self._writes[k]
+
+            self._rewrite_file()
+        return True
+
+    def get_user_stats(self, user_identifier: str) -> Dict[str, Any]:
+        """Return aggregate statistics for a user.
+
+        Args:
+            user_identifier: User email or ID.
+
+        Returns:
+            Dict with total_threads, total_messages, total_checkpoints,
+            oldest_thread, newest_thread.
+        """
+        threads = self.get_user_threads(user_identifier)
+        if not threads:
+            return {
+                "total_threads": 0,
+                "total_messages": 0,
+                "total_checkpoints": 0,
+                "oldest_thread": None,
+                "newest_thread": None,
+            }
+
+        total_messages = sum(t["message_count"] for t in threads)
+        total_checkpoints = sum(t["checkpoint_count"] for t in threads)
+        timestamps = [t["last_updated"] for t in threads if t["last_updated"]]
+        return {
+            "total_threads": len(threads),
+            "total_messages": total_messages,
+            "total_checkpoints": total_checkpoints,
+            "oldest_thread": min(timestamps, default=None),
+            "newest_thread": max(timestamps, default=None),
+        }
+
+    def thread_exists(self, thread_id: str) -> bool:
+        """Return ``True`` if any checkpoint exists for *thread_id*.
+
+        Args:
+            thread_id: Thread to check.
+        """
+        self._ensure_loaded()
+        with self._lock:
+            return any(k[0] == thread_id for k in self._checkpoints)
+
+    # ------------------------------------------------------------------
+    # VersionedCheckpointerMixin abstract method implementations
+    # ------------------------------------------------------------------
+
+    def _get_raw_checkpoint(
+        self, thread_id: str, checkpoint_ns: str = ""
+    ) -> Optional[Dict[str, Any]]:
+        """Return the most recent raw checkpoint record for *thread_id*."""
+        self._ensure_loaded()
+        with self._lock:
+            records = self._checkpoints.get((thread_id, checkpoint_ns), [])
+            return records[-1] if records else None
+
+    def _replace_raw_checkpoint(
+        self,
+        thread_id: str,
+        document: Dict[str, Any],
+        checkpoint_ns: str = "",
+    ) -> bool:
+        """Replace the most recent checkpoint record in the index and rewrite file.
+
+        Args:
+            thread_id: Thread to update.
+            document: Migrated record to write back.
+            checkpoint_ns: Checkpoint namespace.
+
+        Returns:
+            ``True`` if a record was found and replaced.
+        """
+        if "checkpoint_id" not in document:
+            LOGGER.warning(
+                "Cannot replace checkpoint without checkpoint_id for thread %s",
+                thread_id,
+            )
+            return False
+
+        with self._lock:
+            key = (thread_id, checkpoint_ns)
+            records = self._checkpoints.get(key, [])
+            for i, rec in enumerate(records):
+                if rec["checkpoint_id"] == document["checkpoint_id"]:
+                    records[i] = document
+                    self._rewrite_file()
+                    return True
+        return False
+
+    def _archive_checkpoint(
+        self,
+        thread_id: str,
+        document: Dict[str, Any],
+        error: Exception,
+    ) -> None:
+        """Write a failed-migration record to a sidecar ``.archive`` file.
+
+        Args:
+            thread_id: Thread ID of the failed checkpoint.
+            document: Raw record that could not be migrated.
+            error: Exception raised during migration.
+        """
+        archive_path = self._path + ".archive"
+        archive_record = {
+            "record_type": "archive",
+            "thread_id": thread_id,
+            "checkpoint_id": document.get("checkpoint_id"),
+            "migration_error": str(error),
+            "raw_document": document,
+            "archived_at": datetime.now(timezone.utc).isoformat(),
+        }
+        dir_path = os.path.dirname(archive_path)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
+        with open(archive_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(archive_record, ensure_ascii=False) + "\n")
+        LOGGER.info(
+            "Archived failed checkpoint for thread %s to %s", thread_id, archive_path
+        )
+
+
+# ------------------------------------------------------------------
+# Factory functions
+# ------------------------------------------------------------------
+
+
+def get_jsonl_checkpointer(
+    path: Optional[str] = None,
+    keep_last_n: int = -1,
+    user_id: Optional[str] = None,
+) -> JSONLCheckpointSaver:
+    """Create and return a JSONLCheckpointSaver.
+
+    Args:
+        path: Path to the JSONL file.  Falls back to ``JSONL_CHECKPOINT_PATH``
+            env var then ``~/.bili/checkpoints/aether.jsonl``.
+        keep_last_n: Pruning limit per thread (``-1`` = unlimited).
+        user_id: Enable thread ownership validation for this user.
+
+    Returns:
+        A ready-to-use ``JSONLCheckpointSaver``.
+    """
+    return JSONLCheckpointSaver(path=path, keep_last_n=keep_last_n, user_id=user_id)
+
+
+async def get_async_jsonl_checkpointer(
+    path: Optional[str] = None,
+    keep_last_n: int = -1,
+    user_id: Optional[str] = None,
+) -> JSONLCheckpointSaver:
+    """Async factory — returns a JSONLCheckpointSaver (no async setup needed).
+
+    The saver's async methods delegate to sync via ``asyncio.to_thread``, so
+    no coroutine-based setup is required.  This function exists to match the
+    async-factory convention of the PostgreSQL and MongoDB savers.
+
+    Args:
+        path: Path to the JSONL file.
+        keep_last_n: Pruning limit (``-1`` = unlimited).
+        user_id: Enable thread ownership validation.
+
+    Returns:
+        A ``JSONLCheckpointSaver`` instance.
+    """
+    return JSONLCheckpointSaver(path=path, keep_last_n=keep_last_n, user_id=user_id)

--- a/bili/iris/checkpointers/jsonl_checkpointer.py
+++ b/bili/iris/checkpointers/jsonl_checkpointer.py
@@ -482,6 +482,12 @@ class JSONLCheckpointSaver(
 
         Raises:
             PermissionError: If user_id is set and thread_id is foreign.
+
+        Note:
+            There is a narrow partial-write window: the append to the JSONL file
+            succeeds before ``_prune`` rewrites it.  If the process crashes between
+            those two steps, pruned records will reappear on the next
+            ``_load_from_disk`` call, but no data is lost or corrupted.
         """
         self._ensure_loaded()
         thread_id: str = config["configurable"]["thread_id"]

--- a/bili/iris/checkpointers/tests/test_jsonl_checkpointer.py
+++ b/bili/iris/checkpointers/tests/test_jsonl_checkpointer.py
@@ -1,0 +1,921 @@
+"""Tests for bili.iris.checkpointers.jsonl_checkpointer module.
+
+Covers the full BaseCheckpointSaver + QueryableCheckpointerMixin +
+VersionedCheckpointerMixin contract including:
+- Round-trip put/get_tuple (sync + async)
+- put_writes / pending_writes reconstruction
+- list() ordering and filters
+- File-persistence: saver reconstructed from same path returns prior checkpoints
+- Thread isolation: multiple threads in one file do not bleed
+- Thread ownership validation (user_id)
+- Pruning (keep_last_n) + compaction
+- Async delegates (aget_tuple, aput, aput_writes, alist)
+- QueryableCheckpointerMixin methods (get_user_threads, get_thread_messages,
+  delete_thread, get_user_stats, thread_exists)
+- In-process concurrency smoke test (two threads, different thread_ids)
+- VersionedCheckpointerMixin helpers (_get_raw_checkpoint,
+  _replace_raw_checkpoint, _archive_checkpoint)
+"""
+
+import asyncio
+import json
+import os
+import threading
+from typing import Any, Dict
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from bili.iris.checkpointers.jsonl_checkpointer import (
+    JSONLCheckpointSaver,
+    get_async_jsonl_checkpointer,
+    get_jsonl_checkpointer,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_config(
+    thread_id: str,
+    checkpoint_ns: str = "",
+    checkpoint_id: str | None = None,
+) -> Dict[str, Any]:
+    cfg: Dict[str, Any] = {
+        "configurable": {"thread_id": thread_id, "checkpoint_ns": checkpoint_ns}
+    }
+    if checkpoint_id:
+        cfg["configurable"]["checkpoint_id"] = checkpoint_id
+    return cfg
+
+
+def _minimal_checkpoint(checkpoint_id: str = "cp-1") -> Dict[str, Any]:
+    return {
+        "id": checkpoint_id,
+        "ts": "2024-01-01T00:00:00+00:00",
+        "v": 1,
+        "channel_values": {"messages": [], "agent_outputs": {}},
+        "channel_versions": {},
+        "versions_seen": {},
+        "pending_sends": [],
+    }
+
+
+def _minimal_metadata() -> Dict[str, Any]:
+    return {"source": "test", "step": 0, "writes": {}}
+
+
+def _human_message(content: str) -> HumanMessage:
+    return HumanMessage(content=content)
+
+
+def _ai_message(content: str) -> AIMessage:
+    return AIMessage(content=content)
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    """Verify JSONLCheckpointSaver initialisation."""
+
+    def test_default_path_from_env(self, monkeypatch, tmp_path):
+        """Env var JSONL_CHECKPOINT_PATH is respected."""
+        target = str(tmp_path / "env.jsonl")
+        monkeypatch.setenv("JSONL_CHECKPOINT_PATH", target)
+        saver = JSONLCheckpointSaver()
+        assert saver.path == target
+
+    def test_explicit_path_overrides_env(self, monkeypatch, tmp_path):
+        """Explicit path takes priority over env var."""
+        monkeypatch.setenv("JSONL_CHECKPOINT_PATH", "/ignored")
+        target = str(tmp_path / "explicit.jsonl")
+        saver = JSONLCheckpointSaver(path=target)
+        assert saver.path == target
+
+    def test_tilde_expansion(self, tmp_path):
+        """Home-dir expansion works."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "x.jsonl"))
+        assert "~" not in saver.path
+
+    def test_keep_last_n_default(self, tmp_path):
+        """keep_last_n defaults to -1 (unlimited)."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "x.jsonl"))
+        assert saver.keep_last_n == -1
+
+    def test_user_id_default(self, tmp_path):
+        """user_id defaults to None."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "x.jsonl"))
+        assert saver.user_id is None
+
+    def test_factory_get_jsonl_checkpointer(self, tmp_path):
+        """get_jsonl_checkpointer returns a JSONLCheckpointSaver."""
+        saver = get_jsonl_checkpointer(path=str(tmp_path / "x.jsonl"))
+        assert isinstance(saver, JSONLCheckpointSaver)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: put / get_tuple
+# ---------------------------------------------------------------------------
+
+
+class TestPutGetRoundTrip:
+    """put() then get_tuple() returns the saved checkpoint."""
+
+    def test_basic_round_trip(self, tmp_path):
+        """Single put; get_tuple without checkpoint_id returns it."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        config = _minimal_config("thread-1")
+        ck = _minimal_checkpoint("cp-1")
+        new_config = saver.put(config, ck, _minimal_metadata(), {})
+        assert new_config["configurable"]["checkpoint_id"] == "cp-1"
+
+        tup = saver.get_tuple(_minimal_config("thread-1"))
+        assert tup is not None
+        assert tup.checkpoint["id"] == "cp-1"
+
+    def test_get_tuple_by_checkpoint_id(self, tmp_path):
+        """get_tuple with explicit checkpoint_id fetches the right one."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        config = _minimal_config("thread-1")
+        saver.put(config, _minimal_checkpoint("cp-1"), _minimal_metadata(), {})
+        config2 = _minimal_config("thread-1", checkpoint_id="cp-1")
+        saver.put(config2, _minimal_checkpoint("cp-2"), _minimal_metadata(), {})
+
+        tup = saver.get_tuple(_minimal_config("thread-1", checkpoint_id="cp-1"))
+        assert tup is not None
+        assert tup.checkpoint["id"] == "cp-1"
+
+    def test_get_tuple_unknown_checkpoint_id_returns_none(self, tmp_path):
+        """get_tuple with a non-existent checkpoint_id returns None."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        saver.put(
+            _minimal_config("thread-1"),
+            _minimal_checkpoint("cp-1"),
+            _minimal_metadata(),
+            {},
+        )
+        tup = saver.get_tuple(_minimal_config("thread-1", checkpoint_id="ghost"))
+        assert tup is None
+
+    def test_get_tuple_empty_thread_returns_none(self, tmp_path):
+        """get_tuple on a thread with no checkpoints returns None."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        tup = saver.get_tuple(_minimal_config("nonexistent"))
+        assert tup is None
+
+    def test_channel_values_preserved(self, tmp_path):
+        """channel_values (messages, agent_outputs) survive a round-trip."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        ck = _minimal_checkpoint("cp-1")
+        ck["channel_values"] = {
+            "messages": ["hello"],
+            "agent_outputs": {"agent_0": {"message": "Hi"}},
+        }
+        saver.put(_minimal_config("thread-1"), ck, _minimal_metadata(), {})
+        tup = saver.get_tuple(_minimal_config("thread-1"))
+        assert tup.checkpoint["channel_values"]["agent_outputs"]["agent_0"] == {
+            "message": "Hi"
+        }
+
+    def test_parent_checkpoint_id_chain(self, tmp_path):
+        """parent_config is populated from parent_checkpoint_id."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        # First put (no parent)
+        saver.put(
+            _minimal_config("thread-1"),
+            _minimal_checkpoint("cp-1"),
+            _minimal_metadata(),
+            {},
+        )
+        # Second put (parent = cp-1)
+        saver.put(
+            _minimal_config("thread-1", checkpoint_id="cp-1"),
+            _minimal_checkpoint("cp-2"),
+            _minimal_metadata(),
+            {},
+        )
+        tup = saver.get_tuple(_minimal_config("thread-1"))
+        assert tup.checkpoint["id"] == "cp-2"
+        assert tup.parent_config is not None
+        assert tup.parent_config["configurable"]["checkpoint_id"] == "cp-1"
+
+
+# ---------------------------------------------------------------------------
+# File persistence
+# ---------------------------------------------------------------------------
+
+
+class TestFilePersistence:
+    """Checkpoints survive saver reconstruction from the same path."""
+
+    def test_reload_from_disk(self, tmp_path):
+        """Constructing a new saver from the same path finds prior checkpoints."""
+        path = str(tmp_path / "persist.jsonl")
+        s1 = JSONLCheckpointSaver(path=path)
+        s1.put(
+            _minimal_config("thread-1"),
+            _minimal_checkpoint("cp-1"),
+            _minimal_metadata(),
+            {},
+        )
+
+        s2 = JSONLCheckpointSaver(path=path)
+        tup = s2.get_tuple(_minimal_config("thread-1"))
+        assert tup is not None
+        assert tup.checkpoint["id"] == "cp-1"
+
+    def test_multiple_threads_on_disk(self, tmp_path):
+        """Multiple threads in one file are each accessible after reload."""
+        path = str(tmp_path / "multi.jsonl")
+        s1 = JSONLCheckpointSaver(path=path)
+        for i in range(3):
+            s1.put(
+                _minimal_config(f"thread-{i}"),
+                _minimal_checkpoint(f"cp-{i}"),
+                _minimal_metadata(),
+                {},
+            )
+
+        s2 = JSONLCheckpointSaver(path=path)
+        for i in range(3):
+            tup = s2.get_tuple(_minimal_config(f"thread-{i}"))
+            assert tup is not None
+            assert tup.checkpoint["id"] == f"cp-{i}"
+
+
+# ---------------------------------------------------------------------------
+# put_writes / pending_writes
+# ---------------------------------------------------------------------------
+
+
+class TestPutWrites:
+    """put_writes stores pending writes; get_tuple returns them in pending_writes."""
+
+    def test_pending_writes_in_get_tuple(self, tmp_path):
+        """Writes are attached to the checkpoint in pending_writes."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        config = _minimal_config("thread-1")
+        new_config = saver.put(
+            config, _minimal_checkpoint("cp-1"), _minimal_metadata(), {}
+        )
+
+        write_config = {
+            "configurable": {
+                "thread_id": "thread-1",
+                "checkpoint_ns": "",
+                "checkpoint_id": "cp-1",
+            }
+        }
+        saver.put_writes(write_config, [("messages", "hello")], task_id="task-1")
+
+        tup = saver.get_tuple(_minimal_config("thread-1"))
+        assert tup is not None
+        assert len(tup.pending_writes) == 1
+        task_id, channel, value = tup.pending_writes[0]
+        assert task_id == "task-1"
+        assert channel == "messages"
+        assert value == "hello"
+
+    def test_duplicate_writes_deduped(self, tmp_path):
+        """Calling put_writes twice with the same (task_id, idx) is idempotent."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        saver.put(
+            _minimal_config("thread-1"),
+            _minimal_checkpoint("cp-1"),
+            _minimal_metadata(),
+            {},
+        )
+        write_config = {
+            "configurable": {
+                "thread_id": "thread-1",
+                "checkpoint_ns": "",
+                "checkpoint_id": "cp-1",
+            }
+        }
+        saver.put_writes(write_config, [("messages", "first")], task_id="task-1")
+        saver.put_writes(write_config, [("messages", "second")], task_id="task-1")
+
+        tup = saver.get_tuple(_minimal_config("thread-1"))
+        assert len(tup.pending_writes) == 1
+        assert tup.pending_writes[0][2] == "first"
+
+
+# ---------------------------------------------------------------------------
+# list()
+# ---------------------------------------------------------------------------
+
+
+class TestList:
+    """list() yields checkpoint tuples most-recent first with correct filters."""
+
+    def test_list_most_recent_first(self, tmp_path):
+        """list() returns checkpoints in reverse insertion order."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        for i in range(3):
+            saver.put(
+                _minimal_config("thread-1", checkpoint_id=f"cp-{i}" if i else None),
+                _minimal_checkpoint(f"cp-{i}"),
+                _minimal_metadata(),
+                {},
+            )
+        ids = [t.checkpoint["id"] for t in saver.list(_minimal_config("thread-1"))]
+        assert ids == ["cp-2", "cp-1", "cp-0"]
+
+    def test_list_limit(self, tmp_path):
+        """list(limit=1) returns at most one tuple."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        for i in range(3):
+            saver.put(
+                _minimal_config("thread-1"),
+                _minimal_checkpoint(f"cp-{i}"),
+                _minimal_metadata(),
+                {},
+            )
+        results = list(saver.list(_minimal_config("thread-1"), limit=1))
+        assert len(results) == 1
+
+    def test_list_before_filter(self, tmp_path):
+        """list(before=config) excludes checkpoints at or after before.checkpoint_id."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        saver.put(
+            _minimal_config("thread-1"),
+            _minimal_checkpoint("cp-1"),
+            _minimal_metadata(),
+            {},
+        )
+        saver.put(
+            _minimal_config("thread-1", checkpoint_id="cp-1"),
+            _minimal_checkpoint("cp-2"),
+            _minimal_metadata(),
+            {},
+        )
+        before_cfg = _minimal_config("thread-1", checkpoint_id="cp-2")
+        results = list(saver.list(_minimal_config("thread-1"), before=before_cfg))
+        assert all(t.checkpoint["id"] < "cp-2" for t in results)
+
+    def test_list_empty_thread(self, tmp_path):
+        """list() on unknown thread_id returns empty."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        results = list(saver.list(_minimal_config("ghost")))
+        assert results == []
+
+    def test_list_metadata_filter(self, tmp_path):
+        """list(filter=...) respects metadata key/value matching."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        md1 = {"source": "input", "step": 0, "writes": {}}
+        md2 = {"source": "loop", "step": 1, "writes": {}}
+        saver.put(_minimal_config("t"), _minimal_checkpoint("cp-1"), md1, {})
+        saver.put(_minimal_config("t"), _minimal_checkpoint("cp-2"), md2, {})
+        results = list(saver.list(_minimal_config("t"), filter={"source": "loop"}))
+        assert len(results) == 1
+        assert results[0].checkpoint["id"] == "cp-2"
+
+
+# ---------------------------------------------------------------------------
+# Thread isolation
+# ---------------------------------------------------------------------------
+
+
+class TestThreadIsolation:
+    """Records for different thread_ids in one file do not cross."""
+
+    def test_get_tuple_does_not_cross_threads(self, tmp_path):
+        """Checkpoint written for thread-A is not returned for thread-B."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        saver.put(
+            _minimal_config("thread-A"),
+            _minimal_checkpoint("cp-A"),
+            _minimal_metadata(),
+            {},
+        )
+        tup = saver.get_tuple(_minimal_config("thread-B"))
+        assert tup is None
+
+    def test_list_scoped_to_thread(self, tmp_path):
+        """list() for thread-B returns only thread-B checkpoints."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        saver.put(
+            _minimal_config("thread-A"),
+            _minimal_checkpoint("cp-A"),
+            _minimal_metadata(),
+            {},
+        )
+        saver.put(
+            _minimal_config("thread-B"),
+            _minimal_checkpoint("cp-B"),
+            _minimal_metadata(),
+            {},
+        )
+        ids = [t.checkpoint["id"] for t in saver.list(_minimal_config("thread-B"))]
+        assert ids == ["cp-B"]
+
+
+# ---------------------------------------------------------------------------
+# Thread ownership validation
+# ---------------------------------------------------------------------------
+
+
+class TestOwnershipValidation:
+    """user_id-scoped saver rejects foreign thread_ids."""
+
+    def test_put_raises_on_foreign_thread(self, tmp_path):
+        """put() with a foreign thread_id raises PermissionError."""
+        saver = JSONLCheckpointSaver(
+            path=str(tmp_path / "ck.jsonl"), user_id="alice@test.com"
+        )
+        with pytest.raises(PermissionError):
+            saver.put(
+                _minimal_config("bob@test.com"),
+                _minimal_checkpoint("cp-1"),
+                _minimal_metadata(),
+                {},
+            )
+
+    def test_put_allows_owned_thread(self, tmp_path):
+        """put() with a matching thread_id succeeds."""
+        saver = JSONLCheckpointSaver(
+            path=str(tmp_path / "ck.jsonl"), user_id="alice@test.com"
+        )
+        cfg = saver.put(
+            _minimal_config("alice@test.com"),
+            _minimal_checkpoint("cp-1"),
+            _minimal_metadata(),
+            {},
+        )
+        assert cfg["configurable"]["checkpoint_id"] == "cp-1"
+
+    def test_put_allows_user_id_prefixed_thread(self, tmp_path):
+        """thread_id of the form user_id_conv123 is accepted."""
+        saver = JSONLCheckpointSaver(
+            path=str(tmp_path / "ck.jsonl"), user_id="alice@test.com"
+        )
+        cfg = saver.put(
+            _minimal_config("alice@test.com_conv-42"),
+            _minimal_checkpoint("cp-1"),
+            _minimal_metadata(),
+            {},
+        )
+        assert cfg["configurable"]["checkpoint_id"] == "cp-1"
+
+    def test_get_tuple_raises_on_foreign_thread(self, tmp_path):
+        """get_tuple() with a foreign thread_id raises PermissionError."""
+        saver = JSONLCheckpointSaver(
+            path=str(tmp_path / "ck.jsonl"), user_id="alice@test.com"
+        )
+        with pytest.raises(PermissionError):
+            saver.get_tuple(_minimal_config("bob@test.com"))
+
+    def test_no_user_id_accepts_any_thread(self, tmp_path):
+        """Saver without user_id accepts any thread_id."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        saver.put(
+            _minimal_config("any-thread"),
+            _minimal_checkpoint("cp-1"),
+            _minimal_metadata(),
+            {},
+        )
+        tup = saver.get_tuple(_minimal_config("any-thread"))
+        assert tup is not None
+
+
+# ---------------------------------------------------------------------------
+# Pruning
+# ---------------------------------------------------------------------------
+
+
+class TestPruning:
+    """keep_last_n removes old checkpoints on put()."""
+
+    def test_prune_removes_oldest(self, tmp_path):
+        """After 3 puts with keep_last_n=2, only the 2 newest are accessible."""
+        path = str(tmp_path / "ck.jsonl")
+        saver = JSONLCheckpointSaver(path=path, keep_last_n=2)
+        for i in range(3):
+            saver.put(
+                _minimal_config("thread-1"),
+                _minimal_checkpoint(f"cp-{i}"),
+                _minimal_metadata(),
+                {},
+            )
+
+        ids = [t.checkpoint["id"] for t in saver.list(_minimal_config("thread-1"))]
+        assert "cp-0" not in ids
+        assert "cp-1" in ids
+        assert "cp-2" in ids
+
+    def test_prune_compacts_file(self, tmp_path):
+        """After pruning, the JSONL file contains no record for the removed checkpoint."""
+        path = str(tmp_path / "ck.jsonl")
+        saver = JSONLCheckpointSaver(path=path, keep_last_n=2)
+        for i in range(3):
+            saver.put(
+                _minimal_config("thread-1"),
+                _minimal_checkpoint(f"cp-{i}"),
+                _minimal_metadata(),
+                {},
+            )
+
+        with open(path, "r", encoding="utf-8") as fh:
+            lines = [json.loads(l) for l in fh if l.strip()]
+        checkpoint_ids = {
+            l["checkpoint_id"] for l in lines if l.get("record_type") == "checkpoint"
+        }
+        assert "cp-0" not in checkpoint_ids
+
+    def test_reload_after_prune(self, tmp_path):
+        """New saver from same path after pruning only sees kept checkpoints."""
+        path = str(tmp_path / "ck.jsonl")
+        s1 = JSONLCheckpointSaver(path=path, keep_last_n=1)
+        for i in range(3):
+            s1.put(
+                _minimal_config("thread-1"),
+                _minimal_checkpoint(f"cp-{i}"),
+                _minimal_metadata(),
+                {},
+            )
+
+        s2 = JSONLCheckpointSaver(path=path)
+        ids = [t.checkpoint["id"] for t in s2.list(_minimal_config("thread-1"))]
+        assert ids == ["cp-2"]
+
+
+# ---------------------------------------------------------------------------
+# Async delegates
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncDelegates:
+    """Async methods (aget_tuple, aput, aput_writes, alist) work correctly."""
+
+    def test_aput_and_aget_tuple(self, tmp_path):
+        """aput() followed by aget_tuple() returns the checkpoint."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+
+        async def _run():
+            config = _minimal_config("async-thread")
+            await saver.aput(
+                config, _minimal_checkpoint("cp-1"), _minimal_metadata(), {}
+            )
+            return await saver.aget_tuple(_minimal_config("async-thread"))
+
+        tup = asyncio.run(_run())
+        assert tup is not None
+        assert tup.checkpoint["id"] == "cp-1"
+
+    def test_aput_writes_appear_in_aget_tuple(self, tmp_path):
+        """aput_writes results appear in aget_tuple pending_writes."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+
+        async def _run():
+            await saver.aput(
+                _minimal_config("async-t"),
+                _minimal_checkpoint("cp-1"),
+                _minimal_metadata(),
+                {},
+            )
+            write_cfg = {
+                "configurable": {
+                    "thread_id": "async-t",
+                    "checkpoint_ns": "",
+                    "checkpoint_id": "cp-1",
+                }
+            }
+            await saver.aput_writes(write_cfg, [("ch", "v")], task_id="t1")
+            return await saver.aget_tuple(_minimal_config("async-t"))
+
+        tup = asyncio.run(_run())
+        assert len(tup.pending_writes) == 1
+        assert tup.pending_writes[0][1] == "ch"
+
+    def test_alist_yields_results(self, tmp_path):
+        """alist() yields all checkpoint tuples for the thread."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        for i in range(3):
+            saver.put(
+                _minimal_config("async-t"),
+                _minimal_checkpoint(f"cp-{i}"),
+                _minimal_metadata(),
+                {},
+            )
+
+        async def _run():
+            return [t async for t in saver.alist(_minimal_config("async-t"))]
+
+        results = asyncio.run(_run())
+        assert len(results) == 3
+
+    def test_get_async_jsonl_checkpointer_factory(self, tmp_path):
+        """get_async_jsonl_checkpointer() returns a JSONLCheckpointSaver."""
+
+        async def _run():
+            return await get_async_jsonl_checkpointer(path=str(tmp_path / "ck.jsonl"))
+
+        saver = asyncio.run(_run())
+        assert isinstance(saver, JSONLCheckpointSaver)
+
+
+# ---------------------------------------------------------------------------
+# QueryableCheckpointerMixin
+# ---------------------------------------------------------------------------
+
+
+class TestQueryableMixin:
+    """get_user_threads, get_thread_messages, delete_thread, get_user_stats,
+    thread_exists."""
+
+    def test_thread_exists_true(self, tmp_path):
+        """thread_exists returns True after a put."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        saver.put(
+            _minimal_config("alice_conv1"),
+            _minimal_checkpoint("cp-1"),
+            _minimal_metadata(),
+            {},
+        )
+        assert saver.thread_exists("alice_conv1") is True
+
+    def test_thread_exists_false(self, tmp_path):
+        """thread_exists returns False for unknown thread."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        assert saver.thread_exists("ghost") is False
+
+    def test_get_user_threads_matches_prefix(self, tmp_path):
+        """get_user_threads returns threads owned by user (prefix pattern)."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        saver.put(
+            _minimal_config("alice_conv1"),
+            _minimal_checkpoint("cp-1"),
+            _minimal_metadata(),
+            {},
+        )
+        saver.put(
+            _minimal_config("alice_conv2"),
+            _minimal_checkpoint("cp-2"),
+            _minimal_metadata(),
+            {},
+        )
+        saver.put(
+            _minimal_config("bob_conv1"),
+            _minimal_checkpoint("cp-3"),
+            _minimal_metadata(),
+            {},
+        )
+        threads = saver.get_user_threads("alice")
+        tids = [t["thread_id"] for t in threads]
+        assert "alice_conv1" in tids
+        assert "alice_conv2" in tids
+        assert "bob_conv1" not in tids
+
+    def test_get_user_threads_limit_offset(self, tmp_path):
+        """limit and offset are respected."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        for i in range(5):
+            saver.put(
+                _minimal_config(f"alice_conv{i}"),
+                _minimal_checkpoint(f"cp-{i}"),
+                _minimal_metadata(),
+                {},
+            )
+        threads = saver.get_user_threads("alice", limit=2, offset=1)
+        assert len(threads) == 2
+
+    def test_get_user_threads_empty(self, tmp_path):
+        """get_user_threads for unknown user returns empty list."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        assert saver.get_user_threads("nobody") == []
+
+    def test_get_user_threads_exact_match(self, tmp_path):
+        """thread_id exactly equal to user_identifier is included."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        saver.put(
+            _minimal_config("alice"),
+            _minimal_checkpoint("cp-1"),
+            _minimal_metadata(),
+            {},
+        )
+        threads = saver.get_user_threads("alice")
+        assert len(threads) == 1
+        assert threads[0]["conversation_id"] == "default"
+
+    def test_get_thread_messages(self, tmp_path):
+        """get_thread_messages extracts HumanMessage content."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        ck = _minimal_checkpoint("cp-1")
+        ck["channel_values"]["messages"] = [
+            _human_message("Hello agent"),
+            _ai_message("Hello human"),
+        ]
+        saver.put(_minimal_config("thread-1"), ck, _minimal_metadata(), {})
+        msgs = saver.get_thread_messages("thread-1")
+        assert len(msgs) == 2
+        assert msgs[0]["role"] == "user"
+        assert msgs[1]["role"] == "assistant"
+
+    def test_get_thread_messages_type_filter(self, tmp_path):
+        """message_types filter is respected."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        ck = _minimal_checkpoint("cp-1")
+        ck["channel_values"]["messages"] = [
+            _human_message("hi"),
+            _ai_message("hello"),
+        ]
+        saver.put(_minimal_config("thread-1"), ck, _minimal_metadata(), {})
+        msgs = saver.get_thread_messages("thread-1", message_types=["HumanMessage"])
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
+
+    def test_get_thread_messages_unknown_thread(self, tmp_path):
+        """get_thread_messages returns [] for unknown thread."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        assert saver.get_thread_messages("ghost") == []
+
+    def test_delete_thread_removes_records(self, tmp_path):
+        """delete_thread removes all records; thread_exists returns False."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        saver.put(
+            _minimal_config("thread-1"),
+            _minimal_checkpoint("cp-1"),
+            _minimal_metadata(),
+            {},
+        )
+        assert saver.thread_exists("thread-1")
+        result = saver.delete_thread("thread-1")
+        assert result is True
+        assert not saver.thread_exists("thread-1")
+
+    def test_delete_thread_not_found_returns_false(self, tmp_path):
+        """delete_thread on unknown thread returns False."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        assert saver.delete_thread("ghost") is False
+
+    def test_delete_thread_compacts_file(self, tmp_path):
+        """After delete_thread, the JSONL file no longer contains those records."""
+        path = str(tmp_path / "ck.jsonl")
+        saver = JSONLCheckpointSaver(path=path)
+        saver.put(
+            _minimal_config("thread-1"),
+            _minimal_checkpoint("cp-1"),
+            _minimal_metadata(),
+            {},
+        )
+        saver.put(
+            _minimal_config("thread-2"),
+            _minimal_checkpoint("cp-2"),
+            _minimal_metadata(),
+            {},
+        )
+        saver.delete_thread("thread-1")
+
+        with open(path, "r", encoding="utf-8") as fh:
+            records = [json.loads(l) for l in fh if l.strip()]
+        tids = {r["thread_id"] for r in records}
+        assert "thread-1" not in tids
+        assert "thread-2" in tids
+
+    def test_get_user_stats(self, tmp_path):
+        """get_user_stats aggregates across threads."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        ck = _minimal_checkpoint("cp-1")
+        ck["channel_values"]["messages"] = [
+            _human_message("hi"),
+            _ai_message("hello"),
+        ]
+        saver.put(_minimal_config("alice_conv1"), ck, _minimal_metadata(), {})
+        stats = saver.get_user_stats("alice")
+        assert stats["total_threads"] == 1
+        assert stats["total_checkpoints"] == 1
+        assert stats["total_messages"] == 2
+
+    def test_get_user_stats_empty(self, tmp_path):
+        """get_user_stats for unknown user returns zeros."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        stats = saver.get_user_stats("nobody")
+        assert stats["total_threads"] == 0
+
+
+# ---------------------------------------------------------------------------
+# In-process concurrency smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrency:
+    """Two threads writing to different thread_ids in one saver do not corrupt data."""
+
+    def test_concurrent_puts_on_different_threads(self, tmp_path):
+        """Multiple OS threads can call put() concurrently without data loss."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "concurrent.jsonl"))
+        errors = []
+
+        def write_n(tid, n):
+            try:
+                for i in range(n):
+                    saver.put(
+                        _minimal_config(tid),
+                        _minimal_checkpoint(f"cp-{tid}-{i}"),
+                        _minimal_metadata(),
+                        {},
+                    )
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=write_n, args=(f"thread-{t}", 10)) for t in range(4)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Concurrent writes raised errors: {errors}"
+
+        # Verify each thread's checkpoints are accessible
+        for t in range(4):
+            results = list(saver.list(_minimal_config(f"thread-{t}")))
+            assert (
+                len(results) == 10
+            ), f"Expected 10 checkpoints for thread-{t}, got {len(results)}"
+
+
+# ---------------------------------------------------------------------------
+# VersionedCheckpointerMixin helpers
+# ---------------------------------------------------------------------------
+
+
+class TestVersionedMixinHelpers:
+    """_get_raw_checkpoint, _replace_raw_checkpoint, _archive_checkpoint."""
+
+    def test_get_raw_checkpoint_returns_latest(self, tmp_path):
+        """_get_raw_checkpoint returns the latest record dict."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        saver.put(
+            _minimal_config("thread-1"),
+            _minimal_checkpoint("cp-1"),
+            _minimal_metadata(),
+            {},
+        )
+        raw = saver._get_raw_checkpoint("thread-1")
+        assert raw is not None
+        assert raw["checkpoint_id"] == "cp-1"
+
+    def test_get_raw_checkpoint_none_for_unknown_thread(self, tmp_path):
+        """_get_raw_checkpoint returns None for a thread with no checkpoints."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        assert saver._get_raw_checkpoint("ghost") is None
+
+    def test_replace_raw_checkpoint(self, tmp_path):
+        """_replace_raw_checkpoint updates the record and rewrites file."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        saver.put(
+            _minimal_config("thread-1"),
+            _minimal_checkpoint("cp-1"),
+            _minimal_metadata(),
+            {},
+        )
+        raw = saver._get_raw_checkpoint("thread-1")
+        raw["format_version"] = 99
+        result = saver._replace_raw_checkpoint("thread-1", raw)
+        assert result is True
+
+        # Reload from disk and verify
+        s2 = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        raw2 = s2._get_raw_checkpoint("thread-1")
+        assert raw2["format_version"] == 99
+
+    def test_replace_raw_checkpoint_missing_checkpoint_id(self, tmp_path):
+        """_replace_raw_checkpoint returns False when checkpoint_id is absent."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        result = saver._replace_raw_checkpoint("thread-1", {"no_id": True})
+        assert result is False
+
+    def test_replace_raw_checkpoint_unknown_checkpoint_id(self, tmp_path):
+        """_replace_raw_checkpoint returns False for an unknown checkpoint_id."""
+        saver = JSONLCheckpointSaver(path=str(tmp_path / "ck.jsonl"))
+        saver.put(
+            _minimal_config("thread-1"),
+            _minimal_checkpoint("cp-1"),
+            _minimal_metadata(),
+            {},
+        )
+        result = saver._replace_raw_checkpoint("thread-1", {"checkpoint_id": "ghost"})
+        assert result is False
+
+    def test_archive_checkpoint_writes_sidecar(self, tmp_path):
+        """_archive_checkpoint creates a .archive sidecar file."""
+        path = str(tmp_path / "ck.jsonl")
+        saver = JSONLCheckpointSaver(path=path)
+        saver._archive_checkpoint(
+            "thread-1",
+            {"checkpoint_id": "cp-1"},
+            ValueError("oops"),
+        )
+        archive_path = path + ".archive"
+        assert os.path.exists(archive_path)
+        with open(archive_path, "r", encoding="utf-8") as fh:
+            record = json.loads(fh.readline())
+        assert record["record_type"] == "archive"
+        assert record["thread_id"] == "thread-1"
+        assert "oops" in record["migration_error"]


### PR DESCRIPTION
## Summary

- **New backend:** `JSONLCheckpointSaver` — single append-only JSONL file, no database server required. Implements the full LangGraph `BaseCheckpointSaver` contract (8 sync/async methods) plus `VersionedCheckpointerMixin` and `QueryableCheckpointerMixin`.
- **Default-on checkpointing in AETHER:** `MASExecutor.initialize()` now attaches a checkpointer whenever `checkpoint_enabled=True` (the default), regardless of whether `user_id` is set. Previously, a plain local run with no `user_id` attached nothing. The new `_create_checkpointer_local()` helper reads `checkpoint_config` directly via the AETHER factory.
- **`audit_view()`:** Read-only utility in `bili/aether/runtime/audit.py` that builds a human-readable timeline from checkpoint history — diffs `agent_outputs` and `communication_log` between consecutive supersteps and returns `[{step, ts, checkpoint_id, agent_id, output_summary, messages_sent, raw_agent_outputs}]`.

## Design decisions

**JSONL serde:** Blobs are serialised via `self.serde.dumps_typed` / `loads_typed` (LangGraph's `JsonPlusSerializer`) and base64-encoded for JSONL safety. One checkpoint record + N write records per `put()`.

**Atomicity:** Pruning and deletion rewrite via tmp-file-then-`os.replace`. Appends use plain file open in `"a"` mode (atomic at the OS level for single-process use).

**Concurrency:** `threading.RLock` for in-process safety. Multi-process file locking is explicitly out of scope — document in docstring.

**Async:** All async methods delegate to `asyncio.to_thread`; `alist()` collects the sync result and yields.

## Files changed

| File | Change |
|------|--------|
| `bili/iris/checkpointers/jsonl_checkpointer.py` | New — `JSONLCheckpointSaver`, factory functions |
| `bili/iris/checkpointers/checkpointer_functions.py` | Priority 3 JSONL tier (between mongo and memory) |
| `bili/aether/integration/checkpointer_factory.py` | `jsonl` / `file` aliases + `_create_jsonl_checkpointer()` |
| `bili/aether/schema/mas_config.py` | `checkpoint_config` description updated |
| `bili/aether/runtime/executor.py` | Always-on `initialize()`, `_create_checkpointer_local()`, 5 injection-point guard changes |
| `bili/aether/runtime/audit.py` | New — `audit_view()` |
| `bili/aether/runtime/__init__.py` | Export `audit_view` |
| `bili/iris/checkpointers/tests/test_jsonl_checkpointer.py` | 56 tests |
| `bili/aether/tests/test_executor_always_on_checkpointing.py` | 33 tests |
| `CLAUDE.md` | 3 backends → 4 |
| `bili/aether/README.md` | jsonl/file backend row, always-on note, audit_view section |

## Test plan

- [x] 56 JSONL checkpointer tests: round-trip, file-persistence, thread isolation, ownership validation, pruning/compaction, async delegates, `QueryableCheckpointerMixin` methods, `VersionedCheckpointerMixin` helpers, in-process concurrency smoke
- [x] 33 always-on + audit_view tests: behavioural matrix (checkpoint_enabled × user_id, HITL, jsonl/file aliases, env-var cascade tier), `_create_checkpointer_local()`, `audit_view()` (single step, delta, communication log diff, chronological order, edge cases)
- [x] Full suite: 4004 passed, 1 skipped, 0 failures
- [x] Coverage gate: 214 runtime files at ≥ 90%; overall 98.4%
- [x] pylint 9.64/10
- [x] pre-commit (black, autoflake, isort, pylint) — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpXRrbE4UhL22Usj6UdEVQ