### PR TITLE
feat: in-process retry with backoff for transient CLI subprocess failures

### DIFF
--- a/bili/aether/compiler/llm_resolver.py
+++ b/bili/aether/compiler/llm_resolver.py
@@ -219,6 +219,14 @@ def create_llm(agent: AgentSpec) -> Any:
     if agent.cli_subprocess_cwd is not None and provider.startswith("cli"):
         kwargs["cwd"] = agent.cli_subprocess_cwd
 
+    # Forward cli_subprocess_max_retries / cli_subprocess_retry_backoff to
+    # CLI providers only, for the same reason as cli_subprocess_timeout above.
+    if agent.cli_subprocess_max_retries is not None and provider.startswith("cli"):
+        kwargs["max_retries"] = agent.cli_subprocess_max_retries
+
+    if agent.cli_subprocess_retry_backoff is not None and provider.startswith("cli"):
+        kwargs["retry_backoff_seconds"] = agent.cli_subprocess_retry_backoff
+
     LOGGER.info(
         "Creating LLM for agent '%s': provider=%s, model_id=%s",
         agent.agent_id,

--- a/bili/aether/schema/agent_spec.py
+++ b/bili/aether/schema/agent_spec.py
@@ -152,6 +152,36 @@ class AgentSpec(BaseModel):
         ),
     )
 
+    cli_subprocess_max_retries: Optional[int] = Field(
+        None,
+        ge=0,
+        description=(
+            "Number of additional in-process attempts for CLI-backed "
+            "providers (provider types 'cli', 'cli_claude_code', "
+            "'cli_codex', 'cli_gemini_cli', and any custom CLI preset) after "
+            "an initial TRANSIENT subprocess failure (rate limit, overload, "
+            "transient 5xx), before giving up.  When set, overrides the "
+            "preset default (2).  Set to 0 to disable in-process retry "
+            "entirely.  Non-transient failures (bad command, auth error, "
+            "malformed output) always fail on the first attempt regardless "
+            "of this setting.  Only applies to agents whose resolved "
+            "provider is a CLI subprocess type; ignored for API providers."
+        ),
+    )
+
+    cli_subprocess_retry_backoff: Optional[float] = Field(
+        None,
+        ge=0.0,
+        description=(
+            "Base delay in seconds before the first in-process retry for "
+            "CLI-backed providers (provider types 'cli', 'cli_claude_code', "
+            "'cli_codex', 'cli_gemini_cli', and any custom CLI preset); each "
+            "subsequent retry doubles the delay.  When set, overrides the "
+            "preset default (1.0 s).  Only applies to agents whose resolved "
+            "provider is a CLI subprocess type; ignored for API providers."
+        ),
+    )
+
     # =========================================================================
     # CAPABILITIES & TOOLS
     # =========================================================================

--- a/bili/aether/tests/test_compiler_coverage.py
+++ b/bili/aether/tests/test_compiler_coverage.py
@@ -417,6 +417,140 @@ class TestCreateLlm:
         kwargs = fake_load_model.call_args[1]
         assert "cwd" not in kwargs
 
+    def test_create_llm_cli_subprocess_max_retries_forwarded(self):
+        """cli_subprocess_max_retries is forwarded to load_model for CLI providers."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        agent = _agent(
+            "cli_agent_retries", model_name="cli:my-tool", cli_subprocess_max_retries=5
+        )
+
+        fake_load_model = MagicMock(return_value="CLI_LLM")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert kwargs["max_retries"] == 5
+
+    def test_create_llm_cli_max_retries_not_forwarded_to_api_provider(self):
+        """cli_subprocess_max_retries is NOT forwarded when the provider is not
+        a CLI type."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        # gpt-4o resolves to "remote_openai", not a CLI provider
+        agent = _agent(
+            "api_agent_retries", model_name="gpt-4o", cli_subprocess_max_retries=5
+        )
+
+        fake_load_model = MagicMock(return_value="API_LLM")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert "max_retries" not in kwargs
+
+    def test_create_llm_cli_max_retries_none_not_forwarded(self):
+        """When cli_subprocess_max_retries is None (default), max_retries is
+        not added -- the CLI provider uses its preset default."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        agent = _agent("cli_default_retries", model_name="cli:my-tool")
+        # cli_subprocess_max_retries defaults to None
+
+        fake_load_model = MagicMock(return_value="CLI_LLM")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert "max_retries" not in kwargs
+
+    def test_create_llm_cli_subprocess_retry_backoff_forwarded(self):
+        """cli_subprocess_retry_backoff is forwarded to load_model as
+        retry_backoff_seconds for CLI providers."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        agent = _agent(
+            "cli_agent_backoff",
+            model_name="cli:my-tool",
+            cli_subprocess_retry_backoff=3.5,
+        )
+
+        fake_load_model = MagicMock(return_value="CLI_LLM")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert kwargs["retry_backoff_seconds"] == 3.5
+
+    def test_create_llm_cli_retry_backoff_not_forwarded_to_api_provider(self):
+        """cli_subprocess_retry_backoff is NOT forwarded when the provider is
+        not a CLI type."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        # gpt-4o resolves to "remote_openai", not a CLI provider
+        agent = _agent(
+            "api_agent_backoff", model_name="gpt-4o", cli_subprocess_retry_backoff=3.5
+        )
+
+        fake_load_model = MagicMock(return_value="API_LLM")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert "retry_backoff_seconds" not in kwargs
+
+    def test_create_llm_cli_retry_backoff_none_not_forwarded(self):
+        """When cli_subprocess_retry_backoff is None (default),
+        retry_backoff_seconds is not added -- the CLI provider uses its
+        preset default."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        agent = _agent("cli_default_backoff", model_name="cli:my-tool")
+        # cli_subprocess_retry_backoff defaults to None
+
+        fake_load_model = MagicMock(return_value="CLI_LLM")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert "retry_backoff_seconds" not in kwargs
+
 
 class TestResolveProvider:
     """Tests for resolve_provider() and the LLM_MODELS ImportError path."""

--- a/bili/iris/providers/cli_presets.py
+++ b/bili/iris/providers/cli_presets.py
@@ -116,6 +116,13 @@ class CliPreset:  # pylint: disable=too-many-instance-attributes
         directory (a one-time trust decision for a known directory rather
         than one triggered by every caller cwd) or to scope the tool's
         filesystem reach to a dedicated directory.
+    :param max_retries: Additional in-process attempts after an initial
+        transient failure (rate limit, overload, transient 5xx), before
+        raising ``CliLLMError``.  Default ``2``.  Set to ``0`` to disable
+        retry entirely.  Only clearly-transient failures are retried;
+        permanent failures always fail on the first attempt.
+    :param retry_backoff_seconds: Base delay in seconds before the first
+        retry; doubles on each subsequent retry.  Default ``1.0``.
     """
 
     command: List[str] = field(default_factory=list)
@@ -126,6 +133,8 @@ class CliPreset:  # pylint: disable=too-many-instance-attributes
     strip_ansi: bool = True
     timeout_seconds: Optional[float] = 1800.0
     cwd: Optional[str] = None
+    max_retries: int = 2
+    retry_backoff_seconds: float = 1.0
 
 
 # ---------------------------------------------------------------------------

--- a/bili/iris/providers/cli_provider.py
+++ b/bili/iris/providers/cli_provider.py
@@ -17,6 +17,16 @@ propagates up to the caller.  When used with the fallback engine
 (:class:`~bili.iris.providers.fallback.FallbackLLM`), ``CliLLMError`` is
 treated as retryable so the chain can fall through to an API provider.
 
+Before it gets that far, though, the provider itself retries a failure that
+looks *transient* (rate limiting, temporary overload, a transient 5xx from
+whatever backend the CLI tool talks to) in-process, with exponential
+backoff, up to a configurable number of attempts.  This matters most for a
+consumer running a CLI provider with no API-provider fallback configured at
+all: without in-process retry, a single rate-limit blip from the CLI's own
+upstream call fails the whole turn immediately, with nothing to fall through
+to.  See :data:`_TRANSIENT_ERROR_PATTERNS` for the transient-vs-permanent
+detection approach.
+
 The LLM object returned by :meth:`CliProvider.load` is a
 :class:`CliLLM` -- a concrete :class:`~langchain_core.language_models.BaseChatModel`
 subclass.  This makes it a drop-in replacement inside any LangChain/LangGraph
@@ -74,6 +84,7 @@ import os
 import re
 import subprocess
 import tempfile
+import time
 from typing import Any, AsyncIterator, Iterator, List, Optional, Tuple, Union
 
 from langchain_core.language_models import BaseChatModel
@@ -118,6 +129,70 @@ class CliLLMError(RuntimeError):
     ``CliLLMError`` so failed CLI calls fall over to the next provider in
     the chain automatically.
     """
+
+
+# ---------------------------------------------------------------------------
+# Transient-vs-permanent failure detection
+# ---------------------------------------------------------------------------
+
+#: Regex patterns checked (case-insensitively) against the text of a failed
+#: CLI invocation -- the ``CliLLMError`` message built from the captured
+#: stderr -- to decide whether the failure looks TRANSIENT and is therefore
+#: worth retrying in-process, versus PERMANENT (fail fast, no retry).
+#:
+#: Detection approach: text patterns against stderr, not exit codes.  CLI
+#: tools are a heterogeneous grab-bag of processes with no shared convention
+#: for exit codes -- one tool might exit 1 for "rate limited", another might
+#: exit 1 for "bad flag" or "binary not found".  Exit code alone cannot
+#: distinguish those cases across arbitrary CLI tools.  Stderr text is a far
+#: more portable signal: CLI tools that wrap a hosted LLM API commonly
+#: surface the upstream provider's own error text verbatim (e.g. "429",
+#: "rate_limit_error", "Overloaded", "503 Service Unavailable") regardless of
+#: which CLI emits it.
+#:
+#: The list is deliberately narrow and conservative.  A broken command, a
+#: missing binary, a bad flag, an authentication failure, or a malformed-
+#: output parse error are all permanent and must fail on the first attempt;
+#: none of those match these patterns.  When in doubt, a failure is treated
+#: as permanent -- an unnecessary retry is merely slower, but a retry of a
+#: genuinely permanent failure wastes the full backoff schedule for no
+#: benefit and delays the caller from seeing (and acting on) the real error.
+_TRANSIENT_ERROR_PATTERNS: Tuple[re.Pattern, ...] = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"rate[\s_-]?limit",
+        r"too many requests",
+        r"overloaded",
+        r"resource[\s_-]?exhausted",
+        r"quota exceeded",
+        r"throttl",
+        r"service unavailable",
+        r"temporarily unavailable",
+        r"\b429\b",
+        r"\b500\b",
+        r"\b502\b",
+        r"\b503\b",
+        r"\b504\b",
+        r"\b529\b",
+    )
+)
+
+
+def _is_transient_failure(error_text: str) -> bool:
+    """Return ``True`` if *error_text* matches a known transient-failure
+    signature.
+
+    :param error_text: The message text of a raised :class:`CliLLMError`
+        (which embeds the captured stderr snippet for non-zero exits).
+    :returns: ``True`` if *error_text* looks like a transient upstream
+        condition (rate limit, overload, transient 5xx) safe to retry;
+        ``False`` otherwise, including subprocess timeouts, whose messages
+        never match these patterns and are therefore always treated as
+        permanent -- a timeout already waited out the full configured
+        budget, so retrying would only double the wall-clock cost without a
+        clear signal that the retry will fare any better.
+    """
+    return any(pattern.search(error_text) for pattern in _TRANSIENT_ERROR_PATTERNS)
 
 
 # ---------------------------------------------------------------------------
@@ -308,6 +383,22 @@ class CliLLM(BaseChatModel):
         to scope the tool's filesystem reach to a dedicated sandbox rather
         than exposing whatever directory the calling process happens to be
         running from.
+    max_retries : int
+        Number of additional attempts after an initial transient failure,
+        before giving up and raising :class:`CliLLMError`.  Default ``2`` --
+        small enough that a persistently-broken CLI does not multiply the
+        caller's wall-clock cost many times over, but enough that a rate
+        limit or overload signal (which typically clears within a few
+        seconds) usually succeeds on retry.  Set to ``0`` to disable retry
+        entirely, matching the historical behaviour of raising immediately
+        on the first failure.  Only failures that match a known transient
+        signature are retried (see :data:`_TRANSIENT_ERROR_PATTERNS`);
+        permanent failures (bad command, auth error, malformed output)
+        always fail on the first attempt regardless of this setting.
+    retry_backoff_seconds : float
+        Base delay, in seconds, before the first retry.  Each subsequent
+        retry doubles the delay (``retry_backoff_seconds * 2 ** attempt``).
+        Default ``1.0``.
     """
 
     # ------------------------------------------------------------------
@@ -322,6 +413,8 @@ class CliLLM(BaseChatModel):
     strip_ansi_output: bool = True
     timeout_seconds: Optional[float] = 1800.0
     cwd: Optional[str] = None
+    max_retries: int = 2
+    retry_backoff_seconds: float = 1.0
 
     # ------------------------------------------------------------------
     # BaseChatModel required property
@@ -359,7 +452,48 @@ class CliLLM(BaseChatModel):
         return list(self.command) + [tmp_path], None, tmp_path
 
     def _run_subprocess(self, prompt: str) -> str:
-        """Execute the CLI with *prompt* and return the captured output text.
+        """Execute the CLI with *prompt*, retrying transient failures.
+
+        Calls :meth:`_run_subprocess_once` up to ``max_retries + 1`` times.
+        A failure is retried (with exponential backoff) only when
+        :func:`_is_transient_failure` matches the raised
+        :class:`CliLLMError`'s message; any other failure -- or the final
+        attempt of a persistently-transient one -- is re-raised immediately.
+
+        :raises CliLLMError: On a non-transient failure, or once transient
+            retries are exhausted.
+        """
+        max_attempts = max(self.max_retries, 0) + 1
+        last_error: Optional[CliLLMError] = None
+        for attempt in range(max_attempts):
+            try:
+                return self._run_subprocess_once(prompt)
+            except CliLLMError as exc:
+                last_error = exc
+                attempts_remaining = max_attempts - attempt - 1
+                if attempts_remaining <= 0 or not _is_transient_failure(str(exc)):
+                    raise
+                delay = self.retry_backoff_seconds * (2**attempt)
+                LOGGER.warning(
+                    "CliLLM: transient failure on attempt %d/%d (%s); "
+                    "retrying in %.1fs",
+                    attempt + 1,
+                    max_attempts,
+                    exc,
+                    delay,
+                )
+                if delay > 0:
+                    time.sleep(delay)
+        # Unreachable: the loop above always returns from a successful
+        # attempt or raises via the `raise` statement above.  Kept only to
+        # satisfy static analysis that every code path returns or raises.
+        raise last_error  # pragma: no cover
+
+    def _run_subprocess_once(self, prompt: str) -> str:
+        """Execute the CLI once with *prompt* and return captured output text.
+
+        A single subprocess invocation, no retry.  Called by
+        :meth:`_run_subprocess`, which wraps this in the retry loop.
 
         :raises CliLLMError: On non-zero exit code or timeout.
         """
@@ -553,6 +687,19 @@ class CliProvider(LLMProvider):
         or to scope the tool's filesystem reach to a dedicated directory
         rather than whatever directory the calling process happens to be
         running from.
+
+    max_retries : int, optional
+        Number of additional in-process attempts after an initial transient
+        failure (rate limit, overload, transient 5xx -- see
+        :data:`_TRANSIENT_ERROR_PATTERNS`), before raising
+        :class:`CliLLMError`.  Default ``2``.  Pass ``0`` to disable retry
+        entirely, matching the historical (pre-retry) behaviour of raising
+        immediately.  Permanent failures always fail on the first attempt
+        regardless of this setting.
+
+    retry_backoff_seconds : float, optional
+        Base delay, in seconds, before the first retry; doubles on each
+        subsequent retry.  Default ``1.0``.
     """
 
     # The `strip_ansi` parameter intentionally shares its name with the
@@ -570,6 +717,8 @@ class CliProvider(LLMProvider):
         strip_ansi: bool = True,
         timeout_seconds: Optional[float] = 1800.0,
         cwd: Optional[str] = None,
+        max_retries: int = 2,
+        retry_backoff_seconds: float = 1.0,
         **_extra: Any,
     ) -> CliLLM:
         """Create and return a :class:`CliLLM` instance.
@@ -589,9 +738,14 @@ class CliProvider(LLMProvider):
             inherits the calling process's current working directory,
             matching historical behaviour.  Pass a fixed path to pin the
             subprocess to a caller-controlled directory.
+        :param max_retries: Additional attempts after an initial transient
+            failure, before raising.  ``0`` disables retry.
+        :param retry_backoff_seconds: Base delay in seconds before the first
+            retry; doubles on each subsequent retry.
         :returns: A configured :class:`CliLLM` instance.
-        :raises ValueError: If ``command`` is empty, or any config value is
-            not among the supported options.
+        :raises ValueError: If ``command`` is empty, any config value is not
+            among the supported options, or ``max_retries``/
+            ``retry_backoff_seconds`` is negative.
         """
         if not command:
             raise ValueError("CliProvider requires a non-empty 'command' list")
@@ -610,6 +764,12 @@ class CliProvider(LLMProvider):
                 f"output_format={output_format!r} is not supported. "
                 f"Choose from: {sorted(SUPPORTED_OUTPUT_FORMATS)}"
             )
+        if max_retries < 0:
+            raise ValueError(f"max_retries must be >= 0, got {max_retries!r}")
+        if retry_backoff_seconds < 0:
+            raise ValueError(
+                f"retry_backoff_seconds must be >= 0, got {retry_backoff_seconds!r}"
+            )
 
         LOGGER.info("Initializing CliLLM: command=%s", command[0])
 
@@ -622,6 +782,8 @@ class CliProvider(LLMProvider):
             strip_ansi_output=strip_ansi,
             timeout_seconds=timeout_seconds,
             cwd=cwd,
+            max_retries=max_retries,
+            retry_backoff_seconds=retry_backoff_seconds,
         )
         LOGGER.debug(llm)
         return llm

--- a/bili/iris/providers/preset_provider.py
+++ b/bili/iris/providers/preset_provider.py
@@ -78,6 +78,8 @@ class CliPresetProvider(LLMProvider):
             "strip_ansi",
             "timeout_seconds",
             "cwd",
+            "max_retries",
+            "retry_backoff_seconds",
         ):
             val = overrides.get(field, _UNSET)
             resolved[field] = val if val is not _UNSET else getattr(preset, field)
@@ -93,6 +95,8 @@ class CliPresetProvider(LLMProvider):
         strip_ansi: Optional[bool] = _UNSET,
         timeout_seconds: Optional[float] = _UNSET,
         cwd: Optional[str] = _UNSET,
+        max_retries: Optional[int] = _UNSET,
+        retry_backoff_seconds: Optional[float] = _UNSET,
         **extra: Any,
     ) -> CliLLM:
         """Create a :class:`~bili.iris.providers.cli_provider.CliLLM` using
@@ -109,6 +113,10 @@ class CliPresetProvider(LLMProvider):
         :param cwd: Override the preset's ``cwd``.  Pass ``None`` to force
             the subprocess back to inheriting the calling process's current
             working directory even if the bound preset sets a fixed one.
+        :param max_retries: Override the preset's ``max_retries``.  Pass
+            ``0`` to disable in-process retry entirely.
+        :param retry_backoff_seconds: Override the preset's
+            ``retry_backoff_seconds``.
         :returns: A configured :class:`~bili.iris.providers.cli_provider.CliLLM`.
         :raises RuntimeError: If the provider was not created via
             :meth:`for_preset` (i.e. ``_preset`` is ``None``).
@@ -128,6 +136,8 @@ class CliPresetProvider(LLMProvider):
                 "strip_ansi": strip_ansi,
                 "timeout_seconds": timeout_seconds,
                 "cwd": cwd,
+                "max_retries": max_retries,
+                "retry_backoff_seconds": retry_backoff_seconds,
             }
         )
         LOGGER.info(

--- a/bili/iris/providers/tests/test_cli_presets.py
+++ b/bili/iris/providers/tests/test_cli_presets.py
@@ -82,6 +82,8 @@ class TestCliPreset:
         assert preset.strip_ansi is True
         assert preset.timeout_seconds == 1800.0
         assert preset.cwd is None
+        assert preset.max_retries == 2
+        assert preset.retry_backoff_seconds == 1.0
 
     def test_none_timeout_accepted(self):
         """timeout_seconds=None disables the per-call timeout."""
@@ -99,6 +101,8 @@ class TestCliPreset:
             strip_ansi=False,
             timeout_seconds=60.0,
             cwd="/opt/sandbox",
+            max_retries=5,
+            retry_backoff_seconds=2.5,
         )
         assert preset.command == ["llm", "--fast"]
         assert preset.prompt_via == "stdin"
@@ -108,6 +112,8 @@ class TestCliPreset:
         assert preset.strip_ansi is False
         assert preset.timeout_seconds == 60.0
         assert preset.cwd == "/opt/sandbox"
+        assert preset.max_retries == 5
+        assert preset.retry_backoff_seconds == 2.5
 
     def test_dataclass_has_expected_fields(self):
         """CliPreset exposes exactly the fields that CliProvider.load accepts."""
@@ -121,6 +127,8 @@ class TestCliPreset:
             "strip_ansi",
             "timeout_seconds",
             "cwd",
+            "max_retries",
+            "retry_backoff_seconds",
         }
         assert expected == field_names
 
@@ -304,6 +312,27 @@ class TestCliPresetProvider:
         klass = CliPresetProvider.for_preset(preset)
         llm = klass().load(cwd=None)
         assert llm.cwd is None
+
+    def test_load_default_max_retries_matches_preset_default(self):
+        """load() with no override falls back to the preset's max_retries."""
+        preset = CliPreset(command=["tool"])
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load()
+        assert llm.max_retries == 2
+
+    def test_load_overrides_max_retries(self):
+        """load() accepts a caller-supplied max_retries override."""
+        preset = CliPreset(command=["tool"], max_retries=2)
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load(max_retries=5)
+        assert llm.max_retries == 5
+
+    def test_load_overrides_retry_backoff_seconds(self):
+        """load() accepts a caller-supplied retry_backoff_seconds override."""
+        preset = CliPreset(command=["tool"], retry_backoff_seconds=1.0)
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load(retry_backoff_seconds=3.0)
+        assert llm.retry_backoff_seconds == 3.0
 
     def test_load_without_preset_raises(self):
         """load() raises RuntimeError if _preset is None (base class used directly)."""

--- a/bili/iris/providers/tests/test_cli_provider.py
+++ b/bili/iris/providers/tests/test_cli_provider.py
@@ -17,7 +17,7 @@ import json
 import os
 import subprocess
 from typing import Dict
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from langchain_core.messages import (
@@ -36,6 +36,7 @@ from bili.iris.providers.cli_provider import (
     CliLLM,
     CliLLMError,
     CliProvider,
+    _is_transient_failure,
     extract_json_path,
     render_messages,
     strip_ansi,
@@ -273,6 +274,8 @@ class TestCliProviderLoad:
         assert llm.strip_ansi_output is True
         assert llm.timeout_seconds == 1800.0
         assert llm.cwd is None
+        assert llm.max_retries == 2
+        assert llm.retry_backoff_seconds == 1.0
 
     def test_none_timeout_accepted(self):
         """CliProvider.load() accepts timeout_seconds=None to disable the timeout."""
@@ -290,6 +293,8 @@ class TestCliProviderLoad:
             strip_ansi=False,
             timeout_seconds=30.0,
             cwd="/opt/sandbox",
+            max_retries=5,
+            retry_backoff_seconds=2.5,
         )
         assert llm.command == ["my-cli", "--json"]
         assert llm.prompt_via == "arg"
@@ -299,11 +304,28 @@ class TestCliProviderLoad:
         assert llm.strip_ansi_output is False
         assert llm.timeout_seconds == 30.0
         assert llm.cwd == "/opt/sandbox"
+        assert llm.max_retries == 5
+        assert llm.retry_backoff_seconds == 2.5
 
     def test_custom_cwd_propagated(self):
         """CliProvider.load() forwards a caller-supplied cwd to the CliLLM."""
         llm = CliProvider().load(command=["my-cli"], cwd="/workspace/fixed")
         assert llm.cwd == "/workspace/fixed"
+
+    def test_negative_max_retries_raises(self):
+        """A negative max_retries raises ValueError."""
+        with pytest.raises(ValueError, match="max_retries"):
+            CliProvider().load(command=["echo"], max_retries=-1)
+
+    def test_negative_retry_backoff_raises(self):
+        """A negative retry_backoff_seconds raises ValueError."""
+        with pytest.raises(ValueError, match="retry_backoff_seconds"):
+            CliProvider().load(command=["echo"], retry_backoff_seconds=-1.0)
+
+    def test_zero_max_retries_accepted(self):
+        """max_retries=0 (disable retry) is accepted."""
+        llm = CliProvider().load(command=["echo"], max_retries=0)
+        assert llm.max_retries == 0
 
     def test_extra_kwargs_ignored(self):
         """Extra kwargs from an llm_config catalog entry do not raise."""
@@ -488,6 +510,139 @@ class TestRunSubprocess:
             with pytest.raises(CliLLMError) as exc_info:
                 llm._run_subprocess("p")
         assert len(str(exc_info.value)) < 600 + 100
+
+
+# ---------------------------------------------------------------------------
+# Transient-vs-permanent failure detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsTransientFailure:
+    """Unit tests for the transient-failure text-pattern detector."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "CLI subprocess exited with code 1: claude\nstderr: rate limit exceeded",
+            "429 Too Many Requests",
+            "Error: Overloaded (Anthropic 529)",
+            "resource_exhausted: quota exceeded for this project",
+            "503 Service Unavailable",
+            "the upstream service is temporarily unavailable",
+            "request was throttled, please retry",
+        ],
+    )
+    def test_transient_signatures_detected(self, text):
+        """Known transient-failure text patterns are detected."""
+        assert _is_transient_failure(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "CLI subprocess exited with code 127: my-cli\nstderr: command not found",
+            "authentication failed: invalid API key",
+            "CLI output is not valid JSON (output_format='json'): ...",
+            "json_path='content' not found in CLI output: ...",
+            "CLI subprocess timed out after 30.0s: my-cli",
+            "usage: my-cli [OPTIONS]\nerror: unrecognized argument --bogus",
+        ],
+    )
+    def test_permanent_failures_not_detected(self, text):
+        """Permanent-failure text does not match any transient pattern."""
+        assert _is_transient_failure(text) is False
+
+
+# ---------------------------------------------------------------------------
+# CliLLM._run_subprocess -- in-process retry on transient failure
+# ---------------------------------------------------------------------------
+
+
+class TestRunSubprocessRetry:
+    """Tests for the retry-with-backoff wrapper around subprocess execution."""
+
+    def test_transient_failure_retries_then_succeeds(self):
+        """A transient failure is retried and the eventual success is returned."""
+        llm = _llm(max_retries=2, retry_backoff_seconds=0.01)
+        fail = _make_completed_proc("", returncode=1, stderr="429 Too Many Requests")
+        ok = _make_completed_proc("all good")
+        with patch("subprocess.run", side_effect=[fail, ok]) as mock_run:
+            with patch("bili.iris.providers.cli_provider.time.sleep") as mock_sleep:
+                result = llm._run_subprocess("prompt")
+        assert result == "all good"
+        assert mock_run.call_count == 2
+        mock_sleep.assert_called_once()
+
+    def test_transient_failure_exhausts_retries_and_raises(self):
+        """A persistently transient failure raises CliLLMError once max_retries
+        attempts are exhausted."""
+        llm = _llm(max_retries=2, retry_backoff_seconds=0.01)
+        fail = _make_completed_proc("", returncode=1, stderr="503 Service Unavailable")
+        with patch("subprocess.run", side_effect=[fail, fail, fail]) as mock_run:
+            with patch("bili.iris.providers.cli_provider.time.sleep"):
+                with pytest.raises(CliLLMError, match="exited with code 1"):
+                    llm._run_subprocess("prompt")
+        # max_retries=2 -> 3 total attempts (1 initial + 2 retries)
+        assert mock_run.call_count == 3
+
+    def test_permanent_failure_fails_fast_no_retry(self):
+        """A non-transient failure raises immediately with no retry attempts."""
+        llm = _llm(max_retries=2, retry_backoff_seconds=0.01)
+        fail = _make_completed_proc("", returncode=1, stderr="command not found")
+        with patch("subprocess.run", return_value=fail) as mock_run:
+            with patch("bili.iris.providers.cli_provider.time.sleep") as mock_sleep:
+                with pytest.raises(CliLLMError, match="exited with code 1"):
+                    llm._run_subprocess("prompt")
+        assert mock_run.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_max_retries_zero_disables_retry(self):
+        """max_retries=0 preserves the historical behaviour: a single attempt,
+        failing immediately even on a transient signature."""
+        llm = _llm(max_retries=0)
+        fail = _make_completed_proc("", returncode=1, stderr="rate limit exceeded")
+        with patch("subprocess.run", return_value=fail) as mock_run:
+            with patch("bili.iris.providers.cli_provider.time.sleep") as mock_sleep:
+                with pytest.raises(CliLLMError, match="exited with code 1"):
+                    llm._run_subprocess("prompt")
+        assert mock_run.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_backoff_delays_are_exponential(self):
+        """Successive retries back off exponentially from retry_backoff_seconds."""
+        llm = _llm(max_retries=3, retry_backoff_seconds=1.0)
+        fail = _make_completed_proc("", returncode=1, stderr="429 Too Many Requests")
+        ok = _make_completed_proc("done")
+        with patch("subprocess.run", side_effect=[fail, fail, fail, ok]):
+            with patch("bili.iris.providers.cli_provider.time.sleep") as mock_sleep:
+                result = llm._run_subprocess("prompt")
+        assert result == "done"
+        assert mock_sleep.call_args_list == [call(1.0), call(2.0), call(4.0)]
+
+    def test_default_max_retries_is_two(self):
+        """The default max_retries (2) permits two retries after the first
+        transient failure before raising."""
+        llm = _llm()
+        assert llm.max_retries == 2
+        fail = _make_completed_proc("", returncode=1, stderr="429 Too Many Requests")
+        with patch("subprocess.run", side_effect=[fail, fail, fail]) as mock_run:
+            with patch("bili.iris.providers.cli_provider.time.sleep"):
+                with pytest.raises(CliLLMError):
+                    llm._run_subprocess("prompt")
+        assert mock_run.call_count == 3
+
+    def test_timeout_is_not_retried(self):
+        """A subprocess timeout is treated as permanent (not retried): its
+        message never matches a transient signature."""
+        llm = _llm(max_retries=2, retry_backoff_seconds=0.01, timeout_seconds=5.0)
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["echo"], timeout=5),
+        ) as mock_run:
+            with patch("bili.iris.providers.cli_provider.time.sleep") as mock_sleep:
+                with pytest.raises(CliLLMError, match="timed out"):
+                    llm._run_subprocess("prompt")
+        assert mock_run.call_count == 1
+        mock_sleep.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The CLI provider raised `CliLLMError` immediately on any non-zero exit or timeout, with no in-process retry. `CliLLMError` is in the fallback engine's retryable set, so a `FallbackLLM` chain falls through to the next provider on failure -- but a consumer running a single CLI provider with no API-provider fallback configured (the no-API-key case) has nothing to fall through to. A transient rate-limit or overload signal from the CLI's own upstream call failed the whole turn immediately.
- Adds `max_retries` (default `2`) and `retry_backoff_seconds` (default `1.0`, doubling on each retry), threaded through the same layers as the existing `timeout_seconds`/`cwd` config (#233, #234): `CliLLM` / `CliProvider.load()` / `CliPreset` / `CliPresetProvider.load()` / `AgentSpec.cli_subprocess_max_retries` / `AgentSpec.cli_subprocess_retry_backoff`.
- **Transient-vs-permanent detection** is text-based against the `CliLLMError` message (which embeds captured stderr), not exit-code-based: CLI tools have no shared exit-code convention ("rate limited" and "bad flag" can both exit 1 depending on the tool), but text patterns for HTTP-style rate-limit/overload/5xx signatures (`429`, `rate limit`, `Overloaded`, `503 Service Unavailable`, etc.) are portable across arbitrary CLI wrappers around a hosted LLM API. The pattern list is deliberately narrow and conservative -- a broken command, an auth failure, or a malformed-output parse error all fail fast with no retry. Subprocess timeouts are never retried: a timeout message never matches a transient pattern, since the timeout has already spent its full configured budget with no clear signal a retry will fare better.
- `max_retries=0`, or any failure that doesn't match a transient signature, preserves today's behavior of raising on the first failure. All defaults are additive and backward-compatible.

## Test plan

- [x] `pytest` -- transient failure retries then succeeds; persistently-transient failure raises once `max_retries` is exhausted; permanent failure fails fast with exactly one subprocess call (no retry); a subprocess timeout is never retried; `max_retries=0` disables retry entirely; backoff delays are exponential (`retry_backoff_seconds * 2 ** attempt`); `max_retries`/`retry_backoff_seconds` are configurable and validated (`>= 0`) at every layer (`CliLLM`, `CliProvider`, `CliPresetProvider`, `load_model`, `AgentSpec`/`create_llm`); not forwarded to non-CLI (API) providers.
- [x] Full test suite: 4149 passed, 1 skipped.
- [x] Per-file coverage gate (`scripts/check_coverage.py`): all 214 runtime files >= 90%.
- [x] `pre-commit run` (black, autoflake, isort, pylint) passes on all touched files.

Claude-Session: https://claude.ai/code/session_01XpXRrbE4UhL22Usj6UdEVQ