### PR TITLE
fix/feat(providers+aether): configurable CLI timeout via model_kwargs + raise agentic preset defaults

### DIFF
--- a/bili/aether/compiler/llm_resolver.py
+++ b/bili/aether/compiler/llm_resolver.py
@@ -196,9 +196,15 @@ def create_llm(agent: AgentSpec) -> Any:
 
     provider, model_id, extra_kwargs = _resolve_model_full(agent.model_name)
 
-    # Build kwargs for load_model — extra_kwargs first so the resolved
-    # model_id always wins if extra_kwargs ever contains a "model_name" key.
-    kwargs: Dict[str, Any] = {**extra_kwargs, "model_name": model_id}
+    # Build kwargs for load_model.
+    # Precedence (highest wins): named AgentSpec fields > model_kwargs > catalog
+    # extra_kwargs.  Named fields are set last so they cannot be accidentally
+    # overridden by model_kwargs or catalog defaults.
+    kwargs: Dict[str, Any] = {
+        **extra_kwargs,
+        **agent.model_kwargs,
+        "model_name": model_id,
+    }
     if agent.temperature is not None:
         kwargs["temperature"] = agent.temperature
     if agent.max_tokens is not None:
@@ -228,7 +234,13 @@ def create_llm(agent: AgentSpec) -> Any:
     fallback_chain: List[Tuple[str, Dict[str, Any]]] = []
     for fb_model_name in agent.fallback_models:
         fb_provider, fb_model_id, fb_extra = _resolve_model_full(fb_model_name)
-        fb_kwargs: Dict[str, Any] = {**fb_extra, "model_name": fb_model_id}
+        # Apply model_kwargs to fallbacks with the same precedence as the
+        # primary: named fields win, model_kwargs overrides catalog defaults.
+        fb_kwargs: Dict[str, Any] = {
+            **fb_extra,
+            **agent.model_kwargs,
+            "model_name": fb_model_id,
+        }
         if agent.temperature is not None:
             fb_kwargs["temperature"] = agent.temperature
         if agent.max_tokens is not None:

--- a/bili/aether/schema/agent_spec.py
+++ b/bili/aether/schema/agent_spec.py
@@ -113,10 +113,26 @@ class AgentSpec(BaseModel):
             "model fails with a transient error (rate limit, provider "
             "unavailable, API timeout).  Each entry is resolved exactly like "
             "``model_name`` — display name or model_id, looked up in "
-            "``LLM_MODELS`` then by heuristic.  The same ``temperature`` and "
-            "``max_tokens`` values from this AgentSpec are applied to each "
-            "fallback.  Leave empty (the default) to disable fallback "
-            "behaviour entirely."
+            "``LLM_MODELS`` then by heuristic.  The same ``temperature``, "
+            "``max_tokens``, and ``model_kwargs`` values from this AgentSpec "
+            "are applied to each fallback.  Leave empty (the default) to "
+            "disable fallback behaviour entirely."
+        ),
+    )
+
+    model_kwargs: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Extra keyword arguments forwarded verbatim to ``load_model()`` "
+            "for the resolved provider.  Use this to set provider-specific "
+            "parameters that have no dedicated ``AgentSpec`` field.  For CLI "
+            "providers, ``timeout_seconds`` is the primary use case::\n\n"
+            "    model_kwargs:\n"
+            "      timeout_seconds: 600\n\n"
+            "Named fields (``temperature``, ``max_tokens``) take precedence "
+            "over the same keys in ``model_kwargs`` when both are set.  "
+            "``model_kwargs`` is also applied to every fallback model in "
+            "``fallback_models``."
         ),
     )
 

--- a/bili/aether/tests/test_compiler_coverage.py
+++ b/bili/aether/tests/test_compiler_coverage.py
@@ -267,6 +267,95 @@ class TestCreateLlm:
         assert kwargs["api_version"] == "2024-02-01"
         assert kwargs["model_name"] == "azure-gpt-4o"
 
+    def test_create_llm_model_kwargs_forwarded(self):
+        """model_kwargs are passed through to load_model verbatim."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        agent = _agent(
+            "cli",
+            model_name="gpt-4o",
+            model_kwargs={"timeout_seconds": 600.0},
+        )
+
+        fake_load_model = MagicMock(return_value="LLM_INST")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert kwargs["timeout_seconds"] == 600.0
+
+    def test_create_llm_named_fields_win_over_model_kwargs(self):
+        """temperature/max_tokens in AgentSpec override the same keys in model_kwargs."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        agent = _agent(
+            "prio",
+            model_name="gpt-4o",
+            temperature=0.7,
+            model_kwargs={"temperature": 0.1, "timeout_seconds": 300.0},
+        )
+
+        fake_load_model = MagicMock(return_value="LLM_INST")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        # Named field wins.
+        assert kwargs["temperature"] == 0.7
+        # Unrelated model_kwargs key still forwarded.
+        assert kwargs["timeout_seconds"] == 300.0
+
+    def test_create_llm_model_kwargs_forwarded_to_fallbacks(self):
+        """model_kwargs are applied to each fallback model's load_model call."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        agent = _agent(
+            "fb",
+            model_name="gpt-4o",
+            fallback_models=["gpt-4o"],
+            model_kwargs={"timeout_seconds": 600.0},
+        )
+
+        fake_load_model = MagicMock(return_value="PRIMARY")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        # build_fallback_llm needs to be importable but can be a no-op mock.
+        fake_fallback = MagicMock(return_value="FALLBACK_LLM")
+        fake_fallback_mod = types.ModuleType("bili.iris.providers.fallback")
+        fake_fallback_mod.build_fallback_llm = fake_fallback
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(
+                sys.modules,
+                {
+                    "bili.iris.loaders.llm_loader": fake_loader,
+                    "bili.iris.providers.fallback": fake_fallback_mod,
+                },
+            ):
+                llm_resolver.create_llm(agent)
+
+        # build_fallback_llm is called with the primary LLM and the chain.
+        fb_call_kwargs = fake_fallback.call_args[1]
+        fallback_chain = fb_call_kwargs["fallback_chain"]
+        assert len(fallback_chain) == 1
+        _fb_provider, fb_kwargs = fallback_chain[0]
+        assert fb_kwargs.get("timeout_seconds") == 600.0
+
 
 class TestResolveProvider:
     """Tests for resolve_provider() and the LLM_MODELS ImportError path."""

--- a/bili/iris/providers/cli_presets.py
+++ b/bili/iris/providers/cli_presets.py
@@ -25,6 +25,16 @@ Each preset maps to a :class:`~bili.iris.providers.preset_provider.CliPresetProv
 registered under its type string in
 :data:`~bili.iris.providers.registry.PROVIDER_REGISTRY`.
 
+Timeout defaults
+----------------
+The three built-in agentic-CLI presets all default to ``timeout_seconds=600.0``
+(10 minutes).  A single agentic turn can involve multiple tool calls, extended
+reasoning, and filesystem or network I/O; 120 s (the :class:`~.CliPreset`
+dataclass default for generic custom presets) is too short for that workload in
+practice.  Callers that need a tighter bound can still override per call::
+
+    llm = load_model("cli_claude_code", timeout_seconds=120.0)
+
 Built-in presets
 ----------------
 ``cli_claude_code``
@@ -106,7 +116,11 @@ class CliPreset:
     :param json_path: Extraction path for JSON output.  Default ``"content"``.
     :param strip_ansi: Strip ANSI escape codes from stdout.  Default ``True``.
     :param timeout_seconds: Per-call subprocess timeout in seconds.
-        Default ``120.0``.
+        Default ``120.0`` for generic custom presets.  The three built-in
+        agentic presets (Claude Code, Codex, Gemini CLI) use ``600.0``
+        because a single agentic turn involving multiple tool calls and
+        extended reasoning routinely exceeds 120 s; callers may still
+        override per call via ``load_model(..., timeout_seconds=...)``.
     """
 
     command: List[str] = field(default_factory=list)
@@ -129,6 +143,10 @@ class CliPreset:
 #: subprocess inherits the calling process's environment, so whatever OAuth
 #: session or ``ANTHROPIC_API_KEY`` the CLI holds is reused automatically.
 #:
+#: Timeout is set to 600 s (10 min) because agentic turns involving multiple
+#: tool calls and extended reasoning routinely exceed 120 s.  Callers can
+#: still override per call via ``load_model("cli_claude_code", timeout_seconds=...)``.
+#:
 #: Reference: ``claude --help`` (look for ``-p, --print``).
 CLAUDE_CODE_PRESET = CliPreset(
     command=["claude", "-p"],
@@ -136,7 +154,7 @@ CLAUDE_CODE_PRESET = CliPreset(
     message_format="last",
     output_format="text",
     strip_ansi=True,
-    timeout_seconds=120.0,
+    timeout_seconds=600.0,
 )
 
 #: OpenAI Codex CLI -- ``codex exec <prompt>``
@@ -146,6 +164,10 @@ CLAUDE_CODE_PRESET = CliPreset(
 #: exits.  Requires the Codex CLI to be installed and authenticated via
 #: ``OPENAI_API_KEY`` or its interactive login flow.
 #:
+#: Timeout is set to 600 s (10 min) because agentic turns involving multiple
+#: tool calls and extended reasoning routinely exceed 120 s.  Callers can
+#: still override per call via ``load_model("cli_codex", timeout_seconds=...)``.
+#:
 #: Reference: ``codex --help`` / OpenAI Codex CLI documentation.
 CODEX_PRESET = CliPreset(
     command=["codex", "exec"],
@@ -153,7 +175,7 @@ CODEX_PRESET = CliPreset(
     message_format="last",
     output_format="text",
     strip_ansi=True,
-    timeout_seconds=180.0,
+    timeout_seconds=600.0,
 )
 
 #: Google Gemini CLI -- ``gemini -p <prompt>``
@@ -163,6 +185,10 @@ CODEX_PRESET = CliPreset(
 #: the process exits.  Requires the Gemini CLI to be installed and
 #: authenticated (Google account OAuth or ``GEMINI_API_KEY``).
 #:
+#: Timeout is set to 600 s (10 min) because agentic turns involving multiple
+#: tool calls and extended reasoning routinely exceed 120 s.  Callers can
+#: still override per call via ``load_model("cli_gemini_cli", timeout_seconds=...)``.
+#:
 #: Reference: ``gemini --help`` (look for ``-p, --prompt``).
 GEMINI_CLI_PRESET = CliPreset(
     command=["gemini", "-p"],
@@ -170,7 +196,7 @@ GEMINI_CLI_PRESET = CliPreset(
     message_format="last",
     output_format="text",
     strip_ansi=True,
-    timeout_seconds=120.0,
+    timeout_seconds=600.0,
 )
 
 # ---------------------------------------------------------------------------

--- a/bili/iris/providers/tests/test_cli_presets.py
+++ b/bili/iris/providers/tests/test_cli_presets.py
@@ -152,9 +152,17 @@ class TestBuiltinPresets:
         """CODEX_PRESET uses plain-text output."""
         assert CODEX_PRESET.output_format == "text"
 
+    def test_claude_code_preset_timeout(self):
+        """CLAUDE_CODE_PRESET uses 600 s to accommodate agentic multi-tool turns."""
+        assert CLAUDE_CODE_PRESET.timeout_seconds == 600.0
+
     def test_codex_preset_timeout(self):
-        """CODEX_PRESET uses a longer default timeout than the base."""
-        assert CODEX_PRESET.timeout_seconds == 180.0
+        """CODEX_PRESET uses 600 s to accommodate agentic multi-tool turns."""
+        assert CODEX_PRESET.timeout_seconds == 600.0
+
+    def test_gemini_cli_preset_timeout(self):
+        """GEMINI_CLI_PRESET uses 600 s to accommodate agentic multi-tool turns."""
+        assert GEMINI_CLI_PRESET.timeout_seconds == 600.0
 
     def test_gemini_cli_preset_command(self):
         """GEMINI_CLI_PRESET uses 'gemini -p' as the command."""


### PR DESCRIPTION
## Summary

Two-commit PR addressing the full problem: not just a default bump, but an end-to-end configurable path so any consumer can set the CLI timeout declaratively from config.

### Commit 1 — preset default bump (`fix`)

All three built-in agentic-CLI presets (Claude Code, Codex, Gemini CLI) raised to `timeout_seconds=600.0`. A single agentic turn with multiple tool calls reliably exhausts the previous 120 s (Claude Code, Gemini CLI) / 180 s (Codex) defaults.

- `CODEX_PRESET`: 180 s → 600 s
- `CLAUDE_CODE_PRESET` / `GEMINI_CLI_PRESET`: 120 s → 600 s (already in working tree)
- Per-preset comments and module "Timeout defaults" section document the agentic-workload rationale
- Generic `CliPreset` dataclass default (120.0) is unchanged — that's for custom one-shot presets
- Tests: `test_codex_preset_timeout` updated (180→600); `test_claude_code_preset_timeout` and `test_gemini_cli_preset_timeout` added

### Commit 2 — `AgentSpec.model_kwargs` (`feat`)

The real lever: a new `model_kwargs: Dict[str, Any]` field on `AgentSpec` forwarded verbatim to `load_model()`. This lets any MAS agent config declare provider-specific parameters that have no dedicated AgentSpec field.

**Configurable path end-to-end:**

YAML agent config → `AgentSpec.model_kwargs` → `create_llm()` → `load_model(provider, **kwargs)` → `CliPresetProvider.load(timeout_seconds=...)` → `CliLLM(timeout_seconds=...)`

**How a caller sets the CLI timeout from config:**

```yaml
agents:
  - agent_id: my_cli_agent
    role: assistant
    objective: "..."
    model_name: cli_claude_code
    model_kwargs:
      timeout_seconds: 600
```

**Precedence:** named AgentSpec fields (`temperature`, `max_tokens`) win over `model_kwargs`; `model_kwargs` wins over catalog `extra_kwargs`. `model_kwargs` also propagates to every fallback model in `fallback_models`.

**Why it's safe to pass `timeout_seconds` to non-CLI providers:** every API provider `load()` has `**_extra: Any` — unknown kwargs are silently absorbed. No API provider will error on an extra kwarg.

**Changed files:**
- `bili/aether/schema/agent_spec.py`: `model_kwargs` field with full docs
- `bili/aether/compiler/llm_resolver.py`: merge in `create_llm()` for primary + fallback chain
- `bili/aether/tests/test_compiler_coverage.py`: 3 new `TestCreateLlm` cases

## IRIS path (already works)

`load_model("cli_claude_code", timeout_seconds=600.0)` already forwards `timeout_seconds` to `CliPresetProvider.load()` and on to `CliLLM`. The IRIS direct path needed no change.

## Test plan

- [x] `pytest bili/iris/providers/tests/test_cli_presets.py` — 49/49
- [x] `pytest bili/aether/tests/test_compiler_coverage.py::TestCreateLlm` — 6/6
- [x] `python scripts/check_coverage.py` — PASS, 214 runtime files >= 90% (98.4% overall)
- [x] `pylint bili/...` — ≥9.0/10 on all changed files
- [x] Pre-commit (Black, Autoflake, Isort, Pylint) — all passed on both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpXRrbE4UhL22Usj6UdEVQ