### PR TITLE
fix: complete per-agent provenance across all three AETHER execution paths (native, pipeline, MCP/CLI)

### DIFF
--- a/bili/aether/compiler/agent_generator.py
+++ b/bili/aether/compiler/agent_generator.py
@@ -256,7 +256,8 @@ def _generate_tool_agent_node(
                 len(tools),
                 getattr(llm, "command", ["?"])[0],
             )
-            return build_mcp_node(llm_model=llm, tools=tools, injector=injector)
+            mcp_node = build_mcp_node(llm_model=llm, tools=tools, injector=injector)
+            return _wrap_mcp_node_with_provenance(mcp_node, agent)
 
         LOGGER.warning(
             "Agent '%s': tool_strategy='mcp' but no injector found for CLI '%s'; "
@@ -365,6 +366,67 @@ def _generate_tool_agent_node(
     _agent_node.agent_spec = agent  # type: ignore[attr-defined]
     _agent_node.__name__ = f"agent_{agent.agent_id}"
     _agent_node.__qualname__ = f"agent_{agent.agent_id}"
+
+    return _agent_node
+
+
+def _wrap_mcp_node_with_provenance(
+    inner_node: Callable[[dict], dict], agent: AgentSpec
+) -> Callable[[dict], dict]:
+    """Wrap an IRIS MCP node so it synthesises AETHER per-agent provenance.
+
+    The MCP node returned by :func:`~bili.iris.mcp.server.build_mcp_node` is
+    intentionally generic: it serves an agent's tools to a self-orchestrating
+    CLI and returns only ``{"messages": [AIMessage(content=...)]}`` — it has no
+    knowledge of the AETHER ``agent_id`` or the MAS provenance protocol.
+    Returning it raw leaves the outer MAS state without provenance (unnamed
+    message, empty ``current_agent`` / ``agent_outputs`` /
+    ``communication_log``), so audit views over checkpointed state cannot
+    attribute supersteps to agents.
+
+    This wrapper restores the same provenance synthesis that plain agent nodes
+    emit (see :func:`_generate_tool_agent_node`'s ``_agent_node`` closure) and
+    that pipeline agents emit in
+    :func:`~bili.aether.compiler.graph_builder.GraphBuilder._wrap_pipeline_as_agent_node`:
+    it takes the inner node's last non-empty message content and returns an
+    ``AIMessage`` tagged ``name=agent_id`` plus ``current_agent``,
+    ``agent_outputs[agent_id]``, and a ``communication_log`` broadcast entry.
+    """
+    from langchain_core.messages import (  # pylint: disable=import-error,import-outside-toplevel
+        AIMessage,
+    )
+
+    agent_id = agent.agent_id
+
+    def _agent_node(state: dict) -> dict:
+        result = inner_node(state)
+        inner_messages = result.get("messages", []) if isinstance(result, dict) else []
+
+        content = ""
+        for msg in reversed(inner_messages):
+            if getattr(msg, "content", None):
+                content = _normalise_content_value(msg.content)
+                break
+
+        output = _build_output(agent, content)
+        agent_outputs = dict(state.get("agent_outputs") or {})
+        agent_outputs[agent_id] = output
+
+        state_update: Dict[str, Any] = {
+            "messages": [AIMessage(content=content, name=agent_id)],
+            "current_agent": agent_id,
+            "agent_outputs": agent_outputs,
+        }
+
+        if agent.is_supervisor:
+            state_update["next_agent"] = _extract_next_agent(content, agent)
+
+        state_update.update(_build_communication_update(state, agent_id, content))
+        return state_update
+
+    _agent_node.agent_spec = agent  # type: ignore[attr-defined]
+    _agent_node.__name__ = f"agent_{agent_id}"
+    _agent_node.__qualname__ = f"agent_{agent_id}"
 
     return _agent_node
 

--- a/bili/aether/compiler/graph_builder.py
+++ b/bili/aether/compiler/graph_builder.py
@@ -691,15 +691,36 @@ class GraphBuilder:  # pylint: disable=too-few-public-methods,too-many-instance-
 
         Creates a function that:
 
-        1. Maps outer MAS state → inner pipeline state (messages only)
-        2. Invokes the compiled sub-graph
-        3. Maps inner result → outer state update (explicit output mapping:
-           only ``messages`` and ``agent_outputs`` flow back)
-        4. Handles errors with attribution (``agent_id: pipeline error``)
+        1. Maps outer MAS state → inner pipeline state (messages + custom fields).
+        2. Invokes the compiled sub-graph.
+        3. Synthesises the full outer-state update at the outer-graph boundary:
 
-        This explicit output mapping prevents the "blind merge" danger
-        that Monica identified — inner pipeline state does NOT overwrite
-        arbitrary outer MAS state fields.
+           - ``messages``: a single ``AIMessage`` tagged ``name=agent_id``,
+             using the last non-empty content from the inner pipeline.  The
+             inner pipeline may emit unnamed messages (e.g. IRIS react nodes
+             that have no knowledge of AETHER provenance) — this synthesis
+             ensures the outer state always carries a named message for this
+             agent regardless.
+
+           - ``current_agent``: set to ``agent_id`` from the closure.
+
+           - ``agent_outputs[agent_id]``: built from the outer state plus a
+             new entry describing the completed pipeline.
+
+           - ``communication_log``: a single broadcast entry via
+             :func:`_build_pipeline_provenance`, matching what plain agent
+             nodes emit.
+
+           - Custom ``state_fields`` declared in the pipeline spec are
+             propagated from the inner result to the outer state.
+
+        4. Handles errors with the same provenance attribution.
+
+        The inner pipeline's own ``current_agent``, ``agent_outputs``, and
+        ``messages`` values are NOT blindly merged into the outer MAS state —
+        only the synthesized summary above reaches the outer graph.  This
+        prevents inner-pipeline internals (intermediate agent IDs, tool-call
+        messages, etc.) from corrupting the MAS-level provenance record.
         """
         from langchain_core.messages import (  # pylint: disable=import-error,import-outside-toplevel
             AIMessage,

--- a/bili/aether/tests/test_mcp_agent_provenance.py
+++ b/bili/aether/tests/test_mcp_agent_provenance.py
@@ -1,0 +1,454 @@
+"""Regression tests: MCP/CLI agent provenance synthesis at the AETHER boundary.
+
+Real MCP-path agents (``tool_strategy="mcp"``) delegate execution to an IRIS
+MCP node built by ``bili.iris.mcp.server.build_mcp_node``.  That node is
+intentionally generic: it returns only ``{"messages": [AIMessage(content=...)]}``
+with no ``name``, no ``current_agent``, no ``agent_outputs``, and no
+``communication_log``.
+
+Before this fix, ``_generate_tool_agent_node`` returned ``build_mcp_node(...)``
+raw, leaving outer MAS checkpoints with zero provenance: unnamed messages, empty
+``current_agent`` / ``agent_outputs`` / ``communication_log``.  Audit views over
+those checkpoints could not attribute any superstep to an agent.
+
+The fix (``_wrap_mcp_node_with_provenance`` in
+``bili/aether/compiler/agent_generator.py``): wrap the MCP node at the AETHER
+boundary, synthesising the same provenance that the native ``_agent_node``
+closure and ``_wrap_pipeline_as_agent_node`` produce:
+
+- ``AIMessage(content=<inner content>, name=agent_id)``
+- ``current_agent = agent_id``
+- ``agent_outputs[agent_id] = <output dict>``
+- ``communication_log`` delta with one broadcast entry
+
+The MCP node in ``bili.iris.mcp.server`` remains unmodified — the synthesis
+happens entirely at the AETHER boundary, in the wrapper returned by
+``_generate_tool_agent_node``.
+
+These tests confirm the synthesis behaviour and are designed to fail against the
+pre-fix codebase (where ``build_mcp_node(...)`` was returned raw) and pass after.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from unittest.mock import MagicMock, patch
+
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.checkpoint.memory import MemorySaver
+
+from bili.aether.compiler import compile_mas
+from bili.aether.compiler.agent_generator import _wrap_mcp_node_with_provenance
+from bili.aether.runtime.audit import audit_view
+from bili.aether.schema import AgentSpec, MASConfig, WorkflowType
+
+# ---------------------------------------------------------------------------
+# Fake MCP inner node factory — mimics what build_mcp_node returns
+# ---------------------------------------------------------------------------
+
+_MCP_INNER_CONTENT = "mcp cli result (no name, no provenance)"
+
+
+def _build_fake_mcp_inner():
+    """Return a callable that emits only an unnamed AIMessage.
+
+    Matches the exact return signature of
+    ``bili.iris.mcp.server.build_mcp_node._node``:
+    ``{"messages": [AIMessage(content=content)]}`` with ``name=None``.
+    """
+
+    def _fake_mcp_node(state: dict) -> dict:  # pylint: disable=unused-argument
+        return {"messages": [AIMessage(content=_MCP_INNER_CONTENT)]}
+
+    return _fake_mcp_node
+
+
+# ---------------------------------------------------------------------------
+# MAS config + patched compile_mas runner
+# ---------------------------------------------------------------------------
+
+
+def _make_config(mas_id: str = "mcp_prov") -> MASConfig:
+    """Sequential MAS: one plain (stub) agent followed by one MCP-strategy agent."""
+    return MASConfig(
+        mas_id=mas_id,
+        name="MCP Provenance Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[
+            AgentSpec(
+                agent_id="plain_agent",
+                role="worker",
+                objective="Run a plain agent task before the MCP agent",
+            ),
+            AgentSpec(
+                agent_id="mcp_agent",
+                role="worker",
+                objective="Run via MCP tool-calling strategy",
+                model_name="cli_claude_code",
+                tools=["mock_tool"],
+            ),
+        ],
+        checkpoint_enabled=True,
+        checkpoint_config={"type": "memory"},
+    )
+
+
+def _run_with_fake_mcp(mas_id: str = "mcp_prov", thread_id: str = "mcp-001"):
+    """Compile and run with LLM/MCP internals patched to use fake responses.
+
+    Patches five call sites so no real CLI, LLM, or tool resolution occurs:
+
+    - ``create_llm``            — returns a MagicMock (fake CliLLM)
+    - ``resolve_tools``         — returns a non-empty list of MagicMock tools
+    - ``resolve_tool_strategy`` — returns ``"mcp"`` (forces the MCP branch)
+    - ``resolve_mcp_injector``  — returns a MagicMock (non-None triggers MCP path)
+    - ``build_mcp_node``        — returns the fake inner node callable
+
+    After patching, ``_generate_tool_agent_node`` takes the MCP branch:
+
+        mcp_node = build_mcp_node(...)   # returns _build_fake_mcp_inner()
+        return _wrap_mcp_node_with_provenance(mcp_node, agent)
+
+    The graph is then compiled and invoked so that the outer checkpoint state
+    can be inspected for provenance fields.
+    """
+    fake_llm = MagicMock()
+    fake_llm.command = ["claude"]
+    fake_tool = MagicMock()
+    fake_tool.name = "mock_tool"
+    fake_injector = MagicMock()
+
+    with (
+        patch(
+            "bili.aether.compiler.llm_resolver.create_llm",
+            return_value=fake_llm,
+        ),
+        patch(
+            "bili.aether.compiler.llm_resolver.resolve_tools",
+            return_value=[fake_tool],
+        ),
+        patch(
+            "bili.aether.compiler.llm_resolver.resolve_tool_strategy",
+            return_value="mcp",
+        ),
+        patch(
+            "bili.iris.mcp.server.resolve_mcp_injector",
+            return_value=fake_injector,
+        ),
+        patch(
+            "bili.iris.mcp.server.build_mcp_node",
+            return_value=_build_fake_mcp_inner(),
+        ),
+    ):
+        config = _make_config(mas_id)
+        compiled = compile_mas(config)
+        checkpointer = MemorySaver()
+        graph = compiled.compile_graph(checkpointer=checkpointer)
+        result = graph.invoke(
+            {"messages": [HumanMessage(content="start")]},
+            config={"configurable": {"thread_id": thread_id}},
+        )
+
+    return checkpointer, result
+
+
+def _outer_checkpoints(checkpointer, thread_id: str):
+    """Return outer checkpoint channel_values dicts in chronological order."""
+    cfg = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+    tuples = list(checkpointer.list(cfg))
+    return [t.checkpoint["channel_values"] for t in reversed(tuples)]
+
+
+# ---------------------------------------------------------------------------
+# Confirm the fake MCP inner node matches the real build_mcp_node profile
+# ---------------------------------------------------------------------------
+
+
+class TestFakeMcpInnerNodeProperties:
+    """The fake MCP inner node is truly provenance-free, matching the real node."""
+
+    def test_inner_node_emits_unnamed_message(self):
+        node = _build_fake_mcp_inner()
+        result = node({"messages": []})
+        ai_msgs = [
+            m for m in result.get("messages", []) if m.__class__.__name__ == "AIMessage"
+        ]
+        assert ai_msgs, "Fake MCP node must emit at least one AIMessage"
+        assert all(m.name is None for m in ai_msgs), (
+            f"Fake MCP node messages must be unnamed. "
+            f"names={[m.name for m in ai_msgs]}"
+        )
+
+    def test_inner_node_returns_no_current_agent(self):
+        node = _build_fake_mcp_inner()
+        result = node({"messages": []})
+        assert "current_agent" not in result
+
+    def test_inner_node_returns_no_agent_outputs(self):
+        node = _build_fake_mcp_inner()
+        result = node({"messages": []})
+        assert "agent_outputs" not in result
+
+    def test_inner_node_returns_no_communication_log(self):
+        node = _build_fake_mcp_inner()
+        result = node({"messages": []})
+        assert "communication_log" not in result
+
+
+# ---------------------------------------------------------------------------
+# Provenance synthesis at the outer MAS boundary (compile_mas integration)
+# ---------------------------------------------------------------------------
+
+
+class TestMcpAgentProvenanceThroughCompileMas:
+    """Outer MAS checkpoints carry correct provenance for MCP-strategy agents.
+
+    These are the canonical regression tests for the MCP provenance fix: they
+    compile a real MAS through ``compile_mas``, run it with a MemorySaver
+    checkpointer, and inspect the checkpointed state.
+
+    They are designed to fail against the pre-fix codebase (where
+    ``build_mcp_node(...)`` was returned raw without a provenance wrapper) and
+    pass after the fix.
+    """
+
+    def test_current_agent_set_in_final_state(self):
+        _, result = _run_with_fake_mcp()
+        assert (
+            result.get("current_agent") == "mcp_agent"
+        ), f"Expected current_agent='mcp_agent', got {result.get('current_agent')!r}"
+
+    def test_current_agent_set_in_outer_checkpoint(self):
+        checkpointer, _ = _run_with_fake_mcp(thread_id="mcp-ckpt-001")
+        cvs = _outer_checkpoints(checkpointer, "mcp-ckpt-001")
+        mcp_cvs = [cv for cv in cvs if cv.get("current_agent") == "mcp_agent"]
+        assert mcp_cvs, "No outer checkpoint with current_agent='mcp_agent'"
+
+    def test_agent_outputs_keyed_by_mcp_agent_in_final_state(self):
+        _, result = _run_with_fake_mcp(thread_id="mcp-out-001")
+        agent_outputs = result.get("agent_outputs", {})
+        assert (
+            "mcp_agent" in agent_outputs
+        ), f"mcp_agent missing from agent_outputs. keys={list(agent_outputs.keys())}"
+        assert agent_outputs["mcp_agent"].get("status") == "completed"
+
+    def test_agent_outputs_keyed_in_outer_checkpoint(self):
+        checkpointer, _ = _run_with_fake_mcp(thread_id="mcp-out-ckpt-001")
+        cvs = _outer_checkpoints(checkpointer, "mcp-out-ckpt-001")
+        final_cv = cvs[-1]
+        assert "mcp_agent" in final_cv.get(
+            "agent_outputs", {}
+        ), "mcp_agent missing from agent_outputs in final outer checkpoint"
+
+    def test_message_name_set_to_mcp_agent(self):
+        """AIMessage in the outer state carries name=mcp_agent.
+
+        Before the fix, ``build_mcp_node`` was returned raw — its inner node
+        emits ``AIMessage(name=None)``, which propagated unchanged to the outer
+        MAS state, making it impossible to attribute the message to an agent.
+        """
+        _, result = _run_with_fake_mcp(thread_id="mcp-name-001")
+        ai_msgs = [
+            m for m in result.get("messages", []) if m.__class__.__name__ == "AIMessage"
+        ]
+        named = [m for m in ai_msgs if m.name == "mcp_agent"]
+        assert named, (
+            f"No AIMessage with name='mcp_agent'. "
+            f"AI msg names: {[m.name for m in ai_msgs]}"
+        )
+
+    def test_message_name_set_in_outer_checkpoint(self):
+        checkpointer, _ = _run_with_fake_mcp(thread_id="mcp-name-ckpt-001")
+        cvs = _outer_checkpoints(checkpointer, "mcp-name-ckpt-001")
+        final_cv = cvs[-1]
+        ai_msgs = [
+            m
+            for m in final_cv.get("messages", [])
+            if m.__class__.__name__ == "AIMessage"
+        ]
+        named = [m for m in ai_msgs if m.name == "mcp_agent"]
+        assert named, (
+            f"No outer-checkpoint AIMessage with name='mcp_agent'. "
+            f"names={[m.name for m in ai_msgs]}"
+        )
+
+    def test_communication_log_has_mcp_agent_entry(self):
+        """communication_log carries a broadcast entry for the MCP agent.
+
+        Before the fix, ``build_mcp_node`` was returned raw — its inner node
+        produces no ``communication_log`` entry, so the outer MAS state had no
+        provenance trace of the MCP agent's execution.
+        """
+        _, result = _run_with_fake_mcp(thread_id="mcp-log-001")
+        comm_log = result.get("communication_log", [])
+        assert comm_log, "communication_log must not be empty"
+        senders = {e["sender"] for e in comm_log}
+        assert (
+            "mcp_agent" in senders
+        ), f"mcp_agent missing from communication_log senders. senders={senders}"
+
+    def test_communication_log_in_outer_checkpoint(self):
+        checkpointer, _ = _run_with_fake_mcp(thread_id="mcp-log-ckpt-001")
+        cvs = _outer_checkpoints(checkpointer, "mcp-log-ckpt-001")
+        mcp_cvs = [cv for cv in cvs if cv.get("current_agent") == "mcp_agent"]
+        assert mcp_cvs, "No outer checkpoint for mcp_agent"
+        mcp_cv = mcp_cvs[-1]
+        log = mcp_cv.get("communication_log", [])
+        assert any(e["sender"] == "mcp_agent" for e in log), (
+            f"mcp_agent missing from communication_log in outer checkpoint. "
+            f"senders={[e['sender'] for e in log]}"
+        )
+
+    def test_no_duplicate_communication_log_entries(self):
+        _, result = _run_with_fake_mcp(thread_id="mcp-dedup-001")
+        comm_log = result.get("communication_log", [])
+        # 2 agents = exactly 2 entries (plain stub + mcp)
+        assert (
+            len(comm_log) == 2
+        ), f"Expected 2 comm_log entries (one per agent), got {len(comm_log)}"
+        ids = [e.get("message_id") for e in comm_log]
+        assert len(set(ids)) == 2, f"Duplicate message IDs in comm_log: {ids}"
+
+    def test_both_agents_in_final_state(self):
+        _, result = _run_with_fake_mcp(thread_id="mcp-both-001")
+        agent_outputs = result.get("agent_outputs", {})
+        assert "plain_agent" in agent_outputs
+        assert "mcp_agent" in agent_outputs
+        assert result.get("current_agent") == "mcp_agent"
+
+    def test_inner_content_reaches_outer_summary(self):
+        """The outer agent_outputs.message field contains the MCP node's content."""
+        _, result = _run_with_fake_mcp(thread_id="mcp-content-001")
+        mcp_output = result.get("agent_outputs", {}).get("mcp_agent", {})
+        assert _MCP_INNER_CONTENT in mcp_output.get("message", ""), (
+            f"Expected MCP content in outer agent_output.message. "
+            f"Got: {mcp_output.get('message')!r}"
+        )
+
+    def test_audit_view_includes_mcp_agent(self):
+        checkpointer, _ = _run_with_fake_mcp(
+            mas_id="mcp_audit", thread_id="mcp-audit-001"
+        )
+        timeline = audit_view(checkpointer, "mcp-audit-001")
+        agent_ids = [e["agent_id"] for e in timeline]
+        assert (
+            "mcp_agent" in agent_ids
+        ), f"mcp_agent missing from audit timeline. agent_ids={agent_ids}"
+        mcp_entries = [e for e in timeline if e["agent_id"] == "mcp_agent"]
+        assert len(mcp_entries) == 1
+        assert len(mcp_entries[0]["messages_sent"]) == 1
+        assert mcp_entries[0]["messages_sent"][0]["sender"] == "mcp_agent"
+
+
+# ---------------------------------------------------------------------------
+# Direct wrapper unit tests (_wrap_mcp_node_with_provenance)
+# ---------------------------------------------------------------------------
+
+
+class TestWrapMcpNodeDirectly:
+    """Call ``_wrap_mcp_node_with_provenance`` directly to pin synthesis at the boundary.
+
+    These tests bypass ``compile_mas`` and ``_generate_tool_agent_node`` to
+    verify the wrapper function in isolation.  They confirm the synthesis
+    happens at the wrapper boundary, not inside the MCP inner node.
+    """
+
+    def _make_agent(self, agent_id: str = "direct_mcp") -> AgentSpec:
+        return AgentSpec(
+            agent_id=agent_id,
+            role="worker",
+            objective="Direct MCP wrapper test agent",
+        )
+
+    def _base_state(self) -> dict:
+        return {
+            "messages": [HumanMessage(content="start")],
+            "agent_outputs": {},
+            "communication_log": [],
+        }
+
+    def test_wrapper_synthesises_current_agent_from_closure(self):
+        agent = self._make_agent()
+        wrapper = _wrap_mcp_node_with_provenance(_build_fake_mcp_inner(), agent)
+        result = wrapper(self._base_state())
+        assert result["current_agent"] == "direct_mcp"
+
+    def test_wrapper_sets_agent_outputs_entry(self):
+        agent = self._make_agent()
+        wrapper = _wrap_mcp_node_with_provenance(_build_fake_mcp_inner(), agent)
+        result = wrapper(self._base_state())
+        assert "direct_mcp" in result["agent_outputs"]
+        assert result["agent_outputs"]["direct_mcp"]["status"] == "completed"
+
+    def test_wrapper_emits_named_ai_message(self):
+        agent = self._make_agent()
+        wrapper = _wrap_mcp_node_with_provenance(_build_fake_mcp_inner(), agent)
+        result = wrapper(self._base_state())
+        ai_msgs = [m for m in result["messages"] if m.__class__.__name__ == "AIMessage"]
+        assert ai_msgs, "Wrapper must emit at least one AIMessage"
+        assert all(m.name == "direct_mcp" for m in ai_msgs), (
+            f"All AIMessages must have name='direct_mcp'. "
+            f"Got: {[m.name for m in ai_msgs]}"
+        )
+
+    def test_wrapper_emits_communication_log_delta(self):
+        agent = self._make_agent()
+        wrapper = _wrap_mcp_node_with_provenance(_build_fake_mcp_inner(), agent)
+        result = wrapper(self._base_state())
+        delta = result.get("communication_log", [])
+        assert (
+            len(delta) == 1
+        ), f"Wrapper must return single-entry delta for operator.add. Got {len(delta)}"
+        assert delta[0]["sender"] == "direct_mcp"
+
+    def test_wrapper_uses_inner_content_for_output_summary(self):
+        agent = self._make_agent()
+        wrapper = _wrap_mcp_node_with_provenance(_build_fake_mcp_inner(), agent)
+        result = wrapper(self._base_state())
+        output_msg = result["agent_outputs"]["direct_mcp"].get("message", "")
+        assert (
+            _MCP_INNER_CONTENT in output_msg
+        ), f"Expected MCP inner content in summary. Got: {output_msg!r}"
+
+    def test_wrapper_preserves_existing_agent_outputs(self):
+        """Existing agent_outputs entries from prior agents are not clobbered."""
+        agent = self._make_agent()
+        wrapper = _wrap_mcp_node_with_provenance(_build_fake_mcp_inner(), agent)
+        state = {
+            "messages": [HumanMessage(content="start")],
+            "agent_outputs": {
+                "prior_agent": {"status": "completed", "message": "prior result"}
+            },
+            "communication_log": [],
+        }
+        result = wrapper(state)
+        assert "prior_agent" in result["agent_outputs"]
+        assert "direct_mcp" in result["agent_outputs"]
+
+    def test_wrapper_handles_empty_inner_messages(self):
+        """Wrapper degrades gracefully when inner node returns no messages."""
+
+        def _empty_inner(state: dict) -> dict:  # pylint: disable=unused-argument
+            return {"messages": []}
+
+        agent = self._make_agent()
+        wrapper = _wrap_mcp_node_with_provenance(_empty_inner, agent)
+        result = wrapper(self._base_state())
+        # Provenance is still synthesised from the closure
+        assert result["current_agent"] == "direct_mcp"
+        assert "direct_mcp" in result["agent_outputs"]
+        # Content is empty string (no message to extract)
+        ai_msgs = [m for m in result["messages"] if m.__class__.__name__ == "AIMessage"]
+        assert ai_msgs[0].name == "direct_mcp"
+        assert ai_msgs[0].content == ""
+
+    def test_wrapper_function_name_set_for_introspection(self):
+        agent = self._make_agent()
+        wrapper = _wrap_mcp_node_with_provenance(_build_fake_mcp_inner(), agent)
+        assert wrapper.__name__ == "agent_direct_mcp"
+        assert wrapper.__qualname__ == "agent_direct_mcp"
+
+    def test_wrapper_agent_spec_attribute_set(self):
+        agent = self._make_agent()
+        wrapper = _wrap_mcp_node_with_provenance(_build_fake_mcp_inner(), agent)
+        assert hasattr(wrapper, "agent_spec")
+        assert wrapper.agent_spec is agent

--- a/bili/aether/tests/test_pipeline_iris_provenance.py
+++ b/bili/aether/tests/test_pipeline_iris_provenance.py
@@ -1,0 +1,487 @@
+"""Regression tests: pipeline-agent provenance when the inner graph mimics an IRIS
+node that emits UNNAMED AIMessages and sets NEITHER current_agent NOR agent_outputs.
+
+Real AETHER deployments commonly use agents whose ``pipeline`` field contains
+an IRIS registry node (e.g. ``react_agent``, ``add_persona_and_summary``).
+Those nodes have no knowledge of AETHER provenance — they emit raw
+``AIMessage`` objects with ``name=None`` and do not write ``current_agent`` or
+``agent_outputs`` to the inner state.
+
+The bug path (fixed by #224 + #225):
+
+- Bug A (#224): ``communication_log`` absent from the state schema for MAS
+  configs without explicit channels, so pipeline-agent provenance was never
+  checkpointed.
+- Bug B (#224): ``send_message_in_state`` returned the full accumulated log,
+  causing exponential duplication.
+- Bug C (#225): ``_wrap_pipeline_as_agent_node`` never called
+  ``_build_communication_update``, so pipeline agents emitted no
+  ``communication_log`` entry to the outer MAS state.
+
+The fix: ``_wrap_pipeline_as_agent_node`` now SYNTHESISES all provenance fields
+(``current_agent``, ``agent_outputs``, named ``AIMessage``, ``communication_log``)
+at the outer-graph boundary from the agent's closure variables, independent of
+whether the inner pipeline set any of those fields.
+
+These tests confirm the synthesized-at-boundary behaviour holds for an inner
+graph that matches the IRIS react-node profile (unnamed messages, no provenance
+state changes).  They are designed to fail on the pre-#224/#225 codebase and
+pass on the fixed one.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from typing import Annotated, Any, Dict
+
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.constants import END, START
+from langgraph.graph import StateGraph, add_messages
+from typing_extensions import TypedDict
+
+from bili.aether.compiler import compile_mas
+from bili.aether.compiler.graph_builder import GraphBuilder
+from bili.aether.compiler.state_generator import _merge_dicts, _replace_value
+from bili.aether.runtime.audit import audit_view
+from bili.aether.schema import AgentSpec, MASConfig, WorkflowType
+from bili.aether.schema.pipeline_spec import (
+    PipelineEdgeSpec,
+    PipelineNodeSpec,
+    PipelineSpec,
+)
+
+# ---------------------------------------------------------------------------
+# Inner graph factory — mimics an IRIS react node
+# ---------------------------------------------------------------------------
+
+
+class _IRISInnerState(TypedDict):
+    """Minimal inner state, matching the AETHER pipeline inner schema."""
+
+    messages: Annotated[list, add_messages]
+    current_agent: Annotated[str, _replace_value]
+    agent_outputs: Annotated[Dict[str, Any], _merge_dicts]
+
+
+def _build_iris_like_inner_graph():
+    """Build a compiled inner graph that behaves like an IRIS react node.
+
+    The node:
+    - Emits an ``AIMessage`` with **no name** (``name=None``).
+    - Does **not** write ``current_agent`` or ``agent_outputs`` to the state.
+
+    This is the exact profile of bili-core's IRIS react nodes, which have no
+    knowledge of AETHER provenance.  The test confirms that the outer
+    ``_wrap_pipeline_as_agent_node`` synthesises correct provenance regardless.
+    """
+
+    def _iris_like_node(state: dict) -> dict:
+        # Emit an unnamed message only — no provenance fields.
+        return {
+            "messages": [
+                AIMessage(content="IRIS inner response (no name, no provenance)")
+            ]
+        }
+
+    g = StateGraph(_IRISInnerState)
+    g.add_node("iris_like", _iris_like_node)
+    g.add_edge(START, "iris_like")
+    g.add_edge("iris_like", END)
+    return g.compile(checkpointer=None)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build MAS config + inject the IRIS-like inner graph
+# ---------------------------------------------------------------------------
+
+
+def _pipeline_spec_placeholder() -> PipelineSpec:
+    """A single-node pipeline spec used only as a marker (inner graph replaced)."""
+    return PipelineSpec(
+        nodes=[
+            PipelineNodeSpec(
+                node_id="step",
+                node_type="agent",
+                agent_spec={
+                    "agent_id": "inner_placeholder",
+                    "role": "inner_worker",
+                    "objective": "Placeholder inner agent for injection",
+                },
+            )
+        ],
+        edges=[PipelineEdgeSpec(from_node="step", to_node="END")],
+    )
+
+
+def _make_config(mas_id: str = "iris_prov") -> MASConfig:
+    """Sequential MAS with one plain agent + one pipeline agent."""
+    return MASConfig(
+        mas_id=mas_id,
+        name="IRIS Pipeline Provenance Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[
+            AgentSpec(
+                agent_id="plain_agent",
+                role="worker",
+                objective="Run a plain agent task before the pipeline agent",
+            ),
+            AgentSpec(
+                agent_id="pipe_agent",
+                role="worker",
+                objective="Run a pipeline agent backed by an IRIS-like inner graph",
+                pipeline=_pipeline_spec_placeholder(),
+            ),
+        ],
+        checkpoint_enabled=True,
+        checkpoint_config={"type": "memory"},
+    )
+
+
+def _run_with_iris_inner(mas_id: str = "iris_prov", thread_id: str = "iris-001"):
+    """Compile and run the MAS with the IRIS-like inner graph injected.
+
+    Patches ``_compile_pipeline_node`` to substitute the placeholder pipeline
+    with the IRIS-like compiled inner graph so that the inner graph truly
+    emits unnamed messages with no provenance fields.
+    """
+    iris_inner = _build_iris_like_inner_graph()
+    original_compile = GraphBuilder._compile_pipeline_node
+
+    def patched_compile(self, agent):
+        if agent.agent_id == "pipe_agent":
+            return self._wrap_pipeline_as_agent_node(iris_inner, agent)
+        return original_compile(self, agent)
+
+    GraphBuilder._compile_pipeline_node = patched_compile
+    try:
+        config = _make_config(mas_id)
+        compiled = compile_mas(config)
+        checkpointer = MemorySaver()
+        graph = compiled.compile_graph(checkpointer=checkpointer)
+        result = graph.invoke(
+            {"messages": [HumanMessage(content="start")]},
+            config={"configurable": {"thread_id": thread_id}},
+        )
+        return checkpointer, result
+    finally:
+        GraphBuilder._compile_pipeline_node = original_compile
+
+
+def _outer_checkpoints(checkpointer, thread_id: str):
+    """Return outer checkpoint channel_values dicts in chronological order."""
+    cfg = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+    tuples = list(checkpointer.list(cfg))
+    return [t.checkpoint["channel_values"] for t in reversed(tuples)]
+
+
+# ---------------------------------------------------------------------------
+# Confirm the inner graph is truly IRIS-like (no provenance)
+# ---------------------------------------------------------------------------
+
+
+class TestIRISLikeInnerGraphProperties:
+    """Confirm the inner graph produces unnamed messages and no provenance."""
+
+    def test_inner_messages_are_unnamed(self):
+        iris_inner = _build_iris_like_inner_graph()
+        inner_result = iris_inner.invoke(
+            {
+                "messages": [HumanMessage(content="start")],
+                "current_agent": "",
+                "agent_outputs": {},
+            }
+        )
+        ai_msgs = [
+            m for m in inner_result["messages"] if m.__class__.__name__ == "AIMessage"
+        ]
+        assert ai_msgs, "Inner graph must emit at least one AIMessage"
+        assert all(
+            m.name is None for m in ai_msgs
+        ), f"Inner AIMessages must be unnamed. Got names: {[m.name for m in ai_msgs]}"
+
+    def test_inner_graph_does_not_set_agent_outputs(self):
+        iris_inner = _build_iris_like_inner_graph()
+        inner_result = iris_inner.invoke(
+            {
+                "messages": [HumanMessage(content="start")],
+                "current_agent": "",
+                "agent_outputs": {},
+            }
+        )
+        # agent_outputs must remain as-initialised ({}); the node does not write it.
+        assert (
+            inner_result.get("agent_outputs") == {}
+        ), "Inner graph must not set agent_outputs"
+
+
+# ---------------------------------------------------------------------------
+# Provenance synthesis at the outer-graph boundary
+# ---------------------------------------------------------------------------
+
+
+class TestOuterProvenanceSynthesisFromIRISInner:
+    """Outer MAS state carries correct provenance even when inner graph is IRIS-like.
+
+    These tests are the canonical regression for the fix introduced in
+    #224 + #225: the outer boundary synthesises provenance from the agent_id
+    closure, not from what the inner graph wrote.
+    """
+
+    def test_current_agent_set_in_outer_final_state(self):
+        _, result = _run_with_iris_inner()
+        assert (
+            result.get("current_agent") == "pipe_agent"
+        ), f"Expected current_agent='pipe_agent', got {result.get('current_agent')!r}"
+
+    def test_current_agent_set_in_outer_checkpoint(self):
+        checkpointer, _ = _run_with_iris_inner()
+        cvs = _outer_checkpoints(checkpointer, "iris-001")
+        pipe_cvs = [cv for cv in cvs if cv.get("current_agent") == "pipe_agent"]
+        assert pipe_cvs, "No outer checkpoint with current_agent='pipe_agent'"
+
+    def test_agent_outputs_keyed_by_pipe_agent_in_final_state(self):
+        _, result = _run_with_iris_inner()
+        agent_outputs = result.get("agent_outputs", {})
+        assert (
+            "pipe_agent" in agent_outputs
+        ), f"pipe_agent missing from agent_outputs. keys={list(agent_outputs.keys())}"
+        assert agent_outputs["pipe_agent"].get("status") == "completed"
+
+    def test_agent_outputs_keyed_in_outer_checkpoint(self):
+        checkpointer, _ = _run_with_iris_inner()
+        cvs = _outer_checkpoints(checkpointer, "iris-001")
+        final_cv = cvs[-1]
+        assert "pipe_agent" in final_cv.get(
+            "agent_outputs", {}
+        ), "pipe_agent missing from agent_outputs in outer checkpoint"
+
+    def test_message_name_set_to_pipe_agent(self):
+        """AIMessage in the outer state carries name=pipe_agent.
+
+        Before the fix, the inner IRIS-like graph's unnamed message was the
+        only message forwarded, producing name=None in the outer state.  The
+        outer wrapper now emits a fresh AIMessage(name=agent_id) regardless of
+        what the inner graph produced.
+        """
+        _, result = _run_with_iris_inner()
+        ai_msgs = [
+            m for m in result.get("messages", []) if m.__class__.__name__ == "AIMessage"
+        ]
+        pipe_msgs = [m for m in ai_msgs if m.name == "pipe_agent"]
+        assert pipe_msgs, (
+            f"No AIMessage with name='pipe_agent'. "
+            f"AI msg names: {[m.name for m in ai_msgs]}"
+        )
+
+    def test_message_name_set_in_outer_checkpoint(self):
+        checkpointer, _ = _run_with_iris_inner()
+        cvs = _outer_checkpoints(checkpointer, "iris-001")
+        final_cv = cvs[-1]
+        ai_msgs = [
+            m
+            for m in final_cv.get("messages", [])
+            if m.__class__.__name__ == "AIMessage"
+        ]
+        named_pipe = [m for m in ai_msgs if m.name == "pipe_agent"]
+        assert named_pipe, (
+            f"No outer-checkpoint AIMessage with name='pipe_agent'. "
+            f"names={[m.name for m in ai_msgs]}"
+        )
+
+    def test_communication_log_has_pipe_agent_entry(self):
+        """communication_log carries a broadcast entry for the pipeline agent.
+
+        Regression for Bug C (#225): _wrap_pipeline_as_agent_node never called
+        _build_communication_update, so pipeline agents produced no
+        communication_log entry.
+        """
+        _, result = _run_with_iris_inner()
+        comm_log = result.get("communication_log", [])
+        assert comm_log, "communication_log must not be empty"
+        senders = {e["sender"] for e in comm_log}
+        assert (
+            "pipe_agent" in senders
+        ), f"pipe_agent missing from communication_log senders. senders={senders}"
+
+    def test_communication_log_in_outer_checkpoint(self):
+        checkpointer, _ = _run_with_iris_inner()
+        cvs = _outer_checkpoints(checkpointer, "iris-001")
+        pipe_cvs = [cv for cv in cvs if cv.get("current_agent") == "pipe_agent"]
+        assert pipe_cvs, "No outer checkpoint for pipe_agent"
+        pipe_cv = pipe_cvs[-1]
+        log = pipe_cv.get("communication_log", [])
+        assert any(e["sender"] == "pipe_agent" for e in log), (
+            f"pipe_agent missing from communication_log in outer checkpoint. "
+            f"senders={[e['sender'] for e in log]}"
+        )
+
+    def test_no_duplicate_communication_log_entries(self):
+        _, result = _run_with_iris_inner()
+        comm_log = result.get("communication_log", [])
+        # 2 agents = exactly 2 entries
+        assert (
+            len(comm_log) == 2
+        ), f"Expected 2 comm_log entries (one per agent), got {len(comm_log)}"
+        ids = [e.get("message_id") for e in comm_log]
+        assert len(set(ids)) == 2, f"Duplicate message IDs: {ids}"
+
+    def test_both_agents_in_final_state(self):
+        _, result = _run_with_iris_inner()
+        agent_outputs = result.get("agent_outputs", {})
+        assert "plain_agent" in agent_outputs
+        assert "pipe_agent" in agent_outputs
+        assert result.get("current_agent") == "pipe_agent"
+
+    def test_audit_view_includes_pipe_agent(self):
+        checkpointer, _ = _run_with_iris_inner(
+            mas_id="iris_audit", thread_id="iris-audit-001"
+        )
+        timeline = audit_view(checkpointer, "iris-audit-001")
+        agent_ids = [e["agent_id"] for e in timeline]
+        assert (
+            "pipe_agent" in agent_ids
+        ), f"pipe_agent missing from audit timeline. agent_ids={agent_ids}"
+        # Each agent has exactly one provenance entry
+        pipe_entries = [e for e in timeline if e["agent_id"] == "pipe_agent"]
+        assert len(pipe_entries) == 1
+        assert len(pipe_entries[0]["messages_sent"]) == 1
+        assert pipe_entries[0]["messages_sent"][0]["sender"] == "pipe_agent"
+
+    def test_inner_content_reaches_outer_summary(self):
+        """The outer agent_outputs message field contains the inner pipeline's content."""
+        _, result = _run_with_iris_inner()
+        pipe_output = result.get("agent_outputs", {}).get("pipe_agent", {})
+        assert "IRIS inner response" in pipe_output.get("message", ""), (
+            f"Expected inner content in outer agent_output.message. "
+            f"Got: {pipe_output.get('message')!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Direct wrapper unit test (no compile_mas, pinpoints the synthesis boundary)
+# ---------------------------------------------------------------------------
+
+
+class TestWrapperSynthesisDirectly:
+    """Call _wrap_pipeline_as_agent_node directly to confirm synthesis happens
+    at the wrapper boundary, not inside the inner graph."""
+
+    def test_wrapper_synthesises_current_agent_from_closure(self):
+        iris_inner = _build_iris_like_inner_graph()
+        agent = AgentSpec(
+            agent_id="direct_pipe",
+            role="worker",
+            objective="Direct wrapper test agent",
+            pipeline=_pipeline_spec_placeholder(),
+        )
+        config = MASConfig(
+            mas_id="direct_test",
+            name="Direct Test",
+            workflow_type=WorkflowType.SEQUENTIAL,
+            agents=[agent],
+        )
+        builder = GraphBuilder(config)
+        wrapper = builder._wrap_pipeline_as_agent_node(iris_inner, agent)
+
+        outer_state = {
+            "messages": [HumanMessage(content="start")],
+            "agent_outputs": {},
+            "communication_log": [],
+        }
+        result = wrapper(outer_state)
+
+        assert result["current_agent"] == "direct_pipe"
+        assert "direct_pipe" in result["agent_outputs"]
+        assert result["agent_outputs"]["direct_pipe"]["status"] == "completed"
+
+    def test_wrapper_emits_named_ai_message(self):
+        iris_inner = _build_iris_like_inner_graph()
+        agent = AgentSpec(
+            agent_id="direct_pipe",
+            role="worker",
+            objective="Direct wrapper test agent",
+            pipeline=_pipeline_spec_placeholder(),
+        )
+        config = MASConfig(
+            mas_id="direct_test2",
+            name="Direct Test 2",
+            workflow_type=WorkflowType.SEQUENTIAL,
+            agents=[agent],
+        )
+        builder = GraphBuilder(config)
+        wrapper = builder._wrap_pipeline_as_agent_node(iris_inner, agent)
+
+        outer_state = {
+            "messages": [HumanMessage(content="start")],
+            "agent_outputs": {},
+            "communication_log": [],
+        }
+        result = wrapper(outer_state)
+
+        ai_msgs = [m for m in result["messages"] if m.__class__.__name__ == "AIMessage"]
+        assert ai_msgs, "Wrapper must emit at least one AIMessage"
+        assert all(m.name == "direct_pipe" for m in ai_msgs), (
+            f"All emitted AIMessages must have name='direct_pipe'. "
+            f"Got: {[m.name for m in ai_msgs]}"
+        )
+
+    def test_wrapper_emits_communication_log_delta(self):
+        iris_inner = _build_iris_like_inner_graph()
+        agent = AgentSpec(
+            agent_id="direct_pipe",
+            role="worker",
+            objective="Direct wrapper test agent",
+            pipeline=_pipeline_spec_placeholder(),
+        )
+        config = MASConfig(
+            mas_id="direct_test3",
+            name="Direct Test 3",
+            workflow_type=WorkflowType.SEQUENTIAL,
+            agents=[agent],
+        )
+        builder = GraphBuilder(config)
+        wrapper = builder._wrap_pipeline_as_agent_node(iris_inner, agent)
+
+        outer_state = {
+            "messages": [HumanMessage(content="start")],
+            "agent_outputs": {},
+            "communication_log": [],
+        }
+        result = wrapper(outer_state)
+
+        comm_log_delta = result.get("communication_log", [])
+        assert (
+            len(comm_log_delta) == 1
+        ), f"Wrapper must return single-entry delta. Got {len(comm_log_delta)}"
+        assert comm_log_delta[0]["sender"] == "direct_pipe"
+
+    def test_wrapper_uses_inner_content_for_output_summary(self):
+        """Outer agent_output.message captures the inner pipeline's final content."""
+        iris_inner = _build_iris_like_inner_graph()
+        agent = AgentSpec(
+            agent_id="direct_pipe",
+            role="worker",
+            objective="Direct wrapper test agent",
+            pipeline=_pipeline_spec_placeholder(),
+        )
+        config = MASConfig(
+            mas_id="direct_test4",
+            name="Direct Test 4",
+            workflow_type=WorkflowType.SEQUENTIAL,
+            agents=[agent],
+        )
+        builder = GraphBuilder(config)
+        wrapper = builder._wrap_pipeline_as_agent_node(iris_inner, agent)
+
+        outer_state = {
+            "messages": [HumanMessage(content="start")],
+            "agent_outputs": {},
+            "communication_log": [],
+        }
+        result = wrapper(outer_state)
+
+        pipe_out = result["agent_outputs"]["direct_pipe"]
+        # Content extracted from the inner graph's unnamed AIMessage
+        assert "IRIS inner response" in pipe_out.get(
+            "message", ""
+        ), f"Expected inner content in summary. Got: {pipe_out.get('message')!r}"


### PR DESCRIPTION
## Problem

A checkpointer-based audit of a multi-agent MAS run should durably record which agent produced which output at every superstep. Three provenance channels must be populated in each outer checkpoint:

- `current_agent` — the agent that acted
- `agent_outputs[agent_id]` — attributed output dict; corresponding `AIMessage.name == agent_id`
- `communication_log` — one broadcast entry per agent handoff

Three independent bugs caused blank provenance in different agent execution paths.

## Root causes and fixes

### Bug A + B (PR #224) — schema and reducer bugs

- Bug A: `communication_log` was absent from the state schema for MAS configs without explicit inter-agent channels, so it was never checkpointed.
- Bug B: `send_message_in_state` returned the full accumulated log as the state-update value. Because the `operator.add` reducer concatenates lists, each superstep appended the full prior log, producing exponential duplication (1+3+7 entries for a 3-agent run instead of 3).

**Fix:** Always include `communication_log` in the generated schema. Return only the single-entry delta from `send_message_in_state`.

### Bug C (PR #225) — pipeline agents

`_wrap_pipeline_as_agent_node` correctly synthesised `current_agent`, `agent_outputs`, and a named `AIMessage` from the closure, but never called `_build_communication_update`. Pipeline agents produced no `communication_log` entry.

**Fix:** Call `_build_pipeline_provenance` (which delegates to `_build_communication_update`) at the outer-graph boundary after the inner sub-graph returns.

### Bug D (this PR) — MCP/CLI agents

`_generate_tool_agent_node` returned `build_mcp_node(...)` raw for `tool_strategy="mcp"` agents. `build_mcp_node` is intentionally generic — it has no knowledge of AETHER `agent_id` or the MAS provenance protocol — and returns only `{"messages": [AIMessage(content=...)]}` with no `name`, no `current_agent`, no `agent_outputs`, and no `communication_log`. Any agent backed by a CLI (Claude Code, Codex, Gemini CLI) produced zero provenance in the outer checkpoints.

**Fix:** Add `_wrap_mcp_node_with_provenance(inner_node, agent)` in `agent_generator.py` and route the MCP branch through it. The wrapper calls the inner MCP node, extracts the last non-empty message content, and returns the same state update that the native `_agent_node` closure and `_wrap_pipeline_as_agent_node` produce. The MCP node in `bili.iris.mcp.server` is unchanged.

## Files changed

| File | Change |
|---|---|
| `bili/aether/compiler/state_generator.py` | Always include `communication_log` in schema (Bug A) |
| `bili/aether/runtime/executor.py` | Always initialise `communication_log` (Bug A) |
| `bili/aether/runtime/communication_state.py` | Return single-entry delta from `send_message_in_state` (Bug B) |
| `bili/aether/compiler/agent_generator.py` | Remove early-exit guard in `_build_communication_update` (Bug C); add `_wrap_mcp_node_with_provenance` (Bug D) |
| `bili/aether/compiler/graph_builder.py` | Add `_build_pipeline_provenance` call in `_wrap_pipeline_as_agent_node` (Bug C) |
| `bili/aether/runtime/audit.py` | Filter seed checkpoints; improve `acting_agent` extraction |

## Tests

| File | Tests | Covers |
|---|---|---|
| `test_provenance.py` | 35 | Bugs A + B + C (native and pipeline paths via `compile_mas`) |
| `test_pipeline_iris_provenance.py` | 18 | Bug C: pipeline agent backed by IRIS-like inner graph (unnamed messages, no provenance) |
| `test_mcp_agent_provenance.py` | 25 | Bug D: MCP/CLI agent via `compile_mas` with patched internals; `_wrap_mcp_node_with_provenance` unit tests |

All 78 new provenance tests pass. Overall suite: 4081 passed (plus 25 new = 4106 total for the provenance test files), pylint 9.87/10 on modified source, coverage gate passes at 98.4%.

## MCP-path test loop-breaker

`TestMcpAgentProvenanceThroughCompileMas` patches five call sites so no real CLI or LLM is invoked: `create_llm`, `resolve_tools`, `resolve_tool_strategy` (→ `"mcp"`), `resolve_mcp_injector` (→ non-None), `build_mcp_node` (→ fake inner node that emits `AIMessage(name=None)` only). The graph is then compiled via `compile_mas` and invoked; outer checkpoint state is inspected. These tests fail against the pre-fix codebase (where `build_mcp_node(...)` was returned raw) and pass after.