### PR TITLE
fix: durable per-agent provenance in AETHER checkpointed state

### DIFF
--- a/bili/aether/compiler/agent_generator.py
+++ b/bili/aether/compiler/agent_generator.py
@@ -697,31 +697,40 @@ def _get_communication_context(state: dict, agent_id: str) -> str:
 def _build_communication_update(
     state: dict, agent_id: str, content: str
 ) -> Dict[str, Any]:
-    """Record agent output in communication state if communication is active.
+    """Record agent output in the communication log for provenance.
 
-    Uses state-based communication API (send_message_in_state) to properly
-    create messages with full Message structure, timestamps, and IDs.
+    ``communication_log`` is always present in the state schema so this
+    function always records the agent's output as a broadcast event on the
+    ``__agent_output__`` channel.  This produces one entry per agent per
+    superstep, giving a durable per-agent provenance trail regardless of
+    whether the MAS declares explicit inter-agent channels.
 
-    Returns a dict of state fields to merge (empty if communication is
-    not configured). The state schema uses ``operator.add`` / ``_merge_dicts``
-    reducers to combine updates from concurrent agent execution.
+    The returned dict is merged into the LangGraph state update by the
+    caller.  It contains:
+
+    - ``communication_log``: a single-element list with the new entry
+      (the ``operator.add`` reducer appends it to the accumulated log).
+    - ``channel_messages`` / ``pending_messages``: routing auxiliaries;
+      present in the update but ignored by LangGraph when those channels
+      are not in the state schema (MAS without explicit channels).
+
+    Args:
+        state: Current LangGraph state dict.
+        agent_id: ID of the agent that just completed.
+        content: Agent output content to record.
+
+    Returns:
+        State-update dict to merge into the node's return value.
     """
-    if "communication_log" not in state:
-        return {}
-
-    # Use state-based communication API for proper message structure
     # pylint: disable=import-outside-toplevel
     from bili.aether.runtime.communication_state import send_message_in_state
     from bili.aether.runtime.messages import MessageType
 
-    # Send agent output as broadcast message on __agent_output__ channel
-    state_update = send_message_in_state(
+    return send_message_in_state(
         state=state,
         channel_id="__agent_output__",
         sender=agent_id,
         content=content,
-        receiver="__all__",  # Broadcast to all agents
+        receiver="__all__",
         message_type=MessageType.BROADCAST,
     )
-
-    return state_update

--- a/bili/aether/compiler/state_generator.py
+++ b/bili/aether/compiler/state_generator.py
@@ -78,11 +78,17 @@ def generate_state_schema(config: MASConfig) -> Type:
     if wtype == WorkflowType.CUSTOM and config.human_in_loop:
         annotations["needs_human_review"] = bool
 
-    # Communication fields (present when channels are configured)
+    # communication_log is always present so every agent handoff is durably
+    # recorded for provenance, regardless of whether explicit channels are
+    # configured.  Each agent node appends one entry (the delta); the
+    # operator.add reducer accumulates them chronologically across supersteps.
+    annotations["communication_log"] = Annotated[list, operator.add]
+
+    # channel_messages and pending_messages are routing auxiliaries that are
+    # only meaningful when the MAS declares explicit inter-agent channels.
     if config.channels:
         annotations["channel_messages"] = Annotated[Dict[str, list], _merge_dicts]
         annotations["pending_messages"] = Annotated[Dict[str, list], _merge_dicts]
-        annotations["communication_log"] = Annotated[list, operator.add]
 
     # Inheritance state fields (when agents use bili-core inheritance)
     try:

--- a/bili/aether/runtime/audit.py
+++ b/bili/aether/runtime/audit.py
@@ -23,6 +23,14 @@ Example::
     timeline = audit_view(saver, thread_id="run-001")
     for step in timeline:
         print(step["ts"], step["agent_id"], step["output_summary"])
+
+Timeline entries
+----------------
+Only supersteps where at least one agent acted (i.e. ``agent_outputs``
+changed or a ``communication_log`` entry was appended) are included in
+the returned list.  The initial LangGraph checkpoint (written before any
+node runs) and the empty state-initialisation superstep are skipped so
+the timeline starts cleanly with the first agent turn.
 """
 
 from __future__ import annotations
@@ -122,10 +130,22 @@ def audit_view(
         # Diff communication_log: find entries appended this step
         new_messages: List[Any] = current_comm_log[len(prev_comm_log) :]
 
-        # Identify the acting agent (the one that changed outputs this step)
-        acting_agent: Optional[str] = channel_values.get("current_agent")
-        if acting_agent is None and changed_outputs:
+        # Identify the acting agent (the one that changed outputs this step).
+        # ``current_agent`` is set by every agent node; fall back to the first
+        # key in changed_outputs when the channel is absent (e.g. pre-fix
+        # checkpoints).
+        acting_agent: Optional[str] = channel_values.get("current_agent") or None
+        if not acting_agent and changed_outputs:
             acting_agent = next(iter(changed_outputs))
+
+        # Skip supersteps where no agent activity occurred.  These are the
+        # LangGraph-internal initial/state-seed checkpoints written before the
+        # first agent node runs (current_agent is None or '', no new
+        # agent_outputs, no new communication_log entries).
+        if not acting_agent and not changed_outputs and not new_messages:
+            prev_agent_outputs = dict(current_agent_outputs)
+            prev_comm_log = list(current_comm_log)
+            continue
 
         # Summarise the acting agent's output
         output_summary: Optional[str] = None

--- a/bili/aether/runtime/communication_state.py
+++ b/bili/aether/runtime/communication_state.py
@@ -6,11 +6,24 @@ direct reference to the ``ChannelManager``.
 
 State fields used:
     ``channel_messages``  — ``Dict[str, list]``  channel_id -> list of message dicts
-                            (uses _merge_dicts reducer for parallel execution safety)
+                            (uses _merge_dicts reducer for parallel execution safety;
+                            present only when the MAS declares explicit channels)
     ``pending_messages``  — ``Dict[str, list]``  agent_id -> list of message dicts
-                            (uses _merge_dicts reducer for parallel execution safety)
+                            (uses _merge_dicts reducer for parallel execution safety;
+                            present only when the MAS declares explicit channels)
     ``communication_log`` — ``list``             flat list of all message dicts
-                            (uses operator.add reducer, preserves order by completion)
+                            (uses operator.add reducer, preserves order by completion;
+                            ALWAYS present — even without explicit channels — so
+                            per-agent provenance is durably checkpointed for every run)
+
+Reducer contract for ``communication_log``
+------------------------------------------
+The state schema uses ``operator.add`` as the reducer, which *concatenates*
+lists.  This means the state update returned by :func:`send_message_in_state`
+must contain ONLY the *new* message(s) as a single-element list — NOT the
+full accumulated log read from state.  If the full log were returned, the
+reducer would compute ``existing_log + (existing_log + new_msg)``, doubling
+every previous entry on each superstep.
 """
 
 import logging
@@ -30,10 +43,17 @@ def send_message_in_state(
     message_type: MessageType = MessageType.DIRECT,
     metadata: Optional[Dict[str, Any]] = None,
 ) -> dict:
-    """Create a message and return updated communication state fields.
+    """Create a message and return the state-update delta for communication fields.
 
     This is a *pure* helper — it does not mutate *state* in place.
     The caller merges the returned dict into the LangGraph state update.
+
+    ``communication_log`` in the returned dict contains ONLY the new message
+    as a single-element list.  The ``operator.add`` reducer in the state
+    schema concatenates this list onto the accumulated log, producing the
+    correct append-only history.  Do NOT pre-populate it with the existing
+    log from *state* — that would cause the reducer to double-count every
+    prior entry on each subsequent superstep.
 
     Args:
         state: Current LangGraph state dict.
@@ -46,7 +66,7 @@ def send_message_in_state(
 
     Returns:
         Dict with updated ``channel_messages``, ``pending_messages``,
-        and ``communication_log`` fields.
+        and ``communication_log`` (delta-only single-element list).
     """
     msg = Message(
         sender=sender,
@@ -60,13 +80,13 @@ def send_message_in_state(
 
     channel_messages = _update_channel_messages(state, channel_id, msg_dict)
     pending = _update_pending_messages(state, sender, receiver, msg_dict)
-    comm_log = list(state.get("communication_log") or [])
-    comm_log.append(msg_dict)
 
+    # Return only the new message as the communication_log delta.
+    # The operator.add reducer appends this list to the accumulated log.
     return {
         "channel_messages": channel_messages,
         "pending_messages": pending,
-        "communication_log": comm_log,
+        "communication_log": [msg_dict],
     }
 
 

--- a/bili/aether/runtime/executor.py
+++ b/bili/aether/runtime/executor.py
@@ -1114,11 +1114,16 @@ class MASExecutor:  # pylint: disable=too-many-instance-attributes
         if wtype == WorkflowType.CUSTOM and self._config.human_in_loop:
             state["needs_human_review"] = False
 
-        # Communication fields (only when channels are configured)
+        # communication_log is always initialised so per-agent provenance is
+        # captured for every run, regardless of whether explicit channels are
+        # configured.
+        state["communication_log"] = []
+
+        # channel_messages and pending_messages are only needed for MAS
+        # configurations that declare explicit inter-agent channels.
         if self._config.channels:
             state["channel_messages"] = {}
             state["pending_messages"] = {}
-            state["communication_log"] = []
 
         # Merge user-provided data (overrides defaults)
         if input_data:

--- a/bili/aether/tests/test_communication.py
+++ b/bili/aether/tests/test_communication.py
@@ -564,6 +564,11 @@ class TestStateSchemaIntegration:
         schema = generate_state_schema(config)
         annotations = schema.__annotations__
 
+        # channel_messages and pending_messages are routing auxiliaries — present
+        # only when the MAS declares explicit inter-agent channels.
         assert "channel_messages" not in annotations
         assert "pending_messages" not in annotations
-        assert "communication_log" not in annotations
+
+        # communication_log is always present regardless of channel configuration
+        # so per-agent provenance is captured for every run.
+        assert "communication_log" in annotations

--- a/bili/aether/tests/test_executor.py
+++ b/bili/aether/tests/test_executor.py
@@ -163,14 +163,17 @@ class TestSequentialExecution:
 class TestCommunicationLogs:
     """Tests for communication statistics collection."""
 
-    def test_no_channels_zero_messages(self):
+    def test_no_channels_records_agent_output_events(self):
+        # Even without explicit channels, each agent appends one provenance entry
+        # to communication_log via the __agent_output__ broadcast channel.
         config = _seq_config(n_agents=2)
         executor = MASExecutor(config)
         executor.initialize()
         result = executor.run(save_results=False)
 
-        assert result.total_messages == 0
-        assert result.messages_by_channel == {}
+        # 2 agents → 2 broadcast events on __agent_output__
+        assert result.total_messages == 2
+        assert result.messages_by_channel == {"__agent_output__": 2}
 
     def test_channels_collect_communication_log(self):
         config = MASConfig(

--- a/bili/aether/tests/test_executor_always_on_checkpointing.py
+++ b/bili/aether/tests/test_executor_always_on_checkpointing.py
@@ -390,7 +390,9 @@ class TestAuditView:
         """Timeline is chronological (oldest first)."""
         saver = JSONLCheckpointSaver(path=str(tmp_path / "audit.jsonl"))
         for i in range(4):
-            ck = _mk_checkpoint(f"cp-{i}")
+            # Use distinct agent IDs so each checkpoint has new agent activity
+            # and is not filtered by the no-activity guard in audit_view.
+            ck = _mk_checkpoint(f"cp-{i}", agent_id=f"agent_{i}")
             saver.put(_mk_config("run-1"), ck, _mk_metadata(), {})
         timeline = audit_view(saver, thread_id="run-1")
         steps = [e["step"] for e in timeline]
@@ -400,9 +402,11 @@ class TestAuditView:
     def test_checkpoint_id_in_timeline_entry(self, tmp_path):
         """Each timeline entry includes checkpoint_id."""
         saver = JSONLCheckpointSaver(path=str(tmp_path / "audit.jsonl"))
+        # Include agent activity so the entry is not filtered by the
+        # no-activity guard in audit_view.
         saver.put(
             _mk_config("run-1"),
-            _mk_checkpoint("cp-sentinel"),
+            _mk_checkpoint("cp-sentinel", agent_id="agent_sentinel"),
             _mk_metadata(),
             {},
         )
@@ -431,7 +435,9 @@ class TestAuditView:
     def test_ts_extracted_from_checkpoint(self, tmp_path):
         """ts is extracted from the checkpoint dict when not in metadata."""
         saver = JSONLCheckpointSaver(path=str(tmp_path / "audit.jsonl"))
-        ck = _mk_checkpoint("cp-1")
+        # Include agent activity so the entry is not filtered by the
+        # no-activity guard in audit_view.
+        ck = _mk_checkpoint("cp-1", agent_id="agent_ts")
         ck["ts"] = "2024-06-01T12:00:00+00:00"
         saver.put(
             _mk_config("run-1"), ck, {"source": "test", "step": 0, "writes": {}}, {}

--- a/bili/aether/tests/test_provenance.py
+++ b/bili/aether/tests/test_provenance.py
@@ -1,0 +1,517 @@
+"""Tests for per-agent provenance capture in the AETHER checkpointed state.
+
+Verifies that a completed multi-agent run durably records, in every
+checkpointed superstep, the three provenance channels required for full
+post-run observability:
+
+1. ``current_agent`` — which agent acted at each superstep.
+2. ``agent_outputs[agent_id]`` — the output attributed to that agent,
+   and the corresponding ``AIMessage`` tagged with ``name=<agent_id>``.
+3. ``communication_log`` — one broadcast entry per agent handoff, present
+   even when no explicit inter-agent channels are declared.
+
+Root-cause regression tests are also included to pin the two bugs that
+were fixed:
+
+- Bug A: ``communication_log`` was absent from the state schema (and hence
+  never checkpointed) for sequential workflows that declared no explicit
+  channels.  Fix: always include ``communication_log`` in the schema.
+
+- Bug B: ``send_message_in_state`` returned the full accumulated log as the
+  state-update value.  Because the reducer is ``operator.add`` (list
+  concatenation), this caused exponential duplication — a 3-agent run
+  produced 7 entries (1+3+7 pattern) instead of 3.  Fix: return only the
+  delta (single-element list) for ``communication_log``.
+
+All tests use stub agents (``model_name`` not set) and a MemorySaver
+checkpointer so no LLM API calls or database servers are needed.
+"""
+
+# pylint: disable=missing-function-docstring
+
+import operator
+
+from langchain_core.messages import HumanMessage
+
+from bili.aether.runtime.audit import audit_view
+from bili.aether.runtime.executor import MASExecutor
+from bili.aether.schema import (
+    AgentSpec,
+    Channel,
+    CommunicationProtocol,
+    MASConfig,
+    WorkflowType,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _agent(agent_id: str, **kwargs) -> AgentSpec:
+    defaults = {"role": "test_role", "objective": f"Objective for {agent_id}"}
+    defaults.update(kwargs)
+    return AgentSpec(agent_id=agent_id, **defaults)
+
+
+def _seq_config(
+    n_agents: int = 3,
+    with_channels: bool = False,
+    mas_id: str = "prov_test",
+) -> MASConfig:
+    """Build a sequential MASConfig with stub agents and a MemorySaver."""
+    agents = [_agent(f"agent_{i}") for i in range(n_agents)]
+    channels = []
+    if with_channels:
+        for i in range(n_agents - 1):
+            channels.append(
+                Channel(
+                    channel_id=f"ch_{i}_to_{i+1}",
+                    protocol=CommunicationProtocol.DIRECT,
+                    source=f"agent_{i}",
+                    target=f"agent_{i + 1}",
+                )
+            )
+    return MASConfig(
+        mas_id=mas_id,
+        name="Provenance Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=agents,
+        channels=channels,
+        checkpoint_enabled=True,
+        checkpoint_config={"type": "memory"},
+    )
+
+
+def _run(config: MASConfig, thread_id: str = "prov-001"):
+    """Initialize, run, and return (executor, result)."""
+    executor = MASExecutor(config)
+    executor.initialize()
+    result = executor.run(
+        input_data={"messages": [HumanMessage(content="start")]},
+        thread_id=thread_id,
+        save_results=False,
+    )
+    return executor, result
+
+
+def _checkpoints_chronological(executor, thread_id: str):
+    """Return checkpoint dicts in chronological order (oldest first)."""
+    cfg = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+    tuples = list(executor._checkpointer.list(cfg))  # pylint: disable=protected-access
+    return list(reversed(tuples))
+
+
+# ---------------------------------------------------------------------------
+# current_agent provenance
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentAgentProvenance:
+    """current_agent is set to the active agent ID in every agent superstep."""
+
+    def test_current_agent_set_per_superstep_no_channels(self):
+        executor, result = _run(_seq_config(n_agents=3, with_channels=False))
+        assert result.success
+        tuples = _checkpoints_chronological(executor, "prov-001")
+
+        # Collect agent-superstep checkpoints (skip initial empty ones)
+        agent_steps = [
+            t.checkpoint["channel_values"].get("current_agent")
+            for t in tuples
+            if t.checkpoint["channel_values"].get("current_agent")
+        ]
+        # Every agent ran exactly once and is represented in order
+        assert agent_steps == ["agent_0", "agent_1", "agent_2"]
+
+    def test_current_agent_set_per_superstep_with_channels(self):
+        executor, result = _run(
+            _seq_config(n_agents=3, with_channels=True),
+            thread_id="prov-ch-001",
+        )
+        assert result.success
+        tuples = _checkpoints_chronological(executor, "prov-ch-001")
+
+        agent_steps = [
+            t.checkpoint["channel_values"].get("current_agent")
+            for t in tuples
+            if t.checkpoint["channel_values"].get("current_agent")
+        ]
+        assert agent_steps == ["agent_0", "agent_1", "agent_2"]
+
+    def test_current_agent_final_state(self):
+        # The final accumulated state reflects the last agent that ran.
+        _, result = _run(_seq_config(n_agents=2))
+        assert result.final_state.get("current_agent") == "agent_1"
+
+
+# ---------------------------------------------------------------------------
+# agent_outputs provenance
+# ---------------------------------------------------------------------------
+
+
+class TestAgentOutputsProvenance:
+    """agent_outputs accumulates each agent's output dict across supersteps."""
+
+    def test_agent_outputs_accumulate_no_channels(self):
+        executor, result = _run(_seq_config(n_agents=3, with_channels=False))
+        assert result.success
+        tuples = _checkpoints_chronological(executor, "prov-001")
+
+        # After the last agent, all three should be present
+        final_cv = tuples[-1].checkpoint["channel_values"]
+        agent_outputs = final_cv.get("agent_outputs", {})
+        assert set(agent_outputs.keys()) == {"agent_0", "agent_1", "agent_2"}
+        for aid in ("agent_0", "agent_1", "agent_2"):
+            assert agent_outputs[aid].get("status") == "stub"
+
+    def test_agent_outputs_grow_per_superstep(self):
+        executor, result = _run(_seq_config(n_agents=3, with_channels=False))
+        assert result.success
+        tuples = _checkpoints_chronological(executor, "prov-001")
+
+        # Filter to checkpoints where current_agent is set (agent supersteps)
+        agent_cps = [
+            t for t in tuples if t.checkpoint["channel_values"].get("current_agent")
+        ]
+        assert len(agent_cps) == 3
+
+        # agent_outputs grows by one entry each superstep
+        for idx, tup in enumerate(agent_cps):
+            cv = tup.checkpoint["channel_values"]
+            assert len(cv.get("agent_outputs", {})) == idx + 1
+
+    def test_executor_result_agent_results_populated(self):
+        _, result = _run(_seq_config(n_agents=3, with_channels=False))
+        assert result.success
+        assert len(result.agent_results) == 3
+        for ar in result.agent_results:
+            assert ar.output.get("status") == "stub"
+            assert ar.agent_id.startswith("agent_")
+
+
+# ---------------------------------------------------------------------------
+# Message name attribution provenance
+# ---------------------------------------------------------------------------
+
+
+class TestMessageNameProvenance:
+    """AIMessages emitted by agent nodes carry name=<agent_id>."""
+
+    def test_message_names_set_no_channels(self):
+        executor, result = _run(_seq_config(n_agents=3, with_channels=False))
+        assert result.success
+        final_cv = _checkpoints_chronological(executor, "prov-001")[-1].checkpoint[
+            "channel_values"
+        ]
+        messages = final_cv.get("messages", [])
+        ai_names = [
+            getattr(m, "name", None)
+            for m in messages
+            if hasattr(m, "name") and m.__class__.__name__ == "AIMessage"
+        ]
+        # One AIMessage per agent, each tagged with the agent's ID
+        assert set(ai_names) == {"agent_0", "agent_1", "agent_2"}
+
+    def test_serialized_messages_carry_name(self):
+        _, result = _run(_seq_config(n_agents=2, with_channels=False))
+        assert result.success
+        msgs = result.final_state.get("messages", [])
+        ai_msgs = [m for m in msgs if m.get("type") == "AIMessage"]
+        assert len(ai_msgs) == 2
+        names = {m.get("name") for m in ai_msgs}
+        assert names == {"agent_0", "agent_1"}
+
+
+# ---------------------------------------------------------------------------
+# communication_log provenance — no explicit channels (Bug A regression)
+# ---------------------------------------------------------------------------
+
+
+class TestCommunicationLogNoChannels:
+    """communication_log is always present even without explicit channels.
+
+    Regression for Bug A: the channel was absent from the state schema when
+    no channels were declared, so per-agent handoffs were never logged.
+    """
+
+    def test_communication_log_in_schema_no_channels(self):
+        from bili.aether.compiler.state_generator import (  # pylint: disable=import-outside-toplevel
+            generate_state_schema,
+        )
+
+        config = _seq_config(n_agents=2, with_channels=False)
+        schema = generate_state_schema(config)
+        annotations = schema.__annotations__
+
+        assert "communication_log" in annotations
+        # Routing auxiliaries are NOT present without explicit channels
+        assert "channel_messages" not in annotations
+        assert "pending_messages" not in annotations
+
+    def test_communication_log_in_initial_state_no_channels(self):
+        executor = MASExecutor(_seq_config(n_agents=2, with_channels=False))
+        executor.initialize()
+        state = executor._build_initial_state({})  # pylint: disable=protected-access
+        assert "communication_log" in state
+        assert state["communication_log"] == []
+
+    def test_communication_log_checkpointed_no_channels(self):
+        executor, result = _run(_seq_config(n_agents=3, with_channels=False))
+        assert result.success
+
+        tuples = _checkpoints_chronological(executor, "prov-001")
+        final_cv = tuples[-1].checkpoint["channel_values"]
+
+        # communication_log is present in the final checkpoint
+        assert "communication_log" in final_cv
+        comm_log = final_cv["communication_log"]
+        assert isinstance(comm_log, list)
+        # One entry per agent
+        assert len(comm_log) == 3
+
+    def test_communication_log_entries_per_superstep_no_channels(self):
+        executor, result = _run(_seq_config(n_agents=3, with_channels=False))
+        assert result.success
+
+        tuples = _checkpoints_chronological(executor, "prov-001")
+        agent_cps = [
+            t for t in tuples if t.checkpoint["channel_values"].get("current_agent")
+        ]
+        assert len(agent_cps) == 3
+
+        # Accumulated log grows by exactly one entry per superstep
+        for idx, tup in enumerate(agent_cps):
+            cv = tup.checkpoint["channel_values"]
+            comm_log = cv.get("communication_log", [])
+            assert len(comm_log) == idx + 1
+            # The entry at this step is from the current agent
+            assert comm_log[idx]["sender"] == cv["current_agent"]
+
+    def test_communication_log_senders_cover_all_agents_no_channels(self):
+        executor, result = _run(_seq_config(n_agents=3, with_channels=False))
+        assert result.success
+
+        tuples = _checkpoints_chronological(executor, "prov-001")
+        final_cv = tuples[-1].checkpoint["channel_values"]
+        senders = {e["sender"] for e in final_cv.get("communication_log", [])}
+        assert senders == {"agent_0", "agent_1", "agent_2"}
+
+    def test_communication_log_channel_is_agent_output(self):
+        executor, result = _run(_seq_config(n_agents=2, with_channels=False))
+        assert result.success
+
+        tuples = _checkpoints_chronological(executor, "prov-001")
+        final_cv = tuples[-1].checkpoint["channel_values"]
+        channels = {e["channel"] for e in final_cv.get("communication_log", [])}
+        assert channels == {"__agent_output__"}
+
+
+# ---------------------------------------------------------------------------
+# communication_log deduplication (Bug B regression)
+# ---------------------------------------------------------------------------
+
+
+class TestCommunicationLogNoDeduplication:
+    """communication_log entries are not duplicated across supersteps.
+
+    Regression for Bug B: send_message_in_state returned the full accumulated
+    log as the state-update value.  Because the reducer is operator.add, each
+    superstep doubled all prior entries.  A 3-agent run produced 1+3+7=7
+    entries instead of 3.
+    """
+
+    def test_no_duplicate_entries_no_channels(self):
+        executor, result = _run(_seq_config(n_agents=3, with_channels=False))
+        assert result.success
+
+        tuples = _checkpoints_chronological(executor, "prov-001")
+        final_cv = tuples[-1].checkpoint["channel_values"]
+        comm_log = final_cv.get("communication_log", [])
+
+        # Exactly one entry per agent, no duplicates
+        assert len(comm_log) == 3
+        ids = [e.get("message_id") for e in comm_log]
+        assert len(set(ids)) == 3, f"Duplicate IDs found: {ids}"
+
+    def test_no_duplicate_entries_with_channels(self):
+        executor, result = _run(
+            _seq_config(n_agents=3, with_channels=True),
+            thread_id="prov-ch-dedup",
+        )
+        assert result.success
+
+        tuples = _checkpoints_chronological(executor, "prov-ch-dedup")
+        final_cv = tuples[-1].checkpoint["channel_values"]
+        comm_log = final_cv.get("communication_log", [])
+
+        assert len(comm_log) == 3
+        ids = [e.get("message_id") for e in comm_log]
+        assert len(set(ids)) == 3, f"Duplicate IDs found: {ids}"
+
+    def test_communication_log_growth_is_linear(self):
+        # Each superstep adds exactly one entry; growth is N, not 2^N - 1.
+        executor, result = _run(_seq_config(n_agents=4, with_channels=False))
+        assert result.success
+
+        tuples = _checkpoints_chronological(executor, "prov-001")
+        agent_cps = [
+            t for t in tuples if t.checkpoint["channel_values"].get("current_agent")
+        ]
+        lengths = [
+            len(t.checkpoint["channel_values"].get("communication_log", []))
+            for t in agent_cps
+        ]
+        assert lengths == [1, 2, 3, 4], f"Non-linear growth: {lengths}"
+
+    def test_send_message_returns_delta_only(self):
+        """send_message_in_state returns [msg_dict], not the full accumulated list."""
+        from bili.aether.runtime.communication_state import (  # pylint: disable=import-outside-toplevel
+            send_message_in_state,
+        )
+        from bili.aether.runtime.messages import (  # pylint: disable=import-outside-toplevel
+            MessageType,
+        )
+
+        existing_log = [{"sender": "agent_0", "content": "prior output"}]
+        state = {
+            "communication_log": existing_log,
+            "channel_messages": {},
+            "pending_messages": {},
+        }
+        update = send_message_in_state(
+            state=state,
+            channel_id="__agent_output__",
+            sender="agent_1",
+            content="new output",
+            message_type=MessageType.BROADCAST,
+        )
+        # The update must contain only the NEW entry, not the full accumulated log.
+        comm_delta = update["communication_log"]
+        assert (
+            len(comm_delta) == 1
+        ), f"Expected delta of 1, got {len(comm_delta)}: {comm_delta}"
+        assert comm_delta[0]["sender"] == "agent_1"
+
+        # Verify operator.add would produce the correct 2-entry accumulated log.
+        accumulated = operator.add(existing_log, comm_delta)
+        assert len(accumulated) == 2
+
+
+# ---------------------------------------------------------------------------
+# audit_view provenance
+# ---------------------------------------------------------------------------
+
+
+class TestAuditViewProvenance:
+    """audit_view() builds a clean per-agent timeline from checkpoints."""
+
+    def test_audit_view_one_entry_per_agent_no_channels(self):
+        executor, result = _run(_seq_config(n_agents=3, with_channels=False))
+        assert result.success
+
+        timeline = audit_view(
+            executor._checkpointer, "prov-001"
+        )  # pylint: disable=protected-access
+        # Exactly one entry per agent (internal LangGraph seed checkpoints filtered)
+        assert len(timeline) == 3
+
+    def test_audit_view_agent_ids_in_order_no_channels(self):
+        executor, result = _run(_seq_config(n_agents=3, with_channels=False))
+        assert result.success
+
+        timeline = audit_view(
+            executor._checkpointer, "prov-001"
+        )  # pylint: disable=protected-access
+        agent_ids = [e["agent_id"] for e in timeline]
+        assert agent_ids == ["agent_0", "agent_1", "agent_2"]
+
+    def test_audit_view_output_summary_populated(self):
+        executor, result = _run(_seq_config(n_agents=2, with_channels=False))
+        assert result.success
+
+        timeline = audit_view(
+            executor._checkpointer, "prov-001"
+        )  # pylint: disable=protected-access
+        for entry in timeline:
+            assert entry["output_summary"] is not None
+            assert len(entry["output_summary"]) > 0
+
+    def test_audit_view_messages_sent_per_agent(self):
+        # Each agent's timeline entry has exactly one messages_sent entry.
+        executor, result = _run(_seq_config(n_agents=3, with_channels=False))
+        assert result.success
+
+        timeline = audit_view(
+            executor._checkpointer, "prov-001"
+        )  # pylint: disable=protected-access
+        for entry in timeline:
+            assert len(entry["messages_sent"]) == 1
+            msg = entry["messages_sent"][0]
+            assert msg["sender"] == entry["agent_id"]
+
+    def test_audit_view_with_channels(self):
+        executor, result = _run(
+            _seq_config(n_agents=3, with_channels=True),
+            thread_id="prov-ch-audit",
+        )
+        assert result.success
+
+        timeline = audit_view(
+            executor._checkpointer, "prov-ch-audit"
+        )  # pylint: disable=protected-access
+        assert len(timeline) == 3
+        agent_ids = [e["agent_id"] for e in timeline]
+        assert agent_ids == ["agent_0", "agent_1", "agent_2"]
+
+    def test_audit_view_no_initial_noise(self):
+        # The initial LangGraph seed checkpoints (current_agent='' or None)
+        # must not appear in the timeline.
+        executor, result = _run(_seq_config(n_agents=2, with_channels=False))
+        assert result.success
+
+        timeline = audit_view(
+            executor._checkpointer, "prov-001"
+        )  # pylint: disable=protected-access
+        for entry in timeline:
+            assert entry["agent_id"] not in (None, "", "''")
+
+    def test_audit_view_raw_agent_outputs_populated(self):
+        executor, result = _run(_seq_config(n_agents=3, with_channels=False))
+        assert result.success
+
+        timeline = audit_view(
+            executor._checkpointer, "prov-001"
+        )  # pylint: disable=protected-access
+        for entry in timeline:
+            assert entry["raw_agent_outputs"]
+            assert entry["agent_id"] in entry["raw_agent_outputs"]
+
+
+# ---------------------------------------------------------------------------
+# MASExecutionResult provenance statistics
+# ---------------------------------------------------------------------------
+
+
+class TestExecutionResultProvenanceStats:
+    """MASExecutionResult communication stats reflect per-agent provenance."""
+
+    def test_total_messages_equals_agent_count_no_channels(self):
+        # Without explicit channels, each agent emits exactly one broadcast.
+        _, result = _run(_seq_config(n_agents=3, with_channels=False))
+        assert result.success
+        assert result.total_messages == 3
+
+    def test_messages_by_channel_no_channels(self):
+        _, result = _run(_seq_config(n_agents=3, with_channels=False))
+        assert result.success
+        assert result.messages_by_channel == {"__agent_output__": 3}
+
+    def test_total_messages_with_channels(self):
+        _, result = _run(
+            _seq_config(n_agents=3, with_channels=True),
+            thread_id="prov-ch-stats",
+        )
+        assert result.success
+        # With or without channels, each agent emits exactly one broadcast.
+        assert result.total_messages == 3

--- a/bili/aether/tests/test_state_based_communication.py
+++ b/bili/aether/tests/test_state_based_communication.py
@@ -323,7 +323,7 @@ class TestCommunicationWithoutChannels:
     """Tests for default communication behavior without explicit channels."""
 
     def test_agents_broadcast_output_without_channels(self):
-        """Test that agents broadcast their output even without channel definitions."""
+        """Test that agents broadcast provenance to communication_log without explicit channels."""
         config = _make_test_config(WorkflowType.SEQUENTIAL, with_channels=False)
         compiled = compile_mas(config)
         graph = compiled.compile_graph()
@@ -333,9 +333,16 @@ class TestCommunicationWithoutChannels:
             config={"configurable": {"thread_id": "test_no_channels"}},
         )
 
-        # Even without explicit channels, agents should NOT have communication fields
-        # because state generator only adds them when config.channels is present
-        assert "communication_log" not in result
+        # communication_log is always present so per-agent provenance is durably
+        # recorded regardless of whether explicit channels are configured.
+        assert "communication_log" in result
+        comm_log = result["communication_log"]
+        assert isinstance(comm_log, list)
+        # All 3 agents broadcast their output on __agent_output__
+        assert len(comm_log) == 3
+        senders = {e["sender"] for e in comm_log}
+        assert senders == {"agent_a", "agent_b", "agent_c"}
+        # Routing auxiliaries are absent when no explicit channels are declared
         assert "channel_messages" not in result
         assert "pending_messages" not in result
 


### PR DESCRIPTION
## Summary

Three independent bugs prevented per-agent provenance from persisting to the LangGraph checkpoint stream of a completed multi-agent run. After this fix, walking the checkpoints of any sequential MAS run yields the full per-agent chain needed for audit and observability.

### Root causes

**Bug A — `communication_log` absent for workflows without explicit channels**

`state_generator.py` gated `communication_log` behind `if config.channels:`. Sequential workflows with no declared inter-agent channels never had the field in their state schema, and the executor never initialised it. The provenance log simply did not exist.

Fix: unconditionally add `communication_log` (`Annotated[list, operator.add]`) to the generated schema. The routing auxiliaries `channel_messages` and `pending_messages` remain gated — they are only meaningful when explicit channels are declared.

**Bug B — exponential duplication in `communication_log`**

`send_message_in_state` returned the full accumulated log (existing entries + new message) as the state-update value. Because the reducer is `operator.add` (list concatenation), each superstep doubled every prior entry: a 3-agent run produced 1+3+7=7 entries instead of 3.

Fix: return only the delta — a single-element list containing the new message. The reducer concatenates the delta, producing the correct append-only N-entry history.

**Bug C — `_build_communication_update` was a no-op without channels**

`agent_generator.py` guarded `_build_communication_update` with `if "communication_log" not in state: return {}`. Without channels, `communication_log` was absent from the state (Bug A), so this guard always fired and no provenance entry was ever written even after Bug A was fixed.

Fix: remove the guard; always record a broadcast entry on `__agent_output__` for every agent completion.

**`audit_view` cleanup**

Added filtering to skip LangGraph's internal seed checkpoints (supersteps where `current_agent` is empty and no agent output changed), so the rendered timeline contains exactly one entry per agent in chronological order.

### What is durably recorded after this fix

In every checkpointed superstep of a sequential MAS run:

| Channel | Content |
|---|---|
| `current_agent` | Agent ID that acted at this superstep |
| `agent_outputs[agent_id]` | Output dict for that agent |
| `messages[*].name` | Agent ID on every AIMessage emitted |
| `communication_log[N]` | One broadcast entry per agent, no duplicates, present without explicit channels |

### Files changed

- `bili/aether/compiler/state_generator.py` — unconditional `communication_log`
- `bili/aether/runtime/executor.py` — unconditional initialisation
- `bili/aether/runtime/communication_state.py` — delta-only return + clarified reducer contract in module docstring
- `bili/aether/compiler/agent_generator.py` — removed guard, always record provenance
- `bili/aether/runtime/audit.py` — skip no-activity seed checkpoints
- 4 existing test files updated to match new provenance-always-on behavior
- `bili/aether/tests/test_provenance.py` — 28 new tests verifying all three channels end-to-end

## Test plan

- [x] `python -m pytest bili/aether/tests/test_provenance.py` — 28/28 pass (new provenance tests)
- [x] `python -m pytest bili/aether/tests/` — 714/714 pass (zero regressions in AETHER suite)
- [x] `bash run_python_formatters.sh` — pylint 9.64/10, black/isort/autoflake clean
- [x] `python scripts/check_coverage.py` — 214/214 runtime files >= 90%, overall 98.4%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpXRrbE4UhL22Usj6UdEVQ