### PR TITLE
feat: make CLI subprocess working directory configurable (default: inherited)

### DIFF
--- a/bili/aether/compiler/llm_resolver.py
+++ b/bili/aether/compiler/llm_resolver.py
@@ -214,6 +214,11 @@ def create_llm(agent: AgentSpec) -> Any:
         raw = agent.cli_subprocess_timeout
         kwargs["timeout_seconds"] = None if raw == 0.0 else raw
 
+    # Forward cli_subprocess_cwd to CLI providers only, for the same reason
+    # as cli_subprocess_timeout above.
+    if agent.cli_subprocess_cwd is not None and provider.startswith("cli"):
+        kwargs["cwd"] = agent.cli_subprocess_cwd
+
     LOGGER.info(
         "Creating LLM for agent '%s': provider=%s, model_id=%s",
         agent.agent_id,

--- a/bili/aether/schema/agent_spec.py
+++ b/bili/aether/schema/agent_spec.py
@@ -134,6 +134,24 @@ class AgentSpec(BaseModel):
         ),
     )
 
+    cli_subprocess_cwd: Optional[str] = Field(
+        None,
+        description=(
+            "Working directory for CLI-backed providers' subprocess (provider "
+            "types 'cli', 'cli_claude_code', 'cli_codex', 'cli_gemini_cli', "
+            "and any custom CLI preset).  When set, overrides the preset "
+            "default and pins the subprocess to this fixed directory instead "
+            "of inheriting the calling process's current working directory. "
+            "Useful for CLI tools that gate filesystem access per directory "
+            "(a one-time trust decision for a known directory rather than one "
+            "triggered by every caller cwd) or to scope the tool's filesystem "
+            "reach to a dedicated directory.  Leave unset (the default) to "
+            "preserve historical behaviour.  Only applies to agents whose "
+            "resolved provider is a CLI subprocess type; ignored for API "
+            "providers."
+        ),
+    )
+
     # =========================================================================
     # CAPABILITIES & TOOLS
     # =========================================================================

--- a/bili/aether/tests/test_compiler_coverage.py
+++ b/bili/aether/tests/test_compiler_coverage.py
@@ -350,6 +350,73 @@ class TestCreateLlm:
         # timeout_seconds not injected; the CLI provider will use its preset default
         assert "timeout_seconds" not in kwargs
 
+    def test_create_llm_cli_subprocess_cwd_forwarded(self):
+        """cli_subprocess_cwd is forwarded to load_model for CLI providers."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        agent = _agent(
+            "cli_agent_cwd",
+            model_name="cli:my-tool",
+            cli_subprocess_cwd="/fixed/workspace",
+        )
+
+        fake_load_model = MagicMock(return_value="CLI_LLM")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert kwargs["cwd"] == "/fixed/workspace"
+
+    def test_create_llm_cli_cwd_not_forwarded_to_api_provider(self):
+        """cli_subprocess_cwd is NOT forwarded when the provider is not a CLI type."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        # gpt-4o resolves to "remote_openai", not a CLI provider
+        agent = _agent(
+            "api_agent_cwd", model_name="gpt-4o", cli_subprocess_cwd="/fixed/workspace"
+        )
+
+        fake_load_model = MagicMock(return_value="API_LLM")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert "cwd" not in kwargs
+
+    def test_create_llm_cli_cwd_none_not_forwarded(self):
+        """When cli_subprocess_cwd is None (default), cwd is not added -- the
+        CLI provider preserves its historical default of inheriting the
+        calling process's current working directory."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        agent = _agent("cli_default_cwd", model_name="cli:my-tool")
+        # cli_subprocess_cwd defaults to None
+
+        fake_load_model = MagicMock(return_value="CLI_LLM")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert "cwd" not in kwargs
+
 
 class TestResolveProvider:
     """Tests for resolve_provider() and the LLM_MODELS ImportError path."""

--- a/bili/iris/providers/cli_presets.py
+++ b/bili/iris/providers/cli_presets.py
@@ -69,7 +69,7 @@ from typing import List, Optional
 
 
 @dataclass
-class CliPreset:
+class CliPreset:  # pylint: disable=too-many-instance-attributes
     """Configuration bundle for a specific CLI LLM tool.
 
     Each field mirrors a parameter of
@@ -108,6 +108,14 @@ class CliPreset:
     :param timeout_seconds: Per-call subprocess timeout in seconds.
         Default ``1800.0`` (30 min), generous enough for long-running agentic
         turns.  Set to ``None`` to disable the timeout entirely.
+    :param cwd: Working directory the subprocess is spawned in.  Default
+        ``None``, which preserves the historical behaviour of inheriting the
+        calling process's current working directory.  Set to a fixed path to
+        pin every invocation of this preset to a caller-controlled directory
+        instead -- useful for CLI tools that gate filesystem access per
+        directory (a one-time trust decision for a known directory rather
+        than one triggered by every caller cwd) or to scope the tool's
+        filesystem reach to a dedicated directory.
     """
 
     command: List[str] = field(default_factory=list)
@@ -117,6 +125,7 @@ class CliPreset:
     json_path: str = "content"
     strip_ansi: bool = True
     timeout_seconds: Optional[float] = 1800.0
+    cwd: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------

--- a/bili/iris/providers/cli_provider.py
+++ b/bili/iris/providers/cli_provider.py
@@ -297,6 +297,17 @@ class CliLLM(BaseChatModel):
         to disable the timeout entirely (the subprocess runs until it exits
         or the process is killed).  A finite timeout raises
         :class:`CliLLMError` when exceeded.
+    cwd : str or None
+        Working directory for the subprocess.  Default ``None``, which
+        preserves historical behaviour: the subprocess inherits the calling
+        process's current working directory (``subprocess.run``'s own
+        default).  Set to a fixed path to pin every invocation to a
+        caller-controlled directory instead -- useful when the CLI tool
+        gates filesystem access by directory (a one-time trust decision per
+        directory rather than one per caller cwd) or when the caller wants
+        to scope the tool's filesystem reach to a dedicated sandbox rather
+        than exposing whatever directory the calling process happens to be
+        running from.
     """
 
     # ------------------------------------------------------------------
@@ -310,6 +321,7 @@ class CliLLM(BaseChatModel):
     json_path: str = "content"
     strip_ansi_output: bool = True
     timeout_seconds: Optional[float] = 1800.0
+    cwd: Optional[str] = None
 
     # ------------------------------------------------------------------
     # BaseChatModel required property
@@ -356,10 +368,11 @@ class CliLLM(BaseChatModel):
             self.timeout_seconds if self.timeout_seconds is not None else "none"
         )
         LOGGER.debug(
-            "CliLLM: running %s (prompt_via=%s, timeout=%ss)",
+            "CliLLM: running %s (prompt_via=%s, timeout=%ss, cwd=%s)",
             cmd[0],
             self.prompt_via,
             timeout_display,
+            self.cwd or "<inherited>",
         )
         try:
             result = subprocess.run(  # pylint: disable=subprocess-run-check
@@ -368,6 +381,7 @@ class CliLLM(BaseChatModel):
                 capture_output=True,
                 text=True,
                 timeout=self.timeout_seconds,  # None disables the timeout
+                cwd=self.cwd,  # None inherits the calling process's cwd
                 env=os.environ.copy(),
             )
         except subprocess.TimeoutExpired as exc:
@@ -528,6 +542,17 @@ class CliProvider(LLMProvider):
         Pass ``None`` to disable the timeout entirely for CLI tools whose
         runtime is unbounded (e.g. long-form generation or multi-step
         agentic reasoning).
+
+    cwd : str or None, optional
+        Working directory the subprocess is spawned in.  Default ``None``,
+        which preserves the historical behaviour of inheriting the calling
+        process's current working directory.  Pass a fixed path to pin the
+        subprocess to a caller-controlled directory instead -- for CLI tools
+        that gate filesystem access per directory (so trust is granted once
+        for a known directory rather than re-triggered by every caller cwd)
+        or to scope the tool's filesystem reach to a dedicated directory
+        rather than whatever directory the calling process happens to be
+        running from.
     """
 
     # The `strip_ansi` parameter intentionally shares its name with the
@@ -544,6 +569,7 @@ class CliProvider(LLMProvider):
         json_path: str = "content",
         strip_ansi: bool = True,
         timeout_seconds: Optional[float] = 1800.0,
+        cwd: Optional[str] = None,
         **_extra: Any,
     ) -> CliLLM:
         """Create and return a :class:`CliLLM` instance.
@@ -559,6 +585,10 @@ class CliProvider(LLMProvider):
         :param strip_ansi: Strip ANSI escape codes from stdout.
         :param timeout_seconds: Per-call subprocess timeout in seconds.
             ``None`` disables the timeout.
+        :param cwd: Working directory for the subprocess.  ``None`` (default)
+            inherits the calling process's current working directory,
+            matching historical behaviour.  Pass a fixed path to pin the
+            subprocess to a caller-controlled directory.
         :returns: A configured :class:`CliLLM` instance.
         :raises ValueError: If ``command`` is empty, or any config value is
             not among the supported options.
@@ -591,6 +621,7 @@ class CliProvider(LLMProvider):
             json_path=json_path,
             strip_ansi_output=strip_ansi,
             timeout_seconds=timeout_seconds,
+            cwd=cwd,
         )
         LOGGER.debug(llm)
         return llm

--- a/bili/iris/providers/preset_provider.py
+++ b/bili/iris/providers/preset_provider.py
@@ -55,8 +55,9 @@ class CliPresetProvider(LLMProvider):
         """Merge caller-supplied *overrides* with preset defaults.
 
         Caller-supplied values win over the preset default.  ``None`` is a
-        valid caller value for ``timeout_seconds`` (meaning "no timeout"), so
-        the sentinel :data:`_UNSET` is used to distinguish "not provided" from
+        valid caller value for ``timeout_seconds`` (meaning "no timeout") and
+        for ``cwd`` (meaning "inherit the calling process's cwd"), so the
+        sentinel :data:`_UNSET` is used to distinguish "not provided" from
         "explicitly set to None".
 
         :param overrides: Mapping of parameter name to caller-supplied value,
@@ -76,6 +77,7 @@ class CliPresetProvider(LLMProvider):
             "json_path",
             "strip_ansi",
             "timeout_seconds",
+            "cwd",
         ):
             val = overrides.get(field, _UNSET)
             resolved[field] = val if val is not _UNSET else getattr(preset, field)
@@ -90,6 +92,7 @@ class CliPresetProvider(LLMProvider):
         json_path: Optional[str] = _UNSET,
         strip_ansi: Optional[bool] = _UNSET,
         timeout_seconds: Optional[float] = _UNSET,
+        cwd: Optional[str] = _UNSET,
         **extra: Any,
     ) -> CliLLM:
         """Create a :class:`~bili.iris.providers.cli_provider.CliLLM` using
@@ -103,6 +106,9 @@ class CliPresetProvider(LLMProvider):
         :param strip_ansi: Override the preset's ``strip_ansi``.
         :param timeout_seconds: Override the preset's ``timeout_seconds``.
             Pass ``None`` to disable the subprocess timeout entirely.
+        :param cwd: Override the preset's ``cwd``.  Pass ``None`` to force
+            the subprocess back to inheriting the calling process's current
+            working directory even if the bound preset sets a fixed one.
         :returns: A configured :class:`~bili.iris.providers.cli_provider.CliLLM`.
         :raises RuntimeError: If the provider was not created via
             :meth:`for_preset` (i.e. ``_preset`` is ``None``).
@@ -121,6 +127,7 @@ class CliPresetProvider(LLMProvider):
                 "json_path": json_path,
                 "strip_ansi": strip_ansi,
                 "timeout_seconds": timeout_seconds,
+                "cwd": cwd,
             }
         )
         LOGGER.info(

--- a/bili/iris/providers/tests/test_cli_presets.py
+++ b/bili/iris/providers/tests/test_cli_presets.py
@@ -81,6 +81,7 @@ class TestCliPreset:
         assert preset.json_path == "content"
         assert preset.strip_ansi is True
         assert preset.timeout_seconds == 1800.0
+        assert preset.cwd is None
 
     def test_none_timeout_accepted(self):
         """timeout_seconds=None disables the per-call timeout."""
@@ -97,6 +98,7 @@ class TestCliPreset:
             json_path="result.text",
             strip_ansi=False,
             timeout_seconds=60.0,
+            cwd="/opt/sandbox",
         )
         assert preset.command == ["llm", "--fast"]
         assert preset.prompt_via == "stdin"
@@ -105,6 +107,7 @@ class TestCliPreset:
         assert preset.json_path == "result.text"
         assert preset.strip_ansi is False
         assert preset.timeout_seconds == 60.0
+        assert preset.cwd == "/opt/sandbox"
 
     def test_dataclass_has_expected_fields(self):
         """CliPreset exposes exactly the fields that CliProvider.load accepts."""
@@ -117,6 +120,7 @@ class TestCliPreset:
             "json_path",
             "strip_ansi",
             "timeout_seconds",
+            "cwd",
         }
         assert expected == field_names
 
@@ -277,6 +281,29 @@ class TestCliPresetProvider:
         klass = CliPresetProvider.for_preset(preset)
         llm = klass().load(timeout_seconds=None)
         assert llm.timeout_seconds is None
+
+    def test_load_default_cwd_matches_preset_default(self):
+        """load() with no cwd override falls back to the preset's cwd default
+        (None, i.e. inherit the calling process's cwd)."""
+        preset = CliPreset(command=["tool"])
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load()
+        assert llm.cwd is None
+
+    def test_load_overrides_cwd(self):
+        """load() accepts a caller-supplied cwd override."""
+        preset = CliPreset(command=["tool"], cwd="/preset/default/dir")
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load(cwd="/caller/override/dir")
+        assert llm.cwd == "/caller/override/dir"
+
+    def test_load_none_cwd_resets_to_inherited(self):
+        """Explicitly passing cwd=None overrides a preset-fixed cwd back to
+        inheriting the calling process's cwd."""
+        preset = CliPreset(command=["tool"], cwd="/preset/default/dir")
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load(cwd=None)
+        assert llm.cwd is None
 
     def test_load_without_preset_raises(self):
         """load() raises RuntimeError if _preset is None (base class used directly)."""
@@ -456,6 +483,24 @@ class TestLoadModelRoundtrip:
         """The default timeout for a preset CliLLM loaded via load_model is 1800 s."""
         llm = load_model("cli_claude_code")
         assert llm.timeout_seconds == 1800.0
+
+    def test_default_preset_cwd_is_none(self):
+        """The default cwd for a preset CliLLM loaded via load_model is None,
+        i.e. it inherits the calling process's current working directory."""
+        llm = load_model("cli_claude_code")
+        assert llm.cwd is None
+
+    def test_cwd_override_respected(self):
+        """A cwd override passed to load_model is applied to the CliLLM and
+        forwarded to the subprocess call."""
+        with patch(
+            "subprocess.run",
+            return_value=_make_completed_proc(stdout="ok"),
+        ) as mock_run:
+            llm = load_model("cli_claude_code", cwd="/fixed/workspace")
+            assert llm.cwd == "/fixed/workspace"
+            llm.invoke([HumanMessage(content="hello")])
+        assert mock_run.call_args.kwargs.get("cwd") == "/fixed/workspace"
 
     def test_subprocess_error_raises_cli_llm_error(self):
         """A non-zero subprocess exit for a preset raises CliLLMError."""

--- a/bili/iris/providers/tests/test_cli_provider.py
+++ b/bili/iris/providers/tests/test_cli_provider.py
@@ -272,6 +272,7 @@ class TestCliProviderLoad:
         assert llm.output_format == "text"
         assert llm.strip_ansi_output is True
         assert llm.timeout_seconds == 1800.0
+        assert llm.cwd is None
 
     def test_none_timeout_accepted(self):
         """CliProvider.load() accepts timeout_seconds=None to disable the timeout."""
@@ -288,6 +289,7 @@ class TestCliProviderLoad:
             json_path="result.text",
             strip_ansi=False,
             timeout_seconds=30.0,
+            cwd="/opt/sandbox",
         )
         assert llm.command == ["my-cli", "--json"]
         assert llm.prompt_via == "arg"
@@ -296,6 +298,12 @@ class TestCliProviderLoad:
         assert llm.json_path == "result.text"
         assert llm.strip_ansi_output is False
         assert llm.timeout_seconds == 30.0
+        assert llm.cwd == "/opt/sandbox"
+
+    def test_custom_cwd_propagated(self):
+        """CliProvider.load() forwards a caller-supplied cwd to the CliLLM."""
+        llm = CliProvider().load(command=["my-cli"], cwd="/workspace/fixed")
+        assert llm.cwd == "/workspace/fixed"
 
     def test_extra_kwargs_ignored(self):
         """Extra kwargs from an llm_config catalog entry do not raise."""
@@ -415,6 +423,28 @@ class TestRunSubprocess:
             llm._run_subprocess("prompt")
         call_kwargs = mock_run.call_args.kwargs
         assert call_kwargs.get("timeout") is None
+
+    def test_default_cwd_inherits_calling_process(self):
+        """By default (cwd unset), subprocess.run receives cwd=None, which
+        makes it inherit the calling process's current working directory --
+        today's behaviour, preserved for backward compatibility."""
+        llm = _llm()
+        with patch(
+            "subprocess.run", return_value=_make_completed_proc("ok")
+        ) as mock_run:
+            llm._run_subprocess("prompt")
+        call_kwargs = mock_run.call_args.kwargs
+        assert call_kwargs.get("cwd") is None
+
+    def test_explicit_cwd_is_honored(self):
+        """A caller-supplied cwd is forwarded verbatim to subprocess.run."""
+        llm = _llm(cwd="/opt/fixed-workspace")
+        with patch(
+            "subprocess.run", return_value=_make_completed_proc("ok")
+        ) as mock_run:
+            llm._run_subprocess("prompt")
+        call_kwargs = mock_run.call_args.kwargs
+        assert call_kwargs.get("cwd") == "/opt/fixed-workspace"
 
     def test_env_is_passed(self):
         """The subprocess is called with a copy of os.environ."""


### PR DESCRIPTION
## Summary

The CLI provider (subprocess-backed LLM presets and the generic `cli` provider type) always spawned its subprocess in the calling process's current working directory, with no way to override it. That has two real downsides for callers: CLI tools that gate filesystem access per directory (a one-time trust decision) get that gate re-triggered on every new caller cwd instead of trusting a known directory once, and callers have no way to scope the tool's filesystem reach to something other than their own working directory.

This mirrors the configurable-timeout work in #233: a new `cwd` parameter is threaded through the same layers `timeout_seconds` goes through.

- `CliLLM.cwd: Optional[str] = None` -- forwarded to `subprocess.run(cwd=...)`.
- `CliProvider.load(..., cwd: Optional[str] = None)`.
- `CliPreset.cwd: Optional[str] = None` (per-preset default).
- `CliPresetProvider.load(..., cwd=_UNSET)` -- reuses the existing `_UNSET` sentinel so `cwd=None` can explicitly reset a preset's fixed directory back to "inherit the caller's cwd", distinct from "not overridden."
- `AgentSpec.cli_subprocess_cwd: Optional[str] = None` and `llm_resolver.create_llm()` forward it to CLI providers only (never to API providers).

Default is `None` everywhere, which preserves today's behavior exactly (the subprocess inherits the calling process's cwd via `subprocess.run`'s own default). Purely additive, fully backward compatible.

## Test plan

- [x] `CliLLM._run_subprocess` with `cwd` unset passes `cwd=None` to `subprocess.run` (today's behavior).
- [x] `CliLLM._run_subprocess` with an explicit `cwd` forwards it verbatim to `subprocess.run`.
- [x] `CliProvider.load()` default and custom `cwd` propagate to the returned `CliLLM`.
- [x] `CliPreset` dataclass carries a `cwd` field defaulting to `None`.
- [x] `CliPresetProvider.load()`: default falls back to the preset's `cwd`; an explicit override wins; explicit `cwd=None` resets a preset-fixed directory back to inherited.
- [x] `load_model()` end-to-end: default `cwd` is `None`; an override is applied to the `CliLLM` and reaches the mocked `subprocess.run` call.
- [x] `AgentSpec.cli_subprocess_cwd` forwards to `create_llm()`'s `load_model()` call only for CLI providers, not API providers, and is a no-op when left at its default.
- [x] `python scripts/check_coverage.py` passes (all runtime files >= 90%).
- [x] `pylint` on all changed modules stays above the 9.0 gate.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01XpXRrbE4UhL22Usj6UdEVQ