### PR TITLE
feat: model + reasoning-effort knobs for the CLI subprocess provider

### DIFF
--- a/bili/aether/compiler/llm_resolver.py
+++ b/bili/aether/compiler/llm_resolver.py
@@ -154,6 +154,46 @@ def resolve_provider(model_name: str) -> str:
     return provider
 
 
+def _forward_cli_subprocess_kwargs(
+    agent: AgentSpec, provider: str, kwargs: Dict[str, Any]
+) -> None:
+    """Forward ``AgentSpec.cli_subprocess_*`` fields into *kwargs* for CLI providers.
+
+    Mutates *kwargs* in place.  A no-op entirely when *provider* is not a CLI
+    subprocess type -- passing these kwargs to an API provider's loader would
+    raise an unexpected-keyword-argument error, since those loader functions
+    have explicit signatures without ``**kwargs``.
+
+    :param agent: The ``AgentSpec`` whose ``cli_subprocess_*`` fields may be set.
+    :param provider: The resolved provider type string (e.g. ``"cli_claude_code"``).
+    :param kwargs: The in-progress ``load_model`` kwargs dict; updated in place.
+    """
+    if not provider.startswith("cli"):
+        return
+
+    if agent.cli_subprocess_timeout is not None:
+        # 0 is the user's signal for "no timeout" (matches the ge=0 constraint
+        # on the field).  Translate it to None so subprocess.run receives
+        # timeout=None rather than timeout=0 (which would expire immediately).
+        raw = agent.cli_subprocess_timeout
+        kwargs["timeout_seconds"] = None if raw == 0.0 else raw
+
+    if agent.cli_subprocess_cwd is not None:
+        kwargs["cwd"] = agent.cli_subprocess_cwd
+
+    if agent.cli_subprocess_max_retries is not None:
+        kwargs["max_retries"] = agent.cli_subprocess_max_retries
+
+    if agent.cli_subprocess_retry_backoff is not None:
+        kwargs["retry_backoff_seconds"] = agent.cli_subprocess_retry_backoff
+
+    if agent.cli_subprocess_model is not None:
+        kwargs["model"] = agent.cli_subprocess_model
+
+    if agent.cli_subprocess_reasoning_effort is not None:
+        kwargs["reasoning_effort"] = agent.cli_subprocess_reasoning_effort
+
+
 def create_llm(agent: AgentSpec) -> Any:
     """Create a LangChain-compatible chat model from an ``AgentSpec``.
 
@@ -204,28 +244,10 @@ def create_llm(agent: AgentSpec) -> Any:
     if agent.max_tokens is not None:
         kwargs["max_tokens"] = agent.max_tokens
 
-    # Forward cli_subprocess_timeout to CLI providers only.  Passing it to API
-    # providers would raise an unexpected-keyword-argument error because those
-    # loader functions have explicit signatures without **kwargs.
-    if agent.cli_subprocess_timeout is not None and provider.startswith("cli"):
-        # 0 is the user's signal for "no timeout" (matches the ge=0 constraint
-        # on the field).  Translate it to None so subprocess.run receives
-        # timeout=None rather than timeout=0 (which would expire immediately).
-        raw = agent.cli_subprocess_timeout
-        kwargs["timeout_seconds"] = None if raw == 0.0 else raw
-
-    # Forward cli_subprocess_cwd to CLI providers only, for the same reason
-    # as cli_subprocess_timeout above.
-    if agent.cli_subprocess_cwd is not None and provider.startswith("cli"):
-        kwargs["cwd"] = agent.cli_subprocess_cwd
-
-    # Forward cli_subprocess_max_retries / cli_subprocess_retry_backoff to
-    # CLI providers only, for the same reason as cli_subprocess_timeout above.
-    if agent.cli_subprocess_max_retries is not None and provider.startswith("cli"):
-        kwargs["max_retries"] = agent.cli_subprocess_max_retries
-
-    if agent.cli_subprocess_retry_backoff is not None and provider.startswith("cli"):
-        kwargs["retry_backoff_seconds"] = agent.cli_subprocess_retry_backoff
+    # Forward cli_subprocess_* fields (timeout, cwd, retry policy, model,
+    # reasoning effort) to CLI providers only; see
+    # _forward_cli_subprocess_kwargs for the per-field detail.
+    _forward_cli_subprocess_kwargs(agent, provider, kwargs)
 
     LOGGER.info(
         "Creating LLM for agent '%s': provider=%s, model_id=%s",

--- a/bili/aether/schema/agent_spec.py
+++ b/bili/aether/schema/agent_spec.py
@@ -182,6 +182,48 @@ class AgentSpec(BaseModel):
         ),
     )
 
+    cli_subprocess_model: Optional[str] = Field(
+        None,
+        description=(
+            "Model name/ID to pass to a CLI-backed provider's subprocess "
+            "(provider types 'cli', 'cli_claude_code', 'cli_codex', "
+            "'cli_gemini_cli', and any custom CLI preset), pinning a "
+            "specific model instead of whatever the CLI tool's own global "
+            "default or interactive session would otherwise use.  Applied "
+            "via the preset's configured model-selection flag (e.g. "
+            "'--model <value>' for all three built-in presets).  Leave "
+            "unset (the default) to inherit the CLI's own default model -- "
+            "today's behaviour, unchanged.  Only applies to agents whose "
+            "resolved provider is a CLI subprocess type; ignored for API "
+            "providers."
+        ),
+    )
+
+    cli_subprocess_reasoning_effort: Optional[str] = Field(
+        None,
+        description=(
+            "Reasoning-effort / thinking-budget level to pass to a "
+            "CLI-backed provider's subprocess (provider types 'cli', "
+            "'cli_claude_code', 'cli_codex', 'cli_gemini_cli', and any "
+            "custom CLI preset), pinning a specific reasoning depth instead "
+            "of whatever the CLI tool's own default would otherwise use -- "
+            "useful for capping a heavy default reasoner on a mechanical "
+            "role, or forcing deeper reasoning for a hard one.  The "
+            "accepted values and the mechanism used to apply them are "
+            "CLI-specific: Claude Code accepts an effort level (e.g. "
+            "'low', 'medium', 'high', 'xhigh', 'max') via its '--effort' "
+            "flag; Codex accepts an effort level (e.g. 'low', 'medium', "
+            "'high', 'xhigh') via a '-c model_reasoning_effort=' config "
+            "override.  The Gemini CLI has no CLI-settable reasoning-"
+            "effort / thinking-budget control in headless mode, so this "
+            "setting is a documented no-op (a warning is logged) for the "
+            "'cli_gemini_cli' preset.  Leave unset (the default) to "
+            "inherit the CLI's own default reasoning depth -- today's "
+            "behaviour, unchanged.  Only applies to agents whose resolved "
+            "provider is a CLI subprocess type; ignored for API providers."
+        ),
+    )
+
     # =========================================================================
     # CAPABILITIES & TOOLS
     # =========================================================================

--- a/bili/aether/tests/test_compiler_coverage.py
+++ b/bili/aether/tests/test_compiler_coverage.py
@@ -551,6 +551,146 @@ class TestCreateLlm:
         kwargs = fake_load_model.call_args[1]
         assert "retry_backoff_seconds" not in kwargs
 
+    def test_create_llm_cli_subprocess_model_forwarded(self):
+        """cli_subprocess_model is forwarded to load_model as 'model' for
+        CLI providers."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        agent = _agent(
+            "cli_agent_model",
+            model_name="cli:my-tool",
+            cli_subprocess_model="claude-sonnet-5",
+        )
+
+        fake_load_model = MagicMock(return_value="CLI_LLM")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert kwargs["model"] == "claude-sonnet-5"
+
+    def test_create_llm_cli_model_not_forwarded_to_api_provider(self):
+        """cli_subprocess_model is NOT forwarded when the provider is not a
+        CLI type."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        # gpt-4o resolves to "remote_openai", not a CLI provider
+        agent = _agent(
+            "api_agent_model", model_name="gpt-4o", cli_subprocess_model="gpt-5"
+        )
+
+        fake_load_model = MagicMock(return_value="API_LLM")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert "model" not in kwargs
+
+    def test_create_llm_cli_model_none_not_forwarded(self):
+        """When cli_subprocess_model is None (default), model is not added --
+        the CLI provider uses its preset default (the CLI's own default
+        model)."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        agent = _agent("cli_default_model", model_name="cli:my-tool")
+        # cli_subprocess_model defaults to None
+
+        fake_load_model = MagicMock(return_value="CLI_LLM")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert "model" not in kwargs
+
+    def test_create_llm_cli_subprocess_reasoning_effort_forwarded(self):
+        """cli_subprocess_reasoning_effort is forwarded to load_model as
+        'reasoning_effort' for CLI providers."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        agent = _agent(
+            "cli_agent_effort",
+            model_name="cli:my-tool",
+            cli_subprocess_reasoning_effort="high",
+        )
+
+        fake_load_model = MagicMock(return_value="CLI_LLM")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert kwargs["reasoning_effort"] == "high"
+
+    def test_create_llm_cli_reasoning_effort_not_forwarded_to_api_provider(self):
+        """cli_subprocess_reasoning_effort is NOT forwarded when the provider
+        is not a CLI type."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        # gpt-4o resolves to "remote_openai", not a CLI provider
+        agent = _agent(
+            "api_agent_effort",
+            model_name="gpt-4o",
+            cli_subprocess_reasoning_effort="high",
+        )
+
+        fake_load_model = MagicMock(return_value="API_LLM")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert "reasoning_effort" not in kwargs
+
+    def test_create_llm_cli_reasoning_effort_none_not_forwarded(self):
+        """When cli_subprocess_reasoning_effort is None (default),
+        reasoning_effort is not added -- the CLI provider uses its preset
+        default (the CLI's own default reasoning depth)."""
+        from bili.aether.compiler import (  # pylint: disable=import-outside-toplevel
+            llm_resolver,
+        )
+
+        agent = _agent("cli_default_effort", model_name="cli:my-tool")
+        # cli_subprocess_reasoning_effort defaults to None
+
+        fake_load_model = MagicMock(return_value="CLI_LLM")
+        fake_loader = types.ModuleType("bili.iris.loaders.llm_loader")
+        fake_loader.load_model = fake_load_model
+
+        with patch("bili.iris.config.llm_config.LLM_MODELS", {}):
+            with patch.dict(sys.modules, {"bili.iris.loaders.llm_loader": fake_loader}):
+                llm_resolver.create_llm(agent)
+
+        kwargs = fake_load_model.call_args[1]
+        assert "reasoning_effort" not in kwargs
+
 
 class TestResolveProvider:
     """Tests for resolve_provider() and the LLM_MODELS ImportError path."""

--- a/bili/iris/mcp/server.py
+++ b/bili/iris/mcp/server.py
@@ -591,18 +591,44 @@ def build_mcp_node(
        matching ``subprocess.run``'s own default and the direct
        (:meth:`CliLLM._run_subprocess`) CLI execution path's default.
 
+    Model / reasoning-effort flags
+    -------------------------------
+    ``llm_model.model`` and ``llm_model.reasoning_effort``, if set, are
+    rendered into argv tokens (via ``llm_model.model_flag_template`` /
+    ``llm_model.reasoning_effort_flag_template`` -- see
+    :func:`~bili.iris.providers.cli_model_flags.build_model_and_effort_args`)
+    and appended to the *base* command **before** the injector adds its own
+    MCP-related flags.  This mirrors the direct
+    (:meth:`~bili.iris.providers.cli_provider.CliLLM._run_subprocess`) CLI
+    execution path exactly, so a configured model or reasoning effort
+    reaches the spawned CLI on both the tool-less and MCP tool-strategy
+    paths.  A value configured with no corresponding flag template for the
+    target CLI is a documented no-op (see
+    :func:`~bili.iris.providers.cli_model_flags.build_model_and_effort_args`).
+
     :param llm_model: A :class:`~bili.iris.providers.cli_provider.CliLLM`
         instance (provides ``command``, ``message_format``, ``output_format``,
-        ``json_path``, ``strip_ansi_output``, ``timeout_seconds``, and
-        ``cwd``).
+        ``json_path``, ``strip_ansi_output``, ``timeout_seconds``, ``cwd``,
+        ``model``, ``reasoning_effort``, ``model_flag_template``, and
+        ``reasoning_effort_flag_template``).
     :param tools: LangChain tools to expose as MCP tools.
     :param injector: A CLI injector from :mod:`bili.iris.mcp.cli_injectors`
         (or any object implementing ``inject(handle) -> InjectionResult``).
     :returns: A ``(state: dict) -> dict`` callable.
     :raises ImportError: If ``bili-core[mcp]`` is not installed.
     """
+    # Import message rendering from cli_provider at construction time to fail fast
+    # if the package is missing.
+    from bili.iris.providers.cli_model_flags import (  # pylint: disable=import-outside-toplevel
+        build_model_and_effort_args,
+    )
+    from bili.iris.providers.cli_provider import (  # pylint: disable=import-outside-toplevel
+        CliLLMError,
+        render_messages,
+    )
+
     # Capture the CliLLM configuration at construction time.
-    command: List[str] = list(llm_model.command)
+    base_command: List[str] = list(llm_model.command)
     message_format: str = getattr(llm_model, "message_format", "last")
     output_format: str = getattr(llm_model, "output_format", "text")
     json_path: str = getattr(llm_model, "json_path", "content")
@@ -610,11 +636,15 @@ def build_mcp_node(
     timeout_seconds: float = getattr(llm_model, "timeout_seconds", 120.0)
     configured_cwd: Optional[str] = getattr(llm_model, "cwd", None)
 
-    # Import message rendering from cli_provider at construction time to fail fast
-    # if the package is missing.
-    from bili.iris.providers.cli_provider import (  # pylint: disable=import-outside-toplevel
-        CliLLMError,
-        render_messages,
+    # Apply any configured model / reasoning-effort flags to the base command
+    # -- same helper, same precedence as the direct _run_subprocess path --
+    # before the injector appends its own MCP-related flags below.
+    command: List[str] = base_command + build_model_and_effort_args(
+        getattr(llm_model, "model", None),
+        getattr(llm_model, "model_flag_template", None),
+        getattr(llm_model, "reasoning_effort", None),
+        getattr(llm_model, "reasoning_effort_flag_template", None),
+        cli_name=base_command[0] if base_command else "",
     )
 
     def _node(state: Dict) -> Dict:  # pylint: disable=too-many-locals

--- a/bili/iris/mcp/tests/test_server.py
+++ b/bili/iris/mcp/tests/test_server.py
@@ -623,7 +623,15 @@ class TestParseOutput:
 class TestBuildMcpNode:
     """Tests for the build_mcp_node factory and the node callable it returns."""
 
-    def _make_cli_llm(self, command=None, cwd=None):
+    def _make_cli_llm(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        command=None,
+        cwd=None,
+        model=None,
+        reasoning_effort=None,
+        model_flag_template=None,
+        reasoning_effort_flag_template=None,
+    ):
         llm = MagicMock()
         llm.command = command or ["claude", "-p"]
         llm.message_format = "last"
@@ -632,6 +640,10 @@ class TestBuildMcpNode:
         llm.strip_ansi_output = False
         llm.timeout_seconds = 30.0
         llm.cwd = cwd
+        llm.model = model
+        llm.reasoning_effort = reasoning_effort
+        llm.model_flag_template = model_flag_template
+        llm.reasoning_effort_flag_template = reasoning_effort_flag_template
         return llm
 
     def _make_injector(self, extra_env=None, cleanup=None, cwd=None):
@@ -662,6 +674,10 @@ class TestBuildMcpNode:
         extra_env=None,
         cwd=None,
         llm_cwd=None,
+        model=None,
+        reasoning_effort=None,
+        model_flag_template=None,
+        reasoning_effort_flag_template=None,
     ):
         """Patch EphemeralMcpServer and subprocess to run the node callable.
 
@@ -669,9 +685,22 @@ class TestBuildMcpNode:
             temp-dir cwd requirement), forwarded via the injector's extra env.
         :param llm_cwd: The CliLLM's own configured ``cwd`` attribute --
             simulates a caller-configured subprocess working directory.
+        :param model: The CliLLM's own configured ``model`` attribute.
+        :param reasoning_effort: The CliLLM's own configured
+            ``reasoning_effort`` attribute.
+        :param model_flag_template: The CliLLM's own configured
+            ``model_flag_template`` attribute.
+        :param reasoning_effort_flag_template: The CliLLM's own configured
+            ``reasoning_effort_flag_template`` attribute.
         """
         tool = tool or _make_plain_tool()
-        llm = self._make_cli_llm(cwd=llm_cwd)
+        llm = self._make_cli_llm(
+            cwd=llm_cwd,
+            model=model,
+            reasoning_effort=reasoning_effort,
+            model_flag_template=model_flag_template,
+            reasoning_effort_flag_template=reasoning_effort_flag_template,
+        )
         injector = injector or self._make_injector(extra_env=extra_env, cwd=cwd)
 
         node = build_mcp_node(llm_model=llm, tools=[tool], injector=injector)
@@ -790,6 +819,100 @@ class TestBuildMcpNode:
         _, mock_run, _ = self._run_node_with_mocks()
         call_kwargs = mock_run.call_args[1]
         assert call_kwargs.get("cwd") is None
+
+    def test_configured_model_reaches_injector_command(self):
+        """A CliLLM.model configured on the model must reach the base command
+        handed to the injector, before MCP flags are appended.
+
+        Regression coverage for the same dual-path gotcha the cwd fix (#236)
+        had: model/reasoning-effort flags must be applied on the MCP
+        tool-strategy path (build_mcp_node), not only on the direct
+        _run_subprocess path.
+        """
+        _, _, injector = self._run_node_with_mocks(
+            model="claude-sonnet-5",
+            model_flag_template=["--model", "{value}"],
+        )
+        call_kwargs = injector.inject.call_args.kwargs
+        assert call_kwargs["command"] == ["claude", "-p", "--model", "claude-sonnet-5"]
+
+    def test_configured_reasoning_effort_reaches_injector_command(self):
+        """A CliLLM.reasoning_effort configured on the model must reach the
+        base command handed to the injector, before MCP flags are appended."""
+        _, _, injector = self._run_node_with_mocks(
+            reasoning_effort="high",
+            reasoning_effort_flag_template=["--effort", "{value}"],
+        )
+        call_kwargs = injector.inject.call_args.kwargs
+        assert call_kwargs["command"] == ["claude", "-p", "--effort", "high"]
+
+    def test_configured_model_and_reasoning_effort_both_reach_injector_command(self):
+        """Both model and reasoning_effort flags reach the injector's base
+        command, model first, matching the direct-path ordering."""
+        _, _, injector = self._run_node_with_mocks(
+            model="claude-sonnet-5",
+            model_flag_template=["--model", "{value}"],
+            reasoning_effort="high",
+            reasoning_effort_flag_template=["--effort", "{value}"],
+        )
+        call_kwargs = injector.inject.call_args.kwargs
+        assert call_kwargs["command"] == [
+            "claude",
+            "-p",
+            "--model",
+            "claude-sonnet-5",
+            "--effort",
+            "high",
+        ]
+
+    def test_no_model_or_reasoning_effort_configured_leaves_command_unchanged(self):
+        """With neither model nor reasoning_effort set, the base command
+        handed to the injector is unchanged -- today's behaviour, unchanged."""
+        _, _, injector = self._run_node_with_mocks()
+        call_kwargs = injector.inject.call_args.kwargs
+        assert call_kwargs["command"] == ["claude", "-p"]
+
+    def test_model_set_with_no_template_omits_flag_on_mcp_path(self):
+        """model set with model_flag_template=None is a documented no-op on
+        the MCP path too: no extra flag is added to the injector's command."""
+        _, _, injector = self._run_node_with_mocks(
+            model="claude-sonnet-5", model_flag_template=None
+        )
+        call_kwargs = injector.inject.call_args.kwargs
+        assert call_kwargs["command"] == ["claude", "-p"]
+
+    def test_configured_model_flags_reach_final_subprocess_command_when_injector_passthrough(
+        self,
+    ):
+        """End-to-end: when the injector passes the base command through
+        unchanged (appending only its own flags), the final subprocess.run
+        call carries the configured model flags too."""
+        from bili.iris.mcp.cli_injectors import InjectionResult
+
+        def _passthrough_inject(command, handle):  # pylint: disable=unused-argument
+            return InjectionResult(
+                augmented_command=list(command) + ["--mcp-config", "/tmp/x.json"],
+                extra_env={},
+                cleanup=None,
+            )
+
+        injector = MagicMock()
+        injector.inject.side_effect = _passthrough_inject
+
+        _, mock_run, _ = self._run_node_with_mocks(
+            injector=injector,
+            model="claude-sonnet-5",
+            model_flag_template=["--model", "{value}"],
+        )
+        called_cmd = mock_run.call_args[0][0]
+        assert called_cmd == [
+            "claude",
+            "-p",
+            "--model",
+            "claude-sonnet-5",
+            "--mcp-config",
+            "/tmp/x.json",
+        ]
 
     def test_nonzero_exit_raises_cli_error(self):
         from bili.iris.providers.cli_provider import CliLLMError

--- a/bili/iris/providers/cli_model_flags.py
+++ b/bili/iris/providers/cli_model_flags.py
@@ -1,0 +1,130 @@
+"""Model / reasoning-effort argv-templating for CLI-backed LLM providers.
+
+Extracted from :mod:`bili.iris.providers.cli_provider` into its own module so
+the same templating logic can be shared, without duplication, by both CLI
+subprocess execution paths in bili-core:
+
+- The direct path: :meth:`~bili.iris.providers.cli_provider.CliLLM._build_run_args`.
+- The MCP tool-strategy path: :func:`~bili.iris.mcp.server.build_mcp_node`.
+
+Without any further configuration, a CLI subprocess uses whatever model and
+reasoning depth the CLI tool's own global default or interactive session is
+set to.  For a consumer that wants a specific, cost-controlled model for a
+given role -- or wants to avoid a heavy default reasoner turning a single
+mechanical call into a multi-minute wait -- ``model`` and ``reasoning_effort``
+settings (declared on
+:class:`~bili.iris.providers.cli_provider.CliLLM`) pin both explicitly:
+
+``model``
+    The model name/ID to pass to the CLI.  Applied via ``model_flag_template``
+    (default ``("--model", "{value}")``, the near-universal convention across
+    CLI LLM tools).
+
+``reasoning_effort``
+    The reasoning-effort / thinking-budget level to pass to the CLI (the
+    accepted vocabulary -- e.g. ``"low"``/``"medium"``/``"high"``/``"max"`` --
+    is defined by the target CLI, not by bili-core).  Applied via
+    ``reasoning_effort_flag_template``, which has no generic default because
+    there is no cross-CLI convention for this control.  Named presets that
+    know a specific CLI's flag syntax (see
+    :mod:`bili.iris.providers.cli_presets`) configure this template; CLIs
+    with no CLI-settable reasoning-effort control leave it ``None``, which is
+    a documented no-op (a warning is logged and the setting is dropped).
+
+Both settings default to ``None`` (no flag added -- unconfigured behaviour is
+unchanged).
+"""
+
+import logging
+from typing import List, Optional, Sequence, Tuple
+
+LOGGER = logging.getLogger(__name__)
+
+#: Default argv template used to pass a ``model`` override to a CLI tool when
+#: the caller sets ``model`` but does not override ``model_flag_template``.
+#: ``--model <value>`` is the near-universal convention across CLI LLM tools
+#: (Claude Code, Codex, Gemini CLI, and most others), so it is a safe default
+#: for the generic (non-preset)
+#: :class:`~bili.iris.providers.cli_provider.CliProvider` path.  Pass
+#: ``model_flag_template=None`` to disable model-flag injection entirely
+#: (e.g. when the model is already baked into ``command``).
+DEFAULT_MODEL_FLAG_TEMPLATE: Tuple[str, ...] = ("--model", "{value}")
+
+
+def build_model_and_effort_args(
+    model: Optional[str],
+    model_flag_template: Optional[Sequence[str]],
+    reasoning_effort: Optional[str],
+    reasoning_effort_flag_template: Optional[Sequence[str]],
+    cli_name: str = "",
+) -> List[str]:
+    """Return extra argv tokens for a configured model and/or reasoning effort.
+
+    Each ``*_flag_template`` is a sequence of argv tokens in which the literal
+    substring ``"{value}"`` is replaced by the corresponding value -- e.g.
+    ``["--model", "{value}"]`` renders to ``["--model", "gpt-5"]``, and
+    ``["-c", 'model_reasoning_effort="{value}"']`` renders to
+    ``["-c", 'model_reasoning_effort="high"']``.  This lets each CLI preset
+    describe its own flag syntax (a plain ``--flag value`` pair, a combined
+    ``-c key=value`` config override, or anything else expressible as argv
+    tokens) without any CLI-specific branching in the caller -- the same
+    templating is reused by both the direct subprocess path
+    (:meth:`~bili.iris.providers.cli_provider.CliLLM._build_run_args`) and the
+    MCP tool-strategy path (:func:`~bili.iris.mcp.server.build_mcp_node`).
+
+    A configured value with no corresponding template is a documented no-op:
+    a warning is logged and the setting is dropped rather than guessing at a
+    flag the target CLI may not support.  This is the "no CLI-settable
+    control" case -- e.g. the Gemini CLI has no headless-mode flag for its
+    thinking-budget setting, so ``reasoning_effort`` is accepted on that
+    preset but has no effect.
+
+    :param model: The model name/ID to pass to the CLI, or ``None``.
+    :param model_flag_template: Argv template for *model*, or ``None`` if
+        this CLI has no configured model-selection flag.
+    :param reasoning_effort: The reasoning-effort / thinking-budget value to
+        pass to the CLI, or ``None``.
+    :param reasoning_effort_flag_template: Argv template for
+        *reasoning_effort*, or ``None`` if this CLI has no known
+        CLI-settable reasoning-effort / thinking-budget control.
+    :param cli_name: The CLI executable name, used only in the warning
+        message logged when a value is configured but has no template.
+    :returns: A list of extra argv tokens to append to the base command
+        (empty if neither *model* nor *reasoning_effort* is set).
+    """
+    extra: List[str] = []
+
+    if model:
+        if model_flag_template:
+            extra.extend(part.format(value=model) for part in model_flag_template)
+        else:
+            LOGGER.warning(
+                "CliLLM: model=%r requested for %r but no model_flag_template "
+                "is configured for this CLI; the override is ignored and the "
+                "CLI's own default model will be used.",
+                model,
+                cli_name or "<cli>",
+            )
+
+    if reasoning_effort:
+        if reasoning_effort_flag_template:
+            extra.extend(
+                part.format(value=reasoning_effort)
+                for part in reasoning_effort_flag_template
+            )
+        else:
+            LOGGER.warning(
+                "CliLLM: reasoning_effort=%r requested for %r but this CLI "
+                "has no known CLI-settable reasoning-effort / "
+                "thinking-budget control; the setting is ignored.",
+                reasoning_effort,
+                cli_name or "<cli>",
+            )
+
+    return extra
+
+
+__all__ = [
+    "DEFAULT_MODEL_FLAG_TEMPLATE",
+    "build_model_and_effort_args",
+]

--- a/bili/iris/providers/cli_presets.py
+++ b/bili/iris/providers/cli_presets.py
@@ -41,6 +41,33 @@ Built-in presets
     Drives ``gemini -p <prompt>`` (Google Gemini CLI) in non-interactive
     headless mode.  Requires the Gemini CLI to be installed and authenticated.
 
+Per-CLI model / reasoning-effort support
+-----------------------------------------
+Each preset optionally supports pinning the underlying ``model`` and a
+``reasoning_effort`` (reasoning-effort / thinking-budget) value, overriding
+whatever the CLI's own global default or interactive session would
+otherwise use.  Support and mechanism are CLI-specific:
+
+``cli_claude_code``
+    ``model`` via ``--model <value>``.  ``reasoning_effort`` via
+    ``--effort <value>`` (e.g. ``low``/``medium``/``high``/``xhigh``/``max``).
+
+``cli_codex``
+    ``model`` via ``--model <value>``.  ``reasoning_effort`` via
+    ``-c model_reasoning_effort="<value>"`` (e.g.
+    ``low``/``medium``/``high``/``xhigh``).
+
+``cli_gemini_cli``
+    ``model`` via ``--model <value>``.  ``reasoning_effort`` is **not
+    CLI-settable**: the Gemini CLI only exposes a thinking-budget control
+    via ``.gemini/settings.json`` (or interactive ``/think`` / ``/budget``
+    slash commands), not a headless-mode (``-p``) flag or env var.  Setting
+    ``reasoning_effort`` on this preset is a documented no-op -- a warning
+    is logged and the CLI's own default is used.
+
+Both settings default to ``None`` (no override -- the CLI's own default
+model and reasoning depth are used, matching historical behaviour).
+
 Adding custom presets
 ---------------------
 Call :func:`register_cli_preset` at application startup to register an
@@ -60,6 +87,7 @@ additional preset under its own provider-type string:
     )
 """
 
+# pylint: disable=duplicate-code  # CliPreset fields intentionally mirror CliLLM by design
 from dataclasses import dataclass, field
 from typing import List, Optional
 
@@ -123,6 +151,25 @@ class CliPreset:  # pylint: disable=too-many-instance-attributes
         permanent failures always fail on the first attempt.
     :param retry_backoff_seconds: Base delay in seconds before the first
         retry; doubles on each subsequent retry.  Default ``1.0``.
+    :param model: Model name/ID to pass to the CLI, overriding whatever
+        model the CLI's own global default or interactive session would
+        otherwise use.  Default ``None`` (no override).  Applied via
+        ``model_flag_template``.
+    :param reasoning_effort: Reasoning-effort / thinking-budget value to
+        pass to the CLI (the accepted vocabulary is CLI-specific).  Default
+        ``None`` (no override).  Applied via
+        ``reasoning_effort_flag_template``; a value set with no template
+        configured is a documented no-op (a warning is logged).
+    :param model_flag_template: Argv template used to render ``model`` into
+        command-line tokens (``"{value}"`` is replaced by ``model``).
+        Default ``["--model", "{value}"]`` -- the near-universal convention
+        across CLI LLM tools.  Set to ``None`` to disable model-flag
+        injection for this preset.
+    :param reasoning_effort_flag_template: Argv template used to render
+        ``reasoning_effort`` into command-line tokens, analogous to
+        ``model_flag_template``.  Default ``None`` (no known cross-CLI
+        convention); set explicitly for CLIs that support a
+        reasoning-effort control.
     """
 
     command: List[str] = field(default_factory=list)
@@ -135,6 +182,12 @@ class CliPreset:  # pylint: disable=too-many-instance-attributes
     cwd: Optional[str] = None
     max_retries: int = 2
     retry_backoff_seconds: float = 1.0
+    model: Optional[str] = None
+    reasoning_effort: Optional[str] = None
+    model_flag_template: Optional[List[str]] = field(
+        default_factory=lambda: ["--model", "{value}"]
+    )
+    reasoning_effort_flag_template: Optional[List[str]] = None
 
 
 # ---------------------------------------------------------------------------
@@ -148,7 +201,13 @@ class CliPreset:  # pylint: disable=too-many-instance-attributes
 #: subprocess inherits the calling process's environment, so whatever OAuth
 #: session or ``ANTHROPIC_API_KEY`` the CLI holds is reused automatically.
 #:
-#: Reference: ``claude --help`` (look for ``-p, --print``).
+#: ``model`` is applied via ``--model <value>``.  ``reasoning_effort`` is
+#: applied via ``--effort <value>`` (accepted values are defined by the
+#: Claude Code CLI, e.g. ``"low"``/``"medium"``/``"high"``/``"xhigh"``/
+#: ``"max"``).
+#:
+#: Reference: ``claude --help`` (look for ``-p, --print``, ``--model``,
+#: ``--effort``).
 CLAUDE_CODE_PRESET = CliPreset(
     command=["claude", "-p"],
     prompt_via="arg",
@@ -156,6 +215,8 @@ CLAUDE_CODE_PRESET = CliPreset(
     output_format="text",
     strip_ansi=True,
     timeout_seconds=1800.0,
+    model_flag_template=["--model", "{value}"],
+    reasoning_effort_flag_template=["--effort", "{value}"],
 )
 
 #: OpenAI Codex CLI -- ``codex exec <prompt>``
@@ -165,7 +226,12 @@ CLAUDE_CODE_PRESET = CliPreset(
 #: exits.  Requires the Codex CLI to be installed and authenticated via
 #: ``OPENAI_API_KEY`` or its interactive login flow.
 #:
-#: Reference: ``codex --help`` / OpenAI Codex CLI documentation.
+#: ``model`` is applied via ``--model <value>``.  ``reasoning_effort`` is
+#: applied via a ``-c model_reasoning_effort="<value>"`` config override
+#: (accepted values are defined by the Codex CLI, e.g. ``"low"``/
+#: ``"medium"``/``"high"``/``"xhigh"``).
+#:
+#: Reference: ``codex exec --help`` / OpenAI Codex CLI configuration reference.
 CODEX_PRESET = CliPreset(
     command=["codex", "exec"],
     prompt_via="arg",
@@ -173,6 +239,8 @@ CODEX_PRESET = CliPreset(
     output_format="text",
     strip_ansi=True,
     timeout_seconds=1800.0,
+    model_flag_template=["--model", "{value}"],
+    reasoning_effort_flag_template=["-c", 'model_reasoning_effort="{value}"'],
 )
 
 #: Google Gemini CLI -- ``gemini -p <prompt>``
@@ -182,7 +250,15 @@ CODEX_PRESET = CliPreset(
 #: the process exits.  Requires the Gemini CLI to be installed and
 #: authenticated (Google account OAuth or ``GEMINI_API_KEY``).
 #:
-#: Reference: ``gemini --help`` (look for ``-p, --prompt``).
+#: ``model`` is applied via ``--model <value>``.  ``reasoning_effort`` has
+#: **no CLI-settable equivalent** for this preset: the Gemini CLI only
+#: exposes a thinking-budget control via ``.gemini/settings.json`` (or the
+#: interactive ``/think`` / ``/budget`` slash commands), not a headless-mode
+#: flag or environment variable.  Setting ``reasoning_effort`` on this
+#: preset is a documented no-op -- a warning is logged and the CLI's own
+#: default is used.
+#:
+#: Reference: ``gemini --help`` (look for ``-p, --prompt``, ``--model``).
 GEMINI_CLI_PRESET = CliPreset(
     command=["gemini", "-p"],
     prompt_via="arg",
@@ -190,6 +266,8 @@ GEMINI_CLI_PRESET = CliPreset(
     output_format="text",
     strip_ansi=True,
     timeout_seconds=1800.0,
+    model_flag_template=["--model", "{value}"],
+    reasoning_effort_flag_template=None,
 )
 
 # ---------------------------------------------------------------------------

--- a/bili/iris/providers/cli_provider.py
+++ b/bili/iris/providers/cli_provider.py
@@ -74,6 +74,17 @@ The subprocess inherits the calling process's environment (``os.environ``).
 Whatever credential the CLI tool requires (OAuth session, API key file, etc.)
 must already be present in the environment -- bili-core never touches it.
 
+Model and reasoning-effort selection
+-------------------------------------
+``CliLLM.model`` and ``CliLLM.reasoning_effort`` pin a specific model and
+reasoning depth for the spawned CLI, instead of inheriting whatever the CLI
+tool's own global default or interactive session is set to.  Both default to
+``None`` (no override -- unconfigured behaviour is unchanged).  See
+:mod:`bili.iris.providers.cli_model_flags` for the full rationale and the
+shared argv-templating mechanism used by both this module's direct
+subprocess path and the MCP tool-strategy path
+(:func:`bili.iris.mcp.server.build_mcp_node`).
+
 No new optional dependency is required; the module uses stdlib ``subprocess``
 and ``re`` only.
 """
@@ -85,7 +96,7 @@ import re
 import subprocess
 import tempfile
 import time
-from typing import Any, AsyncIterator, Iterator, List, Optional, Tuple, Union
+from typing import Any, AsyncIterator, Iterator, List, Optional, Sequence, Tuple, Union
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import (
@@ -98,6 +109,7 @@ from langchain_core.messages import (
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 
 from .base import LLMProvider
+from .cli_model_flags import DEFAULT_MODEL_FLAG_TEMPLATE, build_model_and_effort_args
 
 LOGGER = logging.getLogger(__name__)
 
@@ -399,6 +411,31 @@ class CliLLM(BaseChatModel):
         Base delay, in seconds, before the first retry.  Each subsequent
         retry doubles the delay (``retry_backoff_seconds * 2 ** attempt``).
         Default ``1.0``.
+    model : str or None
+        Model name/ID to pass to the CLI, overriding whatever model the
+        CLI's own global default or interactive session would otherwise use.
+        Default ``None`` (no override -- the CLI's own default model is
+        used, matching historical behaviour).  Applied via
+        ``model_flag_template``; see :func:`build_model_and_effort_args`.
+    reasoning_effort : str or None
+        Reasoning-effort / thinking-budget value to pass to the CLI (the
+        accepted vocabulary is CLI-specific, e.g. ``"low"``/``"medium"``/
+        ``"high"``/``"max"``).  Default ``None`` (no override).  Applied via
+        ``reasoning_effort_flag_template``; a value set with no template
+        configured for the target CLI is a documented no-op (a warning is
+        logged).  See :func:`build_model_and_effort_args`.
+    model_flag_template : list[str] or None
+        Argv template used to render ``model`` into command-line tokens (the
+        literal substring ``"{value}"`` is replaced by ``model``).  Default
+        ``["--model", "{value}"]`` -- the near-universal convention across
+        CLI LLM tools.  Set to ``None`` to disable model-flag injection
+        entirely for this CLI.
+    reasoning_effort_flag_template : list[str] or None
+        Argv template used to render ``reasoning_effort`` into command-line
+        tokens, analogous to ``model_flag_template``.  Default ``None`` --
+        there is no cross-CLI convention for this control, so named presets
+        that know a specific CLI's syntax configure this explicitly (see
+        :mod:`bili.iris.providers.cli_presets`).
     """
 
     # ------------------------------------------------------------------
@@ -415,6 +452,10 @@ class CliLLM(BaseChatModel):
     cwd: Optional[str] = None
     max_retries: int = 2
     retry_backoff_seconds: float = 1.0
+    model: Optional[str] = None
+    reasoning_effort: Optional[str] = None
+    model_flag_template: Optional[List[str]] = list(DEFAULT_MODEL_FLAG_TEMPLATE)
+    reasoning_effort_flag_template: Optional[List[str]] = None
 
     # ------------------------------------------------------------------
     # BaseChatModel required property
@@ -433,12 +474,24 @@ class CliLLM(BaseChatModel):
     ) -> Tuple[List[str], Optional[str], Optional[str]]:
         """Return ``(cmd, stdin_text, tmp_file_path)`` for the subprocess call.
 
+        The base command is ``self.command`` with any configured ``model`` /
+        ``reasoning_effort`` flags appended (see
+        :func:`build_model_and_effort_args`), before the prompt itself is
+        added according to ``prompt_via``.
+
         The caller is responsible for cleaning up ``tmp_file_path`` if set.
         """
+        base_command = list(self.command) + build_model_and_effort_args(
+            self.model,
+            self.model_flag_template,
+            self.reasoning_effort,
+            self.reasoning_effort_flag_template,
+            cli_name=self.command[0] if self.command else "",
+        )
         if self.prompt_via == "stdin":
-            return list(self.command), prompt, None
+            return base_command, prompt, None
         if self.prompt_via == "arg":
-            return list(self.command) + [prompt], None, None
+            return base_command + [prompt], None, None
         # "file"
         # Write to a temp file and pass the path as an extra arg
         with tempfile.NamedTemporaryFile(
@@ -449,7 +502,7 @@ class CliLLM(BaseChatModel):
         ) as tmp:
             tmp.write(prompt)
             tmp_path = tmp.name
-        return list(self.command) + [tmp_path], None, tmp_path
+        return base_command + [tmp_path], None, tmp_path
 
     def _run_subprocess(self, prompt: str) -> str:
         """Execute the CLI with *prompt*, retrying transient failures.
@@ -700,6 +753,34 @@ class CliProvider(LLMProvider):
     retry_backoff_seconds : float, optional
         Base delay, in seconds, before the first retry; doubles on each
         subsequent retry.  Default ``1.0``.
+
+    model : str or None, optional
+        Model name/ID to pass to the CLI, overriding whatever model the
+        CLI's own global default or interactive session would otherwise use.
+        Default ``None`` (no override -- today's behaviour, unchanged).
+        Applied via ``model_flag_template``.
+
+    reasoning_effort : str or None, optional
+        Reasoning-effort / thinking-budget value to pass to the CLI (the
+        accepted vocabulary -- e.g. ``"low"``/``"medium"``/``"high"``/
+        ``"max"`` -- is defined by the target CLI).  Default ``None`` (no
+        override).  Applied via ``reasoning_effort_flag_template``; a value
+        set with no template configured for this CLI is a documented no-op
+        (a warning is logged, no flag is added).
+
+    model_flag_template : sequence of str or None, optional
+        Argv template used to render ``model`` into command-line tokens (the
+        literal substring ``"{value}"`` is replaced by ``model``).  Default
+        ``("--model", "{value}")`` -- the near-universal convention across
+        CLI LLM tools.  Pass ``None`` to disable model-flag injection
+        entirely for this CLI.
+
+    reasoning_effort_flag_template : sequence of str or None, optional
+        Argv template used to render ``reasoning_effort`` into command-line
+        tokens, analogous to ``model_flag_template``.  Default ``None`` --
+        there is no cross-CLI convention for this control, so named presets
+        that know a specific CLI's syntax configure this explicitly (see
+        :mod:`bili.iris.providers.cli_presets`).
     """
 
     # The `strip_ansi` parameter intentionally shares its name with the
@@ -707,7 +788,7 @@ class CliProvider(LLMProvider):
     # documented in the class docstring; the module function is an
     # implementation detail.  Pylint sees the parameter as shadowing the
     # outer-scope name, which is benign here.
-    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments,redefined-outer-name
+    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments,too-many-locals,redefined-outer-name
         self,
         command: List[str],
         prompt_via: str = "stdin",
@@ -719,6 +800,10 @@ class CliProvider(LLMProvider):
         cwd: Optional[str] = None,
         max_retries: int = 2,
         retry_backoff_seconds: float = 1.0,
+        model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
+        model_flag_template: Optional[Sequence[str]] = DEFAULT_MODEL_FLAG_TEMPLATE,
+        reasoning_effort_flag_template: Optional[Sequence[str]] = None,
         **_extra: Any,
     ) -> CliLLM:
         """Create and return a :class:`CliLLM` instance.
@@ -742,6 +827,18 @@ class CliProvider(LLMProvider):
             failure, before raising.  ``0`` disables retry.
         :param retry_backoff_seconds: Base delay in seconds before the first
             retry; doubles on each subsequent retry.
+        :param model: Model name/ID to pass to the CLI.  ``None`` (default)
+            inherits the CLI's own default model.
+        :param reasoning_effort: Reasoning-effort / thinking-budget value to
+            pass to the CLI.  ``None`` (default) inherits the CLI's own
+            default reasoning depth.
+        :param model_flag_template: Argv template for *model*.  Default
+            ``("--model", "{value}")``.  Pass ``None`` to disable model-flag
+            injection for this CLI.
+        :param reasoning_effort_flag_template: Argv template for
+            *reasoning_effort*.  Default ``None`` (no known cross-CLI
+            convention); named presets configure this explicitly for CLIs
+            that support a reasoning-effort control.
         :returns: A configured :class:`CliLLM` instance.
         :raises ValueError: If ``command`` is empty, any config value is not
             among the supported options, or ``max_retries``/
@@ -784,6 +881,16 @@ class CliProvider(LLMProvider):
             cwd=cwd,
             max_retries=max_retries,
             retry_backoff_seconds=retry_backoff_seconds,
+            model=model,
+            reasoning_effort=reasoning_effort,
+            model_flag_template=(
+                list(model_flag_template) if model_flag_template is not None else None
+            ),
+            reasoning_effort_flag_template=(
+                list(reasoning_effort_flag_template)
+                if reasoning_effort_flag_template is not None
+                else None
+            ),
         )
         LOGGER.debug(llm)
         return llm

--- a/bili/iris/providers/preset_provider.py
+++ b/bili/iris/providers/preset_provider.py
@@ -80,12 +80,28 @@ class CliPresetProvider(LLMProvider):
             "cwd",
             "max_retries",
             "retry_backoff_seconds",
+            "model",
+            "reasoning_effort",
         ):
             val = overrides.get(field, _UNSET)
             resolved[field] = val if val is not _UNSET else getattr(preset, field)
+
+        # model_flag_template / reasoning_effort_flag_template are list-valued
+        # (like command): copy them when falling back to the preset default so
+        # a caller mutating the returned CliLLM's list in place does not
+        # corrupt the shared preset object.
+        for list_field in ("model_flag_template", "reasoning_effort_flag_template"):
+            val = overrides.get(list_field, _UNSET)
+            if val is not _UNSET:
+                resolved[list_field] = val
+            else:
+                preset_val = getattr(preset, list_field)
+                resolved[list_field] = (
+                    list(preset_val) if preset_val is not None else None
+                )
         return resolved
 
-    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments
+    def load(  # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments,too-many-locals
         self,
         command: Optional[List[str]] = _UNSET,
         prompt_via: Optional[str] = _UNSET,
@@ -97,6 +113,10 @@ class CliPresetProvider(LLMProvider):
         cwd: Optional[str] = _UNSET,
         max_retries: Optional[int] = _UNSET,
         retry_backoff_seconds: Optional[float] = _UNSET,
+        model: Optional[str] = _UNSET,
+        reasoning_effort: Optional[str] = _UNSET,
+        model_flag_template: Optional[List[str]] = _UNSET,
+        reasoning_effort_flag_template: Optional[List[str]] = _UNSET,
         **extra: Any,
     ) -> CliLLM:
         """Create a :class:`~bili.iris.providers.cli_provider.CliLLM` using
@@ -117,6 +137,16 @@ class CliPresetProvider(LLMProvider):
             ``0`` to disable in-process retry entirely.
         :param retry_backoff_seconds: Override the preset's
             ``retry_backoff_seconds``.
+        :param model: Override the preset's ``model``.  Pins the CLI to a
+            specific model instead of inheriting the CLI's own default.
+        :param reasoning_effort: Override the preset's ``reasoning_effort``.
+            Pins the CLI's reasoning depth; a value set with no
+            corresponding flag template configured for this preset is a
+            documented no-op (a warning is logged).
+        :param model_flag_template: Override the preset's
+            ``model_flag_template``.
+        :param reasoning_effort_flag_template: Override the preset's
+            ``reasoning_effort_flag_template``.
         :returns: A configured :class:`~bili.iris.providers.cli_provider.CliLLM`.
         :raises RuntimeError: If the provider was not created via
             :meth:`for_preset` (i.e. ``_preset`` is ``None``).
@@ -138,6 +168,10 @@ class CliPresetProvider(LLMProvider):
                 "cwd": cwd,
                 "max_retries": max_retries,
                 "retry_backoff_seconds": retry_backoff_seconds,
+                "model": model,
+                "reasoning_effort": reasoning_effort,
+                "model_flag_template": model_flag_template,
+                "reasoning_effort_flag_template": reasoning_effort_flag_template,
             }
         )
         LOGGER.info(

--- a/bili/iris/providers/tests/test_cli_presets.py
+++ b/bili/iris/providers/tests/test_cli_presets.py
@@ -84,6 +84,10 @@ class TestCliPreset:
         assert preset.cwd is None
         assert preset.max_retries == 2
         assert preset.retry_backoff_seconds == 1.0
+        assert preset.model is None
+        assert preset.reasoning_effort is None
+        assert preset.model_flag_template == ["--model", "{value}"]
+        assert preset.reasoning_effort_flag_template is None
 
     def test_none_timeout_accepted(self):
         """timeout_seconds=None disables the per-call timeout."""
@@ -103,6 +107,10 @@ class TestCliPreset:
             cwd="/opt/sandbox",
             max_retries=5,
             retry_backoff_seconds=2.5,
+            model="fast-model",
+            reasoning_effort="low",
+            model_flag_template=["-m", "{value}"],
+            reasoning_effort_flag_template=["--reasoning", "{value}"],
         )
         assert preset.command == ["llm", "--fast"]
         assert preset.prompt_via == "stdin"
@@ -114,6 +122,15 @@ class TestCliPreset:
         assert preset.cwd == "/opt/sandbox"
         assert preset.max_retries == 5
         assert preset.retry_backoff_seconds == 2.5
+        assert preset.model == "fast-model"
+        assert preset.reasoning_effort == "low"
+        assert preset.model_flag_template == ["-m", "{value}"]
+        assert preset.reasoning_effort_flag_template == ["--reasoning", "{value}"]
+
+    def test_none_model_flag_template_accepted(self):
+        """model_flag_template=None disables model-flag injection for a preset."""
+        preset = CliPreset(command=["my-tool"], model_flag_template=None)
+        assert preset.model_flag_template is None
 
     def test_dataclass_has_expected_fields(self):
         """CliPreset exposes exactly the fields that CliProvider.load accepts."""
@@ -129,6 +146,10 @@ class TestCliPreset:
             "cwd",
             "max_retries",
             "retry_backoff_seconds",
+            "model",
+            "reasoning_effort",
+            "model_flag_template",
+            "reasoning_effort_flag_template",
         }
         assert expected == field_names
 
@@ -192,6 +213,70 @@ class TestBuiltinPresets:
     def test_gemini_cli_preset_output_format(self):
         """GEMINI_CLI_PRESET uses plain-text output."""
         assert GEMINI_CLI_PRESET.output_format == "text"
+
+
+# ---------------------------------------------------------------------------
+# Built-in preset model / reasoning-effort flag mapping
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinPresetModelAndReasoningEffort:
+    """Verify each built-in preset's model / reasoning-effort flag templates.
+
+    Per-CLI mapping (see cli_presets.py module docstring for the full
+    rationale):
+
+    - claude-code: ``--model <value>`` and ``--effort <value>``.
+    - codex: ``--model <value>`` and ``-c model_reasoning_effort="<value>"``.
+    - gemini-cli: ``--model <value>``; no CLI-settable reasoning-effort
+      control (``reasoning_effort_flag_template`` is ``None``).
+    """
+
+    def test_claude_code_model_flag_template(self):
+        """CLAUDE_CODE_PRESET applies model via '--model <value>'."""
+        assert CLAUDE_CODE_PRESET.model_flag_template == ["--model", "{value}"]
+
+    def test_claude_code_reasoning_effort_flag_template(self):
+        """CLAUDE_CODE_PRESET applies reasoning_effort via '--effort <value>'."""
+        assert CLAUDE_CODE_PRESET.reasoning_effort_flag_template == [
+            "--effort",
+            "{value}",
+        ]
+
+    def test_codex_model_flag_template(self):
+        """CODEX_PRESET applies model via '--model <value>'."""
+        assert CODEX_PRESET.model_flag_template == ["--model", "{value}"]
+
+    def test_codex_reasoning_effort_flag_template(self):
+        """CODEX_PRESET applies reasoning_effort via a '-c' config override."""
+        assert CODEX_PRESET.reasoning_effort_flag_template == [
+            "-c",
+            'model_reasoning_effort="{value}"',
+        ]
+
+    def test_gemini_cli_model_flag_template(self):
+        """GEMINI_CLI_PRESET applies model via '--model <value>'."""
+        assert GEMINI_CLI_PRESET.model_flag_template == ["--model", "{value}"]
+
+    def test_gemini_cli_reasoning_effort_not_cli_settable(self):
+        """GEMINI_CLI_PRESET has no reasoning-effort flag template.
+
+        The Gemini CLI exposes a thinking-budget control only via
+        .gemini/settings.json (or interactive slash commands), not a
+        headless-mode flag -- this preset documents that as an explicit
+        ``None`` template.
+        """
+        assert GEMINI_CLI_PRESET.reasoning_effort_flag_template is None
+
+    def test_all_builtin_presets_default_model_unset(self):
+        """None of the built-in presets pin a model by default."""
+        for preset in (CLAUDE_CODE_PRESET, CODEX_PRESET, GEMINI_CLI_PRESET):
+            assert preset.model is None
+
+    def test_all_builtin_presets_default_reasoning_effort_unset(self):
+        """None of the built-in presets pin a reasoning effort by default."""
+        for preset in (CLAUDE_CODE_PRESET, CODEX_PRESET, GEMINI_CLI_PRESET):
+            assert preset.reasoning_effort is None
 
 
 # ---------------------------------------------------------------------------
@@ -346,6 +431,87 @@ class TestCliPresetProvider:
         klass = CliPresetProvider.for_preset(preset)
         llm = klass().load()
         assert isinstance(llm, CliLLM)
+
+    def test_load_default_model_matches_preset_default(self):
+        """load() with no override falls back to the preset's model (None)."""
+        preset = CliPreset(command=["tool"])
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load()
+        assert llm.model is None
+
+    def test_load_overrides_model(self):
+        """load() accepts a caller-supplied model override."""
+        preset = CliPreset(command=["tool"], model="preset-default-model")
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load(model="caller-model")
+        assert llm.model == "caller-model"
+
+    def test_load_overrides_reasoning_effort(self):
+        """load() accepts a caller-supplied reasoning_effort override."""
+        preset = CliPreset(
+            command=["tool"], reasoning_effort_flag_template=["--effort", "{value}"]
+        )
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load(reasoning_effort="high")
+        assert llm.reasoning_effort == "high"
+
+    def test_load_default_model_flag_template_matches_preset(self):
+        """load() with no override falls back to the preset's model_flag_template."""
+        preset = CliPreset(command=["tool"], model_flag_template=["-m", "{value}"])
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load()
+        assert llm.model_flag_template == ["-m", "{value}"]
+
+    def test_load_default_model_flag_template_is_copied_not_aliased(self):
+        """The preset's model_flag_template list is copied, not shared, so a
+        caller mutating the returned CliLLM's list cannot corrupt the preset."""
+        preset = CliPreset(command=["tool"])
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load()
+        llm.model_flag_template.append("mutated")
+        assert preset.model_flag_template == ["--model", "{value}"]
+
+    def test_load_overrides_model_flag_template(self):
+        """load() accepts a caller-supplied model_flag_template override."""
+        preset = CliPreset(command=["tool"])
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load(model_flag_template=["--use-model", "{value}"])
+        assert llm.model_flag_template == ["--use-model", "{value}"]
+
+    def test_load_none_model_flag_template_disables_injection(self):
+        """Passing model_flag_template=None disables model-flag injection
+        even if the bound preset has one configured."""
+        preset = CliPreset(command=["tool"], model_flag_template=["--model", "{value}"])
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load(model_flag_template=None)
+        assert llm.model_flag_template is None
+
+    def test_load_default_reasoning_effort_flag_template_matches_preset(self):
+        """load() with no override falls back to the preset's
+        reasoning_effort_flag_template."""
+        preset = CliPreset(
+            command=["tool"], reasoning_effort_flag_template=["--effort", "{value}"]
+        )
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load()
+        assert llm.reasoning_effort_flag_template == ["--effort", "{value}"]
+
+    def test_load_default_reasoning_effort_flag_template_is_none_by_default(self):
+        """A preset with no reasoning_effort_flag_template configured yields
+        None on the loaded CliLLM (documented no-op if reasoning_effort is
+        also set)."""
+        preset = CliPreset(command=["tool"])
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load()
+        assert llm.reasoning_effort_flag_template is None
+
+    def test_load_overrides_reasoning_effort_flag_template(self):
+        """load() accepts a caller-supplied reasoning_effort_flag_template
+        override."""
+        preset = CliPreset(command=["tool"])
+        klass = CliPresetProvider.for_preset(preset)
+        llm = klass().load(reasoning_effort_flag_template=["--think", "{value}"])
+        assert llm.reasoning_effort_flag_template == ["--think", "{value}"]
 
 
 # ---------------------------------------------------------------------------
@@ -550,6 +716,90 @@ class TestLoadModelRoundtrip:
             llm = load_model("cli_claude_code")
             with pytest.raises(CliLLMError, match="timed out"):
                 llm.invoke([HumanMessage(content="hello")])
+
+    def test_claude_code_model_and_effort_reach_subprocess_command(self):
+        """model + reasoning_effort overrides reach the spawned claude command."""
+        with patch(
+            "subprocess.run",
+            return_value=_make_completed_proc(stdout="ok"),
+        ) as mock_run:
+            llm = load_model(
+                "cli_claude_code", model="claude-sonnet-5", reasoning_effort="high"
+            )
+            llm.invoke([HumanMessage(content="hello")])
+        cmd: List[str] = mock_run.call_args[0][0]
+        assert cmd == [
+            "claude",
+            "-p",
+            "--model",
+            "claude-sonnet-5",
+            "--effort",
+            "high",
+            "hello",
+        ]
+
+    def test_codex_model_and_effort_reach_subprocess_command(self):
+        """model + reasoning_effort overrides reach the spawned codex command,
+        with reasoning_effort applied via the '-c model_reasoning_effort=' config
+        override."""
+        with patch(
+            "subprocess.run",
+            return_value=_make_completed_proc(stdout="ok"),
+        ) as mock_run:
+            llm = load_model("cli_codex", model="gpt-5-codex", reasoning_effort="low")
+            llm.invoke([HumanMessage(content="hello")])
+        cmd: List[str] = mock_run.call_args[0][0]
+        assert cmd == [
+            "codex",
+            "exec",
+            "--model",
+            "gpt-5-codex",
+            "-c",
+            'model_reasoning_effort="low"',
+            "hello",
+        ]
+
+    def test_gemini_cli_model_reaches_subprocess_command(self):
+        """model override reaches the spawned gemini command."""
+        with patch(
+            "subprocess.run",
+            return_value=_make_completed_proc(stdout="ok"),
+        ) as mock_run:
+            llm = load_model("cli_gemini_cli", model="gemini-3-pro")
+            llm.invoke([HumanMessage(content="hello")])
+        cmd: List[str] = mock_run.call_args[0][0]
+        assert cmd == ["gemini", "-p", "--model", "gemini-3-pro", "hello"]
+
+    def test_gemini_cli_reasoning_effort_is_no_op(self):
+        """reasoning_effort on the gemini preset is a documented no-op: no
+        extra flag is added, and the CLI's own default is used."""
+        with patch(
+            "subprocess.run",
+            return_value=_make_completed_proc(stdout="ok"),
+        ) as mock_run:
+            llm = load_model("cli_gemini_cli", reasoning_effort="high")
+            llm.invoke([HumanMessage(content="hello")])
+        cmd: List[str] = mock_run.call_args[0][0]
+        assert cmd == ["gemini", "-p", "hello"]
+
+    def test_unset_model_and_reasoning_effort_add_no_flags(self):
+        """With neither model nor reasoning_effort set, no extra flags are
+        added -- today's behaviour, unchanged."""
+        for preset_type, expected_prefix in (
+            ("cli_claude_code", ["claude", "-p"]),
+            ("cli_codex", ["codex", "exec"]),
+            ("cli_gemini_cli", ["gemini", "-p"]),
+        ):
+            with patch(
+                "subprocess.run",
+                return_value=_make_completed_proc(stdout="ok"),
+            ) as mock_run:
+                llm = load_model(preset_type)
+                llm.invoke([HumanMessage(content="hello")])
+            cmd: List[str] = mock_run.call_args[0][0]
+            assert cmd == expected_prefix + [
+                "hello"
+            ], f"{preset_type}: expected no extra flags, got cmd={cmd}"
 
 
 # ---------------------------------------------------------------------------

--- a/bili/iris/providers/tests/test_cli_provider.py
+++ b/bili/iris/providers/tests/test_cli_provider.py
@@ -33,10 +33,12 @@ from bili.aether.compiler.llm_resolver import resolve_provider
 from bili.iris.config.llm_config import LLM_MODELS
 from bili.iris.providers.base import KNOWN_PROVIDER_TYPES
 from bili.iris.providers.cli_provider import (
+    DEFAULT_MODEL_FLAG_TEMPLATE,
     CliLLM,
     CliLLMError,
     CliProvider,
     _is_transient_failure,
+    build_model_and_effort_args,
     extract_json_path,
     render_messages,
     strip_ansi,
@@ -233,6 +235,85 @@ class TestExtractJsonPath:
 
 
 # ---------------------------------------------------------------------------
+# build_model_and_effort_args
+# ---------------------------------------------------------------------------
+
+
+class TestBuildModelAndEffortArgs:
+    """Unit tests for the model/reasoning-effort argv-templating helper."""
+
+    def test_no_model_no_effort_returns_empty(self):
+        """Neither model nor reasoning_effort set -> no extra argv tokens."""
+        result = build_model_and_effort_args(None, ["--model", "{value}"], None, None)
+        assert result == []
+
+    def test_model_only_renders_template(self):
+        """A configured model renders its template into argv tokens."""
+        result = build_model_and_effort_args(
+            "gpt-5", ["--model", "{value}"], None, None
+        )
+        assert result == ["--model", "gpt-5"]
+
+    def test_reasoning_effort_only_renders_template(self):
+        """A configured reasoning_effort renders its template into argv tokens."""
+        result = build_model_and_effort_args(
+            None, None, "high", ["--effort", "{value}"]
+        )
+        assert result == ["--effort", "high"]
+
+    def test_both_model_and_effort_render_in_order(self):
+        """Both settings render, model tokens first then reasoning-effort tokens."""
+        result = build_model_and_effort_args(
+            "gpt-5",
+            ["--model", "{value}"],
+            "high",
+            ["--effort", "{value}"],
+        )
+        assert result == ["--model", "gpt-5", "--effort", "high"]
+
+    def test_combined_flag_template_renders_single_token(self):
+        """A template that embeds '{value}' inside a larger token (e.g. a
+        '-c key=value' style config override) renders correctly."""
+        result = build_model_and_effort_args(
+            None, None, "high", ["-c", 'model_reasoning_effort="{value}"']
+        )
+        assert result == ["-c", 'model_reasoning_effort="high"']
+
+    def test_model_set_but_no_template_is_no_op_with_warning(self, caplog):
+        """model set with model_flag_template=None is a documented no-op:
+        no argv tokens are added, and a warning is logged."""
+        with caplog.at_level("WARNING"):
+            result = build_model_and_effort_args(
+                "gpt-5", None, None, None, cli_name="my-cli"
+            )
+        assert result == []
+        assert "model" in caplog.text
+        assert "my-cli" in caplog.text
+
+    def test_reasoning_effort_set_but_no_template_is_no_op_with_warning(self, caplog):
+        """reasoning_effort set with reasoning_effort_flag_template=None is a
+        documented no-op: no argv tokens are added, and a warning is logged."""
+        with caplog.at_level("WARNING"):
+            result = build_model_and_effort_args(
+                None, None, "high", None, cli_name="gemini"
+            )
+        assert result == []
+        assert "reasoning-effort" in caplog.text or "reasoning_effort" in caplog.text
+        assert "gemini" in caplog.text
+
+    def test_no_template_no_op_uses_placeholder_cli_name_when_unset(self, caplog):
+        """When cli_name is not passed, the warning uses a '<cli>' placeholder
+        rather than crashing or logging an empty string."""
+        with caplog.at_level("WARNING"):
+            build_model_and_effort_args("gpt-5", None, None, None)
+        assert "<cli>" in caplog.text
+
+    def test_default_model_flag_template_constant(self):
+        """DEFAULT_MODEL_FLAG_TEMPLATE is the near-universal '--model' convention."""
+        assert DEFAULT_MODEL_FLAG_TEMPLATE == ("--model", "{value}")
+
+
+# ---------------------------------------------------------------------------
 # CliProvider.load validation
 # ---------------------------------------------------------------------------
 
@@ -276,6 +357,10 @@ class TestCliProviderLoad:
         assert llm.cwd is None
         assert llm.max_retries == 2
         assert llm.retry_backoff_seconds == 1.0
+        assert llm.model is None
+        assert llm.reasoning_effort is None
+        assert llm.model_flag_template == ["--model", "{value}"]
+        assert llm.reasoning_effort_flag_template is None
 
     def test_none_timeout_accepted(self):
         """CliProvider.load() accepts timeout_seconds=None to disable the timeout."""
@@ -295,6 +380,10 @@ class TestCliProviderLoad:
             cwd="/opt/sandbox",
             max_retries=5,
             retry_backoff_seconds=2.5,
+            model="fast-model",
+            reasoning_effort="low",
+            model_flag_template=["-m", "{value}"],
+            reasoning_effort_flag_template=["--reasoning", "{value}"],
         )
         assert llm.command == ["my-cli", "--json"]
         assert llm.prompt_via == "arg"
@@ -306,11 +395,28 @@ class TestCliProviderLoad:
         assert llm.cwd == "/opt/sandbox"
         assert llm.max_retries == 5
         assert llm.retry_backoff_seconds == 2.5
+        assert llm.model == "fast-model"
+        assert llm.reasoning_effort == "low"
+        assert llm.model_flag_template == ["-m", "{value}"]
+        assert llm.reasoning_effort_flag_template == ["--reasoning", "{value}"]
 
     def test_custom_cwd_propagated(self):
         """CliProvider.load() forwards a caller-supplied cwd to the CliLLM."""
         llm = CliProvider().load(command=["my-cli"], cwd="/workspace/fixed")
         assert llm.cwd == "/workspace/fixed"
+
+    def test_none_model_flag_template_disables_injection(self):
+        """Passing model_flag_template=None disables model-flag injection."""
+        llm = CliProvider().load(command=["my-cli"], model_flag_template=None)
+        assert llm.model_flag_template is None
+
+    def test_model_flag_template_is_copied_not_aliased(self):
+        """The returned CliLLM's model_flag_template is an independent list,
+        not the same object passed in by the caller."""
+        template = ["--model", "{value}"]
+        llm = CliProvider().load(command=["my-cli"], model_flag_template=template)
+        llm.model_flag_template.append("mutated")
+        assert template == ["--model", "{value}"]
 
     def test_negative_max_retries_raises(self):
         """A negative max_retries raises ValueError."""
@@ -376,6 +482,74 @@ class TestBuildRunArgs:
     def test_command_is_not_mutated(self):
         """_build_run_args does not mutate the CliLLM.command list."""
         llm = _llm(command=["my-llm", "--flag"], prompt_via="arg")
+        original = list(llm.command)
+        llm._build_run_args("prompt")
+        assert llm.command == original
+
+    def test_model_flag_applied_before_prompt(self):
+        """A configured model is inserted between the base command and the
+        prompt argument."""
+        llm = _llm(prompt_via="arg", model="gpt-5")
+        cmd, _, _ = llm._build_run_args("hello")
+        assert cmd == ["echo", "--model", "gpt-5", "hello"]
+
+    def test_reasoning_effort_flag_applied_before_prompt(self):
+        """A configured reasoning_effort is inserted between the base command
+        and the prompt argument, using the configured template."""
+        llm = _llm(
+            prompt_via="arg",
+            reasoning_effort="high",
+            reasoning_effort_flag_template=["--effort", "{value}"],
+        )
+        cmd, _, _ = llm._build_run_args("hello")
+        assert cmd == ["echo", "--effort", "high", "hello"]
+
+    def test_model_and_reasoning_effort_both_applied_in_order(self):
+        """Model flags precede reasoning-effort flags, both before the prompt."""
+        llm = _llm(
+            prompt_via="arg",
+            model="gpt-5",
+            reasoning_effort="high",
+            reasoning_effort_flag_template=["--effort", "{value}"],
+        )
+        cmd, _, _ = llm._build_run_args("hello")
+        assert cmd == ["echo", "--model", "gpt-5", "--effort", "high", "hello"]
+
+    def test_unset_model_and_reasoning_effort_add_no_flags(self):
+        """With neither set, the command is unchanged -- backward compatible."""
+        llm = _llm(prompt_via="arg")
+        cmd, _, _ = llm._build_run_args("hello")
+        assert cmd == ["echo", "hello"]
+
+    def test_model_flag_applied_in_stdin_mode(self):
+        """A configured model is applied to the base command even when the
+        prompt is delivered via stdin (not appended to the argv)."""
+        llm = _llm(prompt_via="stdin", model="gpt-5")
+        cmd, stdin_text, _ = llm._build_run_args("hello")
+        assert cmd == ["echo", "--model", "gpt-5"]
+        assert stdin_text == "hello"
+
+    def test_model_flag_applied_in_file_mode(self):
+        """A configured model is applied to the base command in file mode,
+        before the temp-file path argument."""
+        llm = _llm(prompt_via="file", model="gpt-5")
+        cmd, _, tmp = llm._build_run_args("hello")
+        os.unlink(tmp)
+        assert cmd == ["echo", "--model", "gpt-5", tmp]
+
+    def test_model_set_with_no_template_logs_warning_and_omits_flag(self, caplog):
+        """model set with model_flag_template=None is a documented no-op on
+        the direct path too."""
+        llm = _llm(prompt_via="arg", model="gpt-5", model_flag_template=None)
+        with caplog.at_level("WARNING"):
+            cmd, _, _ = llm._build_run_args("hello")
+        assert cmd == ["echo", "hello"]
+        assert "model" in caplog.text
+
+    def test_command_still_not_mutated_with_model_configured(self):
+        """_build_run_args does not mutate CliLLM.command even when model
+        flags are applied on top of it."""
+        llm = _llm(command=["my-llm", "--flag"], prompt_via="arg", model="gpt-5")
         original = list(llm.command)
         llm._build_run_args("prompt")
         assert llm.command == original
@@ -877,6 +1051,29 @@ class TestInvokeEndToEnd:
         positional_cmd = mock_run.call_args.args[0]
         assert positional_cmd[-1] == "question"
         assert mock_run.call_args.kwargs.get("input") is None
+
+    def test_invoke_applies_configured_model_and_reasoning_effort(self):
+        """A full invoke() call carries the configured model and
+        reasoning_effort flags through to the spawned subprocess command."""
+        llm = _llm(
+            prompt_via="arg",
+            model="gpt-5",
+            reasoning_effort="high",
+            reasoning_effort_flag_template=["--effort", "{value}"],
+        )
+        with patch(
+            "subprocess.run", return_value=_make_completed_proc("answer")
+        ) as mock_run:
+            llm.invoke([_human("question")])
+        positional_cmd = mock_run.call_args.args[0]
+        assert positional_cmd == [
+            "echo",
+            "--model",
+            "gpt-5",
+            "--effort",
+            "high",
+            "question",
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -344,6 +344,22 @@ bili-core process
 
 **Install:** `pip install bili-core[mcp]` (includes both `mcp>=1.0` and `uvicorn>=0.30`)
 
+**Model / reasoning-effort control:** `CliLLM.model` and `CliLLM.reasoning_effort`
+(set via `AgentSpec.cli_subprocess_model` / `cli_subprocess_reasoning_effort` in
+AETHER, or directly on `CliProvider.load()`) pin a specific model and reasoning
+depth for the spawned CLI, instead of inheriting whatever the CLI's own global
+default or interactive session is set to. Applied identically on both the
+direct subprocess path and the ephemeral-MCP path above, via
+`bili.iris.providers.cli_model_flags.build_model_and_effort_args`:
+
+| Preset | `model` flag | `reasoning_effort` flag |
+|--------|-------------|--------------------------|
+| `cli_claude_code` | `--model <value>` | `--effort <value>` (e.g. `low`/`medium`/`high`/`xhigh`/`max`) |
+| `cli_codex` | `--model <value>` | `-c model_reasoning_effort="<value>"` (e.g. `low`/`medium`/`high`/`xhigh`) |
+| `cli_gemini_cli` | `--model <value>` | Not CLI-settable (Gemini exposes thinking-budget only via `.gemini/settings.json` or interactive slash commands); setting it is a documented no-op with a logged warning |
+
+Both settings default to `None` (no override -- unconfigured behaviour is unchanged).
+
 **Extension point:** Register injectors for additional CLIs at startup:
 
 ```python


### PR DESCRIPTION
## Summary

- Adds `model` and `reasoning_effort` config knobs to the CLI subprocess provider stack (`CliLLM` / `CliProvider` / `CliPreset` / `CliPresetProvider`), plus `cli_subprocess_model` / `cli_subprocess_reasoning_effort` fields on `AgentSpec`, following the same pattern as the existing `cli_subprocess_timeout` / `cli_subprocess_cwd` knobs (#233, #234).
- Without this, a consumer configuring a CLI provider has no way to control which model or how much reasoning the spawned CLI agent uses — it always inherits the user's global CLI default, which can make a single agent role take many minutes when the default is a heavy reasoner, or waste budget on a mechanical task that doesn't need deep reasoning.
- Both settings default to `None` (unset = inherit the CLI's own default — fully backward compatible; no flags are added unless explicitly configured).
- Each value is rendered into argv tokens via a per-CLI flag template (new `bili.iris.providers.cli_model_flags.build_model_and_effort_args`), so no CLI-specific branching lives in the execution path:
  - `cli_claude_code`: `--model <value>` / `--effort <value>`
  - `cli_codex`: `--model <value>` / `-c model_reasoning_effort="<value>"`
  - `cli_gemini_cli`: `--model <value>` / `reasoning_effort` has no CLI-settable equivalent in headless mode — documented no-op with a logged warning
- **Critically, applied on BOTH CLI subprocess spawn paths**: the direct path (`CliLLM._build_run_args`) and the MCP tool-strategy path (`build_mcp_node`, used by claude-code/codex agents) — the same dual-path split that hid the `cwd` bug fixed in #236.

## Test plan

- [x] `build_model_and_effort_args` unit tests: model-only, effort-only, both, combined single-token templates, no-template no-op with warning, unset -> no flags.
- [x] `CliLLM`/`CliProvider` tests: field defaults, custom values, `_build_run_args` applies flags in `arg`/`stdin`/`file` modes, full `invoke()` round trip.
- [x] `CliPreset`/`CliPresetProvider` tests: per-preset flag-template defaults (claude/codex/gemini), override + list-aliasing safety, end-to-end `load_model()` round trips asserting the exact spawned command for all three presets (with and without model/effort set).
- [x] **MCP-path regression tests** (`build_mcp_node`): assert the command handed to `injector.inject()` carries the model/effort flags, that unset values leave the command unchanged, that a no-template value is a no-op, and an end-to-end passthrough-injector test confirming the flags reach the final `subprocess.run` call.
- [x] `AgentSpec`/`llm_resolver` forwarding tests: `cli_subprocess_model`/`cli_subprocess_reasoning_effort` forwarded to CLI providers only, not forwarded to API providers, no-op when unset.
- [x] Full suite: `4208 passed, 1 skipped`.
- [x] Per-file coverage gate: `python scripts/check_coverage.py` — PASS, all 219 runtime files >= 90% (new `cli_model_flags.py` at 100%).
- [x] `pylint bili/` — 9.64/10 (matches pre-change baseline; no new findings, two pre-existing findings unrelated to this change).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>