### PR TITLE
fix: pipeline-agent provenance missing from outer MAS checkpointed state

### DIFF
--- a/bili/aether/compiler/graph_builder.py
+++ b/bili/aether/compiler/graph_builder.py
@@ -210,6 +210,33 @@ def safe_eval_condition(condition: str, context: Dict[str, Any]) -> bool:
     return bool(result)
 
 
+def _build_pipeline_provenance(state: dict, agent_id: str, content: str) -> dict:
+    """Return a state-update delta that records pipeline-agent provenance.
+
+    Pipeline agents run as compiled inner subgraphs whose state schemas do not
+    include ``communication_log`` (the outer MAS routing auxiliary).  Provenance
+    must therefore be emitted explicitly at the outer-graph boundary — after the
+    inner subgraph returns — using the same helper that plain agent nodes use.
+
+    Args:
+        state: The current outer-graph state dict (read for existing log / channels).
+        agent_id: The pipeline agent's ID (becomes ``sender`` in the log entry).
+        content: The final output content produced by the pipeline.
+
+    Returns:
+        A partial state-update dict ready to merge into the outer node return
+        value.  Always includes ``communication_log`` (single-element delta).
+        Includes ``channel_messages`` / ``pending_messages`` when the outer
+        schema carries them; those keys are silently ignored by LangGraph when
+        the outer schema omits them.
+    """
+    from .agent_generator import (  # pylint: disable=import-outside-toplevel
+        _build_communication_update,
+    )
+
+    return _build_communication_update(state, agent_id, content)
+
+
 class GraphBuilder:  # pylint: disable=too-few-public-methods,too-many-instance-attributes
     """Builds a LangGraph ``StateGraph`` from a validated ``MASConfig``.
 
@@ -718,13 +745,23 @@ class GraphBuilder:  # pylint: disable=too-few-public-methods,too-many-instance-
                     "status": "error",
                     "message": error_msg,
                 }
-                return {
+                err_output = {
                     "messages": [AIMessage(content=error_msg, name=agent_id)],
                     "current_agent": agent_id,
                     "agent_outputs": agent_outputs,
                 }
+                # Record provenance even on failure so the audit log reflects
+                # which agent faulted and what error it emitted.
+                err_output.update(
+                    _build_pipeline_provenance(state, agent_id, error_msg)
+                )
+                return err_output
 
-            # Output mapping: inner → outer (explicit — only messages + agent_outputs)
+            # Output mapping: inner → outer (explicit — only messages + agent_outputs
+            # + per-agent provenance).  The inner pipeline schema intentionally omits
+            # communication_log (routing auxiliaries are only for the outer MAS graph),
+            # so provenance is emitted here at the outer-graph boundary rather than
+            # propagated from the inner result.
             inner_messages = result.get("messages", [])
             inner_outputs = result.get("agent_outputs", {})
 
@@ -762,6 +799,10 @@ class GraphBuilder:  # pylint: disable=too-few-public-methods,too-many-instance-
             for field in custom_state_fields:
                 if field.name in result:
                     output[field.name] = result[field.name]
+            # Emit per-agent provenance to the outer communication_log so
+            # pipeline agents are observable in audit views just like plain
+            # agent nodes.
+            output.update(_build_pipeline_provenance(state, agent_id, final_content))
             return output
 
         _pipeline_node.__name__ = f"pipeline_{agent_id}"

--- a/bili/aether/tests/test_pipeline_compiler.py
+++ b/bili/aether/tests/test_pipeline_compiler.py
@@ -288,7 +288,18 @@ class TestStateAdapter:
         assert messages[0].name == "test_agent"
 
     def test_pipeline_does_not_leak_inner_state(self):
-        """Pipeline output should not include inner state fields beyond messages/agent_outputs."""
+        """Pipeline output should not include inner sub-graph state fields.
+
+        The inner pipeline schema declares custom state_fields that are
+        private to the sub-graph (e.g. intermediate routing flags).  Those
+        must NOT appear in the outer node return value unless explicitly
+        propagated via ``state_fields`` propagation logic.
+
+        The outer provenance fields (``communication_log``,
+        ``channel_messages``, ``pending_messages``) ARE expected — they
+        are emitted by every agent node (plain and pipeline) so that
+        per-agent provenance is durably checkpointed in the outer MAS state.
+        """
         agent = _simple_agent(pipeline=_single_node_pipeline())
         mas = _build_sequential_mas(agent)
         compiled = GraphBuilder(mas).build()
@@ -296,8 +307,16 @@ class TestStateAdapter:
         node_fn = compiled.agent_nodes["test_agent"]
         result = node_fn({"messages": [], "agent_outputs": {}})
 
-        # Only expected keys should be in the result
-        expected_keys = {"messages", "current_agent", "agent_outputs"}
+        # Core state fields plus outer-MAS provenance channels.
+        # Inner sub-graph fields (e.g. custom state_fields) must NOT appear.
+        expected_keys = {
+            "messages",
+            "current_agent",
+            "agent_outputs",
+            "communication_log",
+            "channel_messages",
+            "pending_messages",
+        }
         assert set(result.keys()) == expected_keys
 
 

--- a/bili/aether/tests/test_pipeline_comprehensive.py
+++ b/bili/aether/tests/test_pipeline_comprehensive.py
@@ -327,7 +327,12 @@ class TestErrorAttribution:
         assert "inner node failed" in error_msg
 
     def test_error_returns_all_required_state_fields(self):
-        """Pipeline errors return complete state update (messages, current_agent, agent_outputs)."""
+        """Pipeline errors return a complete state update including provenance fields.
+
+        The error path emits the same provenance fields as the success path so
+        that a faulted pipeline agent still appears in the outer communication_log
+        and can be identified in audit views.
+        """
         agent = _agent("failing", pipeline=_stub_pipeline())
         mock_subgraph = MagicMock()
         mock_subgraph.invoke.side_effect = ValueError("bad input")
@@ -343,10 +348,22 @@ class TestErrorAttribution:
         wrapper = builder._wrap_pipeline_as_agent_node(mock_subgraph, agent)
         result = wrapper({"messages": [], "agent_outputs": {}})
 
-        assert set(result.keys()) == {"messages", "current_agent", "agent_outputs"}
+        # Core fields plus outer-MAS provenance channels (same as success path).
+        expected_keys = {
+            "messages",
+            "current_agent",
+            "agent_outputs",
+            "communication_log",
+            "channel_messages",
+            "pending_messages",
+        }
+        assert set(result.keys()) == expected_keys
         assert len(result["messages"]) == 1
         assert result["current_agent"] == "failing"
         assert result["agent_outputs"]["failing"]["status"] == "error"
+        # The error message is attributed in communication_log too.
+        assert len(result["communication_log"]) == 1
+        assert result["communication_log"][0]["sender"] == "failing"
 
 
 # =========================================================================

--- a/bili/aether/tests/test_provenance.py
+++ b/bili/aether/tests/test_provenance.py
@@ -10,8 +10,7 @@ post-run observability:
 3. ``communication_log`` — one broadcast entry per agent handoff, present
    even when no explicit inter-agent channels are declared.
 
-Root-cause regression tests are also included to pin the two bugs that
-were fixed:
+Root-cause regression tests are also included to pin the bugs that were fixed:
 
 - Bug A: ``communication_log`` was absent from the state schema (and hence
   never checkpointed) for sequential workflows that declared no explicit
@@ -23,6 +22,14 @@ were fixed:
   produced 7 entries (1+3+7 pattern) instead of 3.  Fix: return only the
   delta (single-element list) for ``communication_log``.
 
+- Bug C: pipeline agents (``AgentSpec.pipeline`` set) compiled as inner
+  sub-graphs did not emit a ``communication_log`` entry to the OUTER MAS
+  state.  The inner sub-graph schema intentionally omits ``communication_log``
+  (it is an outer MAS routing auxiliary), and the inner→outer output mapping
+  in ``_wrap_pipeline_as_agent_node`` never called ``_build_communication_update``.
+  Fix: call ``_build_pipeline_provenance`` at the outer-graph boundary after
+  the sub-graph returns, just as plain agent nodes do.
+
 All tests use stub agents (``model_name`` not set) and a MemorySaver
 checkpointer so no LLM API calls or database servers are needed.
 """
@@ -33,6 +40,7 @@ import operator
 
 from langchain_core.messages import HumanMessage
 
+from bili.aether.compiler import compile_mas
 from bili.aether.runtime.audit import audit_view
 from bili.aether.runtime.executor import MASExecutor
 from bili.aether.schema import (
@@ -41,6 +49,11 @@ from bili.aether.schema import (
     CommunicationProtocol,
     MASConfig,
     WorkflowType,
+)
+from bili.aether.schema.pipeline_spec import (
+    PipelineEdgeSpec,
+    PipelineNodeSpec,
+    PipelineSpec,
 )
 
 # ---------------------------------------------------------------------------
@@ -515,3 +528,214 @@ class TestExecutionResultProvenanceStats:
         assert result.success
         # With or without channels, each agent emits exactly one broadcast.
         assert result.total_messages == 3
+
+
+# ---------------------------------------------------------------------------
+# Pipeline-agent provenance via the compile_mas / GraphBuilder path
+# ---------------------------------------------------------------------------
+
+
+def _pipeline_spec() -> PipelineSpec:
+    """A minimal two-node stub pipeline: step_a → step_b → END."""
+    return PipelineSpec(
+        nodes=[
+            PipelineNodeSpec(
+                node_id="step_a",
+                node_type="agent",
+                agent_spec={
+                    "agent_id": "inner_a",
+                    "role": "analyzer",
+                    "objective": "First pipeline step for analysis work",
+                },
+            ),
+            PipelineNodeSpec(
+                node_id="step_b",
+                node_type="agent",
+                agent_spec={
+                    "agent_id": "inner_b",
+                    "role": "formatter",
+                    "objective": "Format pipeline output for delivery",
+                },
+            ),
+        ],
+        edges=[
+            PipelineEdgeSpec(from_node="step_a", to_node="step_b"),
+            PipelineEdgeSpec(from_node="step_b", to_node="END"),
+        ],
+    )
+
+
+def _pipeline_config(mas_id: str = "pip_prov") -> MASConfig:
+    """Sequential MAS with one plain agent and one pipeline agent."""
+    return MASConfig(
+        mas_id=mas_id,
+        name="Pipeline Provenance Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[
+            AgentSpec(
+                agent_id="plain_agent",
+                role="worker",
+                objective="Run a plain agent task without a pipeline",
+            ),
+            AgentSpec(
+                agent_id="pipe_agent",
+                role="worker",
+                objective="Run a pipeline agent task via inner sub-graph",
+                pipeline=_pipeline_spec(),
+            ),
+        ],
+        checkpoint_enabled=True,
+        checkpoint_config={"type": "memory"},
+    )
+
+
+class TestPipelineAgentProvenance:
+    """Per-agent provenance reaches the OUTER checkpointed state for pipeline agents.
+
+    Regression for Bug C: ``_wrap_pipeline_as_agent_node`` compiled each agent as
+    an inner sub-graph but never called ``_build_communication_update`` for the
+    outer MAS state, so pipeline agents produced no ``communication_log`` entry
+    in the OUTER (checkpointed) state even though plain agents did.
+
+    These tests compile through the full ``compile_mas`` → ``GraphBuilder`` →
+    ``_compile_pipeline_node`` → ``_wrap_pipeline_as_agent_node`` path to
+    catch the exact boundary that the fix addresses.
+    """
+
+    def _run_pipeline_mas(self, thread_id: str = "pip-001"):
+        """Run the mixed plain+pipeline MAS and return (checkpointer, result)."""
+        from langgraph.checkpoint.memory import (  # pylint: disable=import-outside-toplevel
+            MemorySaver,
+        )
+
+        config = _pipeline_config()
+        compiled = compile_mas(config)
+        checkpointer = MemorySaver()
+        graph = compiled.compile_graph(checkpointer=checkpointer)
+
+        result = graph.invoke(
+            {"messages": [HumanMessage(content="start")]},
+            config={"configurable": {"thread_id": thread_id}},
+        )
+        return checkpointer, result
+
+    def _outer_checkpoints(self, checkpointer, thread_id: str):
+        """Return outer checkpoint channel_values dicts in chronological order."""
+        cfg = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+        tuples = list(checkpointer.list(cfg))
+        return [t.checkpoint["channel_values"] for t in reversed(tuples)]
+
+    # ------------------------------------------------------------------
+    # current_agent
+    # ------------------------------------------------------------------
+
+    def test_pipeline_agent_sets_current_agent_in_outer_checkpoint(self):
+        """current_agent is set correctly in the outer checkpoint for a pipeline agent.
+
+        This test exercises the compile_mas → GraphBuilder → _compile_pipeline_node
+        path and asserts that provenance fields reach the OUTER (checkpointed) state,
+        not just the inner sub-graph's transient state.
+        """
+        checkpointer, result = self._run_pipeline_mas()
+        assert result.get("current_agent") == "pipe_agent"
+
+        cvs = self._outer_checkpoints(checkpointer, "pip-001")
+        agent_steps = [cv.get("current_agent") for cv in cvs if cv.get("current_agent")]
+        assert "plain_agent" in agent_steps
+        assert "pipe_agent" in agent_steps
+
+    # ------------------------------------------------------------------
+    # agent_outputs
+    # ------------------------------------------------------------------
+
+    def test_pipeline_agent_populates_agent_outputs_in_outer_checkpoint(self):
+        checkpointer, result = self._run_pipeline_mas()
+        agent_outputs = result.get("agent_outputs", {})
+
+        # Both the plain agent and the pipeline agent must appear.
+        assert "plain_agent" in agent_outputs
+        assert "pipe_agent" in agent_outputs
+        assert agent_outputs["pipe_agent"].get("status") == "completed"
+        # pipeline_outputs records the inner sub-graph's agent_outputs dict.
+        assert "pipeline_outputs" in agent_outputs["pipe_agent"]
+
+    # ------------------------------------------------------------------
+    # communication_log — Bug C regression
+    # ------------------------------------------------------------------
+
+    def test_pipeline_agent_emits_communication_log_entry(self):
+        """Pipeline agent emits a communication_log entry to the OUTER state.
+
+        Bug C regression: _wrap_pipeline_as_agent_node never called
+        _build_communication_update, so pipeline agents produced no
+        communication_log entry in the outer (checkpointed) state.
+        """
+        checkpointer, result = self._run_pipeline_mas()
+        comm_log = result.get("communication_log", [])
+
+        # One entry per outer agent (plain_agent + pipe_agent)
+        assert len(comm_log) == 2
+        senders = {e["sender"] for e in comm_log}
+        assert senders == {"plain_agent", "pipe_agent"}
+
+    def test_pipeline_agent_communication_log_entry_in_checkpoint(self):
+        """The outer checkpoint carries pipe_agent's communication_log entry."""
+        checkpointer, _ = self._run_pipeline_mas()
+        cvs = self._outer_checkpoints(checkpointer, "pip-001")
+
+        # Find the checkpoint where pipe_agent ran
+        pipe_cvs = [cv for cv in cvs if cv.get("current_agent") == "pipe_agent"]
+        assert pipe_cvs, "No checkpoint with current_agent='pipe_agent'"
+
+        pipe_cv = pipe_cvs[-1]  # use the latest pipe_agent checkpoint
+        log = pipe_cv.get("communication_log", [])
+        senders = [e["sender"] for e in log]
+        assert (
+            "pipe_agent" in senders
+        ), f"pipe_agent missing from communication_log. senders={senders}"
+
+    def test_pipeline_agent_no_duplicate_log_entries(self):
+        """Communication log entries are not duplicated for pipeline agents."""
+        checkpointer, result = self._run_pipeline_mas()
+        comm_log = result.get("communication_log", [])
+
+        ids = [e.get("message_id") for e in comm_log]
+        assert len(set(ids)) == len(ids), f"Duplicate IDs in log: {ids}"
+
+    # ------------------------------------------------------------------
+    # messages.name
+    # ------------------------------------------------------------------
+
+    def test_pipeline_agent_message_name_set(self):
+        """AIMessage emitted by pipeline agent carries name=pipe_agent."""
+        _, result = self._run_pipeline_mas()
+        messages = result.get("messages", [])
+        names = {getattr(m, "name", None) for m in messages if hasattr(m, "name")}
+        assert "pipe_agent" in names, f"pipe_agent name missing from messages: {names}"
+
+    # ------------------------------------------------------------------
+    # audit_view end-to-end
+    # ------------------------------------------------------------------
+
+    def test_pipeline_agent_appears_in_audit_view(self):
+        """audit_view returns one entry per agent, including the pipeline agent."""
+        from langgraph.checkpoint.memory import (  # pylint: disable=import-outside-toplevel
+            MemorySaver,
+        )
+
+        config = _pipeline_config(mas_id="pip_audit")
+        compiled = compile_mas(config)
+        checkpointer = MemorySaver()
+        graph = compiled.compile_graph(checkpointer=checkpointer)
+        graph.invoke(
+            {"messages": [HumanMessage(content="start")]},
+            config={"configurable": {"thread_id": "pip-audit-001"}},
+        )
+
+        timeline = audit_view(checkpointer, "pip-audit-001")
+        agent_ids = [e["agent_id"] for e in timeline]
+        assert "plain_agent" in agent_ids
+        assert "pipe_agent" in agent_ids
+        # Both agents have messages_sent entries
+        for entry in timeline:
+            assert len(entry["messages_sent"]) >= 1


### PR DESCRIPTION
## Summary

- `_wrap_pipeline_as_agent_node` compiled pipeline agents as inner sub-graphs but never called `_build_communication_update`, so pipeline agents produced no `communication_log` entry in the outer (checkpointed) MAS state.
- Plain agent nodes (fixed in #224) called `_build_communication_update` correctly; pipeline agents did not.
- Fix: add `_build_pipeline_provenance()` in `graph_builder.py` that calls `_build_communication_update` at the outer-graph boundary after the inner sub-graph returns, on both the success path and the error path.
- 7 new tests in `TestPipelineAgentProvenance` confirm the fix via the full `compile_mas` → `GraphBuilder` → `_compile_pipeline_node` → `_wrap_pipeline_as_agent_node` path.

## Root cause

The inner pipeline sub-graph schema intentionally omits `communication_log` — it is an outer MAS routing auxiliary, not an inner sub-graph field. The inner→outer output mapping at the end of `_pipeline_node` mapped `messages`, `current_agent`, `agent_outputs`, and custom `state_fields`, but not `communication_log`. As a result, pipeline agents were invisible to `audit_view` and the outer communication log was incomplete.

## What is fixed

After this change, pipeline agents emit the same provenance as plain agent nodes to the outer MAS state:

| Channel | Before | After |
|---|---|---|
| `current_agent` | Set correctly (was not affected) | Set correctly |
| `agent_outputs[agent_id]` | Set correctly (was not affected) | Set correctly |
| `messages[*].name` | Set correctly (was not affected) | Set correctly |
| `communication_log` | **Missing** — pipeline agents produced 0 entries | One entry per pipeline agent per superstep |

## Files changed

- `bili/aether/compiler/graph_builder.py` — `_build_pipeline_provenance()` helper + call sites in `_pipeline_node` success and error paths
- `bili/aether/tests/test_provenance.py` — 7 new `TestPipelineAgentProvenance` tests; updated module docstring with Bug C description
- `bili/aether/tests/test_pipeline_compiler.py` — updated expected key set in `test_pipeline_does_not_leak_inner_state`
- `bili/aether/tests/test_pipeline_comprehensive.py` — updated expected key set in `test_error_returns_all_required_state_fields`

## Before / after confirmation

3 of the 7 new tests fail on the `develop` base before this fix:
- `test_pipeline_agent_emits_communication_log_entry`
- `test_pipeline_agent_communication_log_entry_in_checkpoint`
- `test_pipeline_agent_appears_in_audit_view`

All 7 pass after the fix.

## Test plan

- [x] `python -m pytest bili/aether/tests/test_provenance.py::TestPipelineAgentProvenance` — 7/7 pass (new pipeline provenance tests)
- [x] `python -m pytest bili/aether/tests/` — 721/721 pass (zero regressions)
- [x] `bash run_python_formatters.sh` — pylint 9.64/10, black/isort/autoflake clean
- [x] `python scripts/check_coverage.py` — 214/214 runtime files >= 90%, overall 98.4%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpXRrbE4UhL22Usj6UdEVQ