### PR TITLE
fix: honor configured CLI subprocess cwd on the MCP tool-strategy path

### DIFF
--- a/bili/iris/mcp/server.py
+++ b/bili/iris/mcp/server.py
@@ -575,9 +575,26 @@ def build_mcp_node(
     7. Returns a state dict update with the response as an ``AIMessage``.
     8. Cleans up the ephemeral server and any injector-created temp resources.
 
+    Working-directory precedence
+    -----------------------------
+    The subprocess's working directory is resolved in this order:
+
+    1. ``llm_model.cwd``, if set. This is a caller-controlled isolation
+       boundary (e.g. pinning the CLI subprocess to a fixed sandbox
+       directory rather than letting it inherit the calling process's cwd)
+       and always takes precedence.
+    2. The injector-provided cwd sentinel, if the CLI injector requires a
+       specific working directory of its own (e.g. :class:`GeminiCliInjector`
+       points the subprocess at a temp directory containing its
+       project-scoped MCP settings file).
+    3. ``None`` -- the subprocess inherits the calling process's cwd,
+       matching ``subprocess.run``'s own default and the direct
+       (:meth:`CliLLM._run_subprocess`) CLI execution path's default.
+
     :param llm_model: A :class:`~bili.iris.providers.cli_provider.CliLLM`
         instance (provides ``command``, ``message_format``, ``output_format``,
-        ``json_path``, ``strip_ansi_output``, and ``timeout_seconds``).
+        ``json_path``, ``strip_ansi_output``, ``timeout_seconds``, and
+        ``cwd``).
     :param tools: LangChain tools to expose as MCP tools.
     :param injector: A CLI injector from :mod:`bili.iris.mcp.cli_injectors`
         (or any object implementing ``inject(handle) -> InjectionResult``).
@@ -591,6 +608,7 @@ def build_mcp_node(
     json_path: str = getattr(llm_model, "json_path", "content")
     strip_ansi_flag: bool = getattr(llm_model, "strip_ansi_output", True)
     timeout_seconds: float = getattr(llm_model, "timeout_seconds", 120.0)
+    configured_cwd: Optional[str] = getattr(llm_model, "cwd", None)
 
     # Import message rendering from cli_provider at construction time to fail fast
     # if the package is missing.
@@ -636,8 +654,20 @@ def build_mcp_node(
             )
 
             run_env = os.environ.copy()
-            subprocess_cwd: Optional[str] = extra_env.pop(_GEMINI_CWD_KEY, None)
+            sentinel_cwd: Optional[str] = extra_env.pop(_GEMINI_CWD_KEY, None)
             run_env.update(extra_env)
+
+            # Resolve the subprocess working directory. An explicitly configured
+            # CliLLM.cwd always wins -- it is a caller-controlled isolation
+            # boundary (e.g. pinning the CLI subprocess to a sandbox directory)
+            # and must not be silently overridden by an injector's own cwd
+            # requirements. When no explicit cwd is configured, fall back to the
+            # injector-provided sentinel (used by GeminiCliInjector to point the
+            # subprocess at its generated project-scoped settings directory).
+            # With neither set, cwd stays None and the subprocess inherits the
+            # calling process's cwd, matching subprocess.run's own default and
+            # the direct (_run_subprocess) CLI path's default.
+            subprocess_cwd: Optional[str] = configured_cwd or sentinel_cwd
 
             LOGGER.debug(
                 "EphemeralMcpServer: running CLI %s with MCP server %s",

--- a/bili/iris/mcp/tests/test_server.py
+++ b/bili/iris/mcp/tests/test_server.py
@@ -623,7 +623,7 @@ class TestParseOutput:
 class TestBuildMcpNode:
     """Tests for the build_mcp_node factory and the node callable it returns."""
 
-    def _make_cli_llm(self, command=None):
+    def _make_cli_llm(self, command=None, cwd=None):
         llm = MagicMock()
         llm.command = command or ["claude", "-p"]
         llm.message_format = "last"
@@ -631,6 +631,7 @@ class TestBuildMcpNode:
         llm.json_path = "content"
         llm.strip_ansi_output = False
         llm.timeout_seconds = 30.0
+        llm.cwd = cwd
         return llm
 
     def _make_injector(self, extra_env=None, cleanup=None, cwd=None):
@@ -652,7 +653,7 @@ class TestBuildMcpNode:
     def _make_state(self, text: str = "hello"):
         return {"messages": [HumanMessage(content=text)]}
 
-    def _run_node_with_mocks(
+    def _run_node_with_mocks(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
         self,
         tool=None,
         injector=None,
@@ -660,10 +661,17 @@ class TestBuildMcpNode:
         returncode=0,
         extra_env=None,
         cwd=None,
+        llm_cwd=None,
     ):
-        """Patch EphemeralMcpServer and subprocess to run the node callable."""
+        """Patch EphemeralMcpServer and subprocess to run the node callable.
+
+        :param cwd: Injector-side cwd sentinel (e.g. the Gemini injector's
+            temp-dir cwd requirement), forwarded via the injector's extra env.
+        :param llm_cwd: The CliLLM's own configured ``cwd`` attribute --
+            simulates a caller-configured subprocess working directory.
+        """
         tool = tool or _make_plain_tool()
-        llm = self._make_cli_llm()
+        llm = self._make_cli_llm(cwd=llm_cwd)
         injector = injector or self._make_injector(extra_env=extra_env, cwd=cwd)
 
         node = build_mcp_node(llm_model=llm, tools=[tool], injector=injector)
@@ -745,6 +753,43 @@ class TestBuildMcpNode:
         assert call_kwargs.get("cwd") == "/tmp/gemini_work"
         # Sentinel must NOT appear in the forwarded env.
         assert _GEMINI_CWD_KEY not in call_kwargs.get("env", {})
+
+    def test_configured_llm_cwd_forwarded_to_subprocess(self):
+        """A CliLLM.cwd configured on the model must reach the MCP subprocess.
+
+        Regression test: build_mcp_node previously ignored llm_model.cwd
+        entirely, so a configured working directory (e.g. for claude/codex,
+        which have no cwd-sentinel injector) was silently dropped and the
+        subprocess inherited the caller's cwd instead.
+        """
+        _, mock_run, _ = self._run_node_with_mocks(llm_cwd="/fixed/workspace")
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs.get("cwd") == "/fixed/workspace"
+
+    def test_configured_llm_cwd_takes_precedence_over_gemini_sentinel(self):
+        """An explicit CliLLM.cwd wins over the injector's own cwd sentinel.
+
+        The Gemini injector requests a temp-dir cwd so it can pick up its
+        generated project-scoped settings file, but a caller-configured
+        CliLLM.cwd is an isolation boundary and must not be silently
+        overridden by injector plumbing.
+        """
+        _, mock_run, _ = self._run_node_with_mocks(
+            cwd="/tmp/gemini_work", llm_cwd="/fixed/workspace"
+        )
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs.get("cwd") == "/fixed/workspace"
+
+    def test_no_cwd_configured_leaves_subprocess_cwd_none(self):
+        """With no configured cwd and no injector sentinel, cwd stays None.
+
+        None means the subprocess inherits the calling process's cwd,
+        matching subprocess.run's own default and the direct CLI execution
+        path's default.
+        """
+        _, mock_run, _ = self._run_node_with_mocks()
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs.get("cwd") is None
 
     def test_nonzero_exit_raises_cli_error(self):
         from bili.iris.providers.cli_provider import CliLLMError


### PR DESCRIPTION
## Summary

A configured CLI subprocess working directory (`CliLLM.cwd`, set via the `cli_subprocess_cwd` agent field, #234) was applied only on the direct execution path (`CliLLM._run_subprocess`). The MCP tool-strategy path (`build_mcp_node`, used by `tool_strategy: "mcp"` CLI providers such as the claude-code and codex catalog entries) never read this attribute, so those providers always spawned with `cwd=None` and silently inherited the calling process's working directory instead of the configured one.

Root cause: `build_mcp_node` derived the subprocess `cwd` solely from a private cwd sentinel used internally by the Gemini CLI injector (which needs a temp directory containing its generated project-scoped MCP settings file). Providers without that sentinel (claude, codex) had no path by which a configured `.cwd` could reach the subprocess call.

## Fix

`build_mcp_node` now captures `getattr(llm_model, "cwd", None)` at construction time and resolves the subprocess working directory with this precedence:

1. **`llm_model.cwd`, if set** — a caller-controlled isolation boundary (e.g. pinning the CLI subprocess to a fixed directory rather than letting it inherit the caller's cwd). Always wins.
2. **The injector's own cwd sentinel**, if present (Gemini's temp-dir requirement for its settings file) — used only when no explicit `.cwd` is configured.
3. **`None`** — the subprocess inherits the calling process's cwd, matching `subprocess.run`'s default and the direct `_run_subprocess` path's default when nothing is configured.

This is a generic reliability/isolation fix: any consumer that pins a CLI subprocess's working directory to isolate the agent from the caller's directory now gets that isolation honored consistently across both the direct and MCP tool-strategy execution paths.

## Test plan

- [x] New regression tests in `bili/iris/mcp/tests/test_server.py::TestBuildMcpNode`:
  - `test_configured_llm_cwd_forwarded_to_subprocess` — a configured `CliLLM.cwd` reaches the MCP subprocess spawn (the gap this PR closes; the existing `test_create_llm_cli_subprocess_cwd_forwarded` only covered the resolver → `CliLLM` forward, not this spawn point).
  - `test_configured_llm_cwd_takes_precedence_over_gemini_sentinel` — an explicit `.cwd` wins over the Gemini injector's sentinel.
  - `test_no_cwd_configured_leaves_subprocess_cwd_none` — unchanged default behavior when nothing is configured.
- [x] Full suite: `pytest bili/ --cov=bili --cov-report=json:coverage.json -q` → 4152 passed, 1 skipped.
- [x] Per-file coverage gate: `python scripts/check_coverage.py` → PASS, all 218 runtime files >= 90% (`bili/iris/mcp/server.py` at 100%).
- [x] `pylint bili/iris/mcp/server.py bili/iris/mcp/tests/test_server.py --fail-under=9` → 9.89/10 (pre-existing findings only, none introduced by this diff).
- [x] Pre-commit hooks (black/autoflake/isort/pylint) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)