### PR TITLE
docs: full four-way tool_strategy + fix auto-checkpointer description

### DIFF
--- a/bili/aether/schema/mas_config.py
+++ b/bili/aether/schema/mas_config.py
@@ -232,10 +232,10 @@ class MASConfig(BaseModel):
         description=(
             "Checkpoint backend configuration. Supported types: "
             "'memory' (default), 'postgres'/'pg', 'mongo'/'mongodb', "
-            "'jsonl'/'file' (local JSONL file — no server required; "
+            "'jsonl'/'file' (local JSONL file, no server required; "
             "set 'path' key to override the default path; "
             "activated automatically via JSONL_CHECKPOINT_PATH env var), "
-            "'auto' (env-based detection of postgres/mongo/jsonl/memory). "
+            "'auto' (env-based detection of postgres/mongo, else memory). "
             "Additional keys like 'keep_last_n' are forwarded to the "
             "checkpointer constructor."
         ),

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,7 +68,7 @@ from bili.aegis.evaluator import Evaluator
 | Feature | Description |
 |---------|-------------|
 | **106 LLM Configurations** | Pre-configured models across 17 provider types — API, CLI, and local (via `bili.iris.config`) |
-| **BYO-LLM / CLI Providers** | Use Claude Code, Codex CLI, or Gemini CLI as first-class LLM providers via subprocess; fallback to prompted ReAct for tool calling when native function-calling is unavailable |
+| **BYO-LLM / CLI Providers** | Use Claude Code, Codex CLI, or Gemini CLI as first-class LLM providers via subprocess. Tool calling routes per model via `tool_strategy`: `native` (bind_tools, API providers), `facilitated` (prompted ReAct loop for text-only/local models), `mcp` (agent tools exposed as an ephemeral MCP server; the CLI self-orchestrates), `none` (plain path, no tools) |
 | **Fallback Engine** | `FallbackLLM` silently retries across a provider chain on transient failures; declared via `AgentSpec.fallback_models` |
 | **MCP Client Subsystem** | `bili/iris/mcp/` lets agents consume tools from any MCP server (stdio or HTTP/SSE), adapted as LangChain tools (install with `pip install bili-core[mcp]`) |
 | **LangGraph Workflows** | Node-based workflow system with customizable execution pipelines (via `bili.iris.loaders`) |


### PR DESCRIPTION
Two documentation-currency fixes from a docs sweep.

## docs/README.md (~line 71)
The Key Features table described only the prompted-ReAct fallback for CLI provider tool calling. It now describes the full four-way `tool_strategy` (`native`/`facilitated`/`mcp`/`none`) that `README.MD` and `docs/ARCHITECTURE.md` already document, so the three surfaces tell the same story.

## bili/aether/schema/mas_config.py (checkpoint_config field)
The field description claimed `auto` does "env-based detection of postgres/mongo/jsonl/memory". `_create_auto_checkpointer` intentionally EXCLUDES jsonl (its own docstring: auto targets server-backed stores, callers wanting the local-file backend declare `type: jsonl` explicitly). Description corrected to "postgres/mongo, else memory". Also scrubbed an em dash in the same description (project no-em-dash rule).

Docs/docstring only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)