### PR TITLE
feat: per-model prompt-length limit for AgentSpec.system_prompt

### DIFF
--- a/bili/aether/README.md
+++ b/bili/aether/README.md
@@ -221,7 +221,7 @@ agents:
 | `model_name` | No | `None` | LLM model (e.g., `gpt-4`, `claude-sonnet-3-5-20241022`) |
 | `temperature` | No | `0.0` | LLM sampling temperature (0.0-2.0) |
 | `max_tokens` | No | `None` | Maximum tokens in LLM response |
-| `system_prompt` | No | `None` | Instructions for the LLM (up to 10,000 chars) |
+| `system_prompt` | No | `None` | Instructions for the LLM. No fixed length cap — checked against the bound model's own declared input-token limit when `model_name` resolves to a catalog entry with a known limit; unconstrained otherwise. See [`get_prompt_length_limit()`](#per-model-prompt-length-limits). |
 | `capabilities` | No | `[]` | Agent capabilities (free-form strings) |
 | `tools` | No | `[]` | Tool names from the tool registry |
 | `output_format` | No | `text` | Output format: `text`, `json`, or `structured` |
@@ -252,6 +252,24 @@ Each agent has two distinct text fields that serve different purposes:
 The `objective` is required and describes the agent's role in the system. The `system_prompt` is optional and controls the LLM's behavior when executing that agent. When `system_prompt` is omitted, the agent inherits its prompt from bili-core (if `inherit_from_bili_core: true` and `inherit_system_prompt: true`) or uses the LLM's default behavior.
 
 Each agent can also specify its own LLM via `model_name` — different agents in the same MAS can use different models (e.g., a fast model for initial screening and a more capable model for final judgment).
+
+### Per-Model Prompt Length Limits
+
+`system_prompt` has no fixed character cap — every model has a different prompt/context budget, so a single hardcoded number is wrong for the catalog as a whole regardless of what it is. Instead, `AgentSpec` checks `system_prompt` length against the *bound model's own* declared limit:
+
+- When `model_name` resolves to a catalog entry with a known `max_input_tokens`, the prompt is checked against an approximate character budget derived from that limit.
+- When `model_name` is unset, unrecognized, or resolves to a catalog entry with no declared limit (e.g. CLI-subprocess and local providers, whose real limits depend on the underlying tool/hardware), the check is skipped — an unknown limit never becomes an arbitrary cap.
+
+Call `agent.get_prompt_length_limit()` to query the bound model's declared input-token limit directly (returns `None` when unknown), so you can budget a composed prompt against the model it will actually run on before constructing the `AgentSpec`:
+
+```python
+from bili.aether.schema import AgentSpec
+
+agent = AgentSpec(agent_id="researcher", role="researcher", objective="Research topics", model_name="claude-opus-4-8")
+agent.get_prompt_length_limit()  # -> 200000 (max_input_tokens from the catalog)
+```
+
+The same lookup is available directly from a model name via `bili.aether.compiler.llm_resolver.resolve_prompt_length_limit(model_name)`, useful for budgeting a prompt before an `AgentSpec` exists at all.
 
 ### Use Presets for Common Patterns
 

--- a/bili/aether/compiler/llm_resolver.py
+++ b/bili/aether/compiler/llm_resolver.py
@@ -364,6 +364,60 @@ def resolve_tool_strategy(model_name: str) -> str:
     return "native"
 
 
+def resolve_prompt_length_limit(model_name: str) -> Optional[int]:
+    """Return the declared maximum input-token limit for *model_name*, if known.
+
+    Every model has a different prompt/context budget -- a small local model
+    and a long-context frontier model tolerate very different prompt sizes --
+    so a single hardcoded limit is wrong for the catalog as a whole regardless
+    of what number is chosen. This gives callers (e.g. ``AgentSpec`` prompt
+    validation, or any code composing a prompt before it knows which model
+    will consume it) a way to look up the *actual* per-model limit and budget
+    accordingly, rather than guessing.
+
+    Args:
+        model_name: The model identifier to look up. Can be a display name
+            (e.g. ``"Claude Opus 4.8"``) or a model ID (e.g.
+            ``"claude-opus-4-8"``), matched the same way as
+            :func:`resolve_model`.
+
+    Returns:
+        The model's declared ``max_input_tokens`` from
+        ``bili.iris.config.llm_config.LLM_MODELS``, or ``None`` when the
+        model is not found in the catalog, the catalog entry does not
+        declare a limit (e.g. CLI-subprocess and local providers, whose
+        real limits depend on the underlying tool/hardware rather than
+        bili-core's catalog), or the catalog module cannot be imported.
+        ``None`` means "no known limit" -- callers should treat that as
+        permissive (no cap), never as zero.
+    """
+    try:
+        from bili.iris.config.llm_config import (  # noqa: E402  pylint: disable=import-outside-toplevel
+            LLM_MODELS,
+        )
+    except ImportError:
+        LOGGER.debug(
+            "bili.iris.config.llm_config not available; "
+            "no known prompt length limit for '%s'",
+            model_name,
+        )
+        return None
+
+    for provider_info in LLM_MODELS.values():
+        for entry in provider_info.get("models", []):
+            if (
+                entry.get("model_id") == model_name
+                or entry.get("model_name") == model_name
+            ):
+                return entry.get("max_input_tokens")
+
+    LOGGER.debug(
+        "'%s' not found in LLM_MODELS; no known prompt length limit",
+        model_name,
+    )
+    return None
+
+
 def resolve_supports_tools(model_name: str) -> bool:
     """Return whether *model_name* supports native ``bind_tools``.
 

--- a/bili/aether/docs/configuration.md
+++ b/bili/aether/docs/configuration.md
@@ -132,7 +132,7 @@ agents:
 | `model_name` | No | `None` | LLM model (e.g., `gpt-4`, `claude-sonnet-3-5-20241022`) |
 | `temperature` | No | `0.0` | LLM sampling temperature (0.0-2.0) |
 | `max_tokens` | No | `None` | Maximum tokens in LLM response |
-| `system_prompt` | No | `None` | Instructions for the LLM (up to 10,000 chars) |
+| `system_prompt` | No | `None` | Instructions for the LLM. No fixed length cap — checked against the bound model's own declared input-token limit when known (see below); unconstrained otherwise. |
 | `capabilities` | No | `[]` | Agent capabilities (free-form strings) |
 | `tools` | No | `[]` | Tool names from the tool registry |
 | `output_format` | No | `text` | Output format: `text`, `json`, or `structured` |
@@ -161,6 +161,12 @@ agents:
 `objective` is required. `system_prompt` is optional — when omitted, the agent inherits from bili-core (if `inherit_from_bili_core: true` and `inherit_system_prompt: true`) or uses the LLM's default behavior.
 
 Each agent can specify its own LLM via `model_name`. Different agents in the same MAS can use different models.
+
+### Per-Model Prompt Length Limits
+
+Every model has a different prompt/context budget, so `system_prompt` is not checked against a single hardcoded number. When `model_name` resolves to a catalog entry with a known `max_input_tokens`, the prompt is checked against an approximate character budget derived from that limit; when the model is unset, unrecognized, or has no declared limit (e.g. CLI-subprocess and local providers), the check is skipped rather than imposing an arbitrary cap.
+
+Call `agent.get_prompt_length_limit()` to query the bound model's declared input-token limit directly (`None` when unknown), or `bili.aether.compiler.llm_resolver.resolve_prompt_length_limit(model_name)` to look it up from a model name before an `AgentSpec` exists, so you can budget a composed prompt against the model it will actually run on.
 
 ### Preset System
 

--- a/bili/aether/schema/agent_spec.py
+++ b/bili/aether/schema/agent_spec.py
@@ -15,6 +15,14 @@ from .enums import OutputFormat
 
 LOGGER = logging.getLogger(__name__)
 
+# Rough, deliberately generous characters-per-token estimate used only to turn
+# a model's declared *token* limit into a *character* budget for the
+# ``system_prompt`` length check below. Real tokenizers vary (and a caller
+# doing exact accounting should count tokens directly rather than rely on
+# this), but ~4 characters/token is a widely used approximation for English
+# text and errs on the side of not rejecting legitimate prompts.
+_APPROX_CHARS_PER_TOKEN = 4
+
 
 class AgentSpec(BaseModel):
     """
@@ -82,8 +90,15 @@ class AgentSpec(BaseModel):
 
     system_prompt: Optional[str] = Field(
         None,
-        description="Custom system prompt (overrides bili-core prompt if inherit=True)",
-        max_length=10000,
+        description=(
+            "Custom system prompt (overrides bili-core prompt if inherit=True). "
+            "No fixed length cap is imposed here -- prompt budgets vary enormously "
+            "by bound model (a small local model and a long-context frontier model "
+            "tolerate very different prompt sizes). When 'model_name' is set and "
+            "the model's declared input-token limit is known, the length is "
+            "checked against that model's own budget instead; see "
+            "'get_prompt_length_limit()' and 'validate_system_prompt_length'."
+        ),
     )
 
     temperature: Optional[float] = Field(
@@ -444,6 +459,44 @@ class AgentSpec(BaseModel):
         return self
 
     @model_validator(mode="after")
+    def validate_system_prompt_length(self):
+        """Check ``system_prompt`` length against the bound model's own budget.
+
+        Unlike a single fixed character cap (which is wrong for every model
+        simultaneously -- too generous for small-context models, too strict
+        for long-context ones), this validates the prompt against whatever
+        limit the *bound* model actually declares in the model catalog.
+
+        - No ``model_name`` set: nothing to validate against; skipped.
+        - ``model_name`` set but the model is unrecognised, or recognised but
+          without a declared input-token limit (e.g. CLI-subprocess and local
+          providers, whose limits depend on the underlying tool/hardware, not
+          bili-core's catalog): permissive by design. An unknown limit must
+          never manifest as an arbitrary cap.
+        - ``model_name`` set and resolves to a catalog entry with a declared
+          ``max_input_tokens``: the prompt is checked against an approximate
+          character budget derived from that limit. Token accounting varies
+          by tokenizer, so the estimate intentionally errs on the generous
+          side -- callers that need exact accounting should call
+          ``get_prompt_length_limit()`` and do their own token counting.
+        """
+        limit_tokens = self.get_prompt_length_limit()
+        if limit_tokens is None or not self.system_prompt:
+            return self
+
+        char_budget = limit_tokens * _APPROX_CHARS_PER_TOKEN
+        prompt_length = len(self.system_prompt)
+        if prompt_length > char_budget:
+            raise ValueError(
+                f"system_prompt is {prompt_length} characters, which exceeds the "
+                f"approximate {char_budget}-character budget for model "
+                f"'{self.model_name}' (declared limit: {limit_tokens} input "
+                f"tokens, estimated at {_APPROX_CHARS_PER_TOKEN} characters/token). "
+                "Shorten the prompt or bind a model with a larger input-token limit."
+            )
+        return self
+
+    @model_validator(mode="after")
     def validate_pipeline_depth(self):
         """Validate that pipeline nesting doesn't exceed max depth.
 
@@ -478,6 +531,30 @@ class AgentSpec(BaseModel):
     # =========================================================================
     # HELPER METHODS
     # =========================================================================
+
+    def get_prompt_length_limit(self) -> Optional[int]:
+        """Return this agent's bound model's declared input-token limit, if known.
+
+        Looks up ``self.model_name`` in bili-core's model catalog
+        (``bili.iris.config.llm_config.LLM_MODELS``) and returns its declared
+        ``max_input_tokens``, letting a caller budget a composed prompt
+        against the model it will actually run on instead of guessing at a
+        one-size-fits-all number.
+
+        Returns:
+            The model's declared maximum input tokens, or ``None`` when
+            ``model_name`` is unset, the model is not in the catalog, or the
+            catalog entry does not declare a limit (e.g. CLI-subprocess and
+            local providers). ``None`` means "no known limit" -- callers
+            should treat that as permissive, not as zero.
+        """
+        if not self.model_name:  # pylint: disable=no-member
+            return None
+        from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+            resolve_prompt_length_limit,
+        )
+
+        return resolve_prompt_length_limit(self.model_name)  # pylint: disable=no-member
 
     def get_display_name(self) -> str:
         """Get human-readable agent name."""

--- a/bili/aether/tests/test_agent_spec.py
+++ b/bili/aether/tests/test_agent_spec.py
@@ -1,9 +1,45 @@
 """Tests for AgentSpec schema (domain-agnostic design)."""
 
+from unittest.mock import patch
+
 import pytest
 from pydantic import ValidationError
 
 from bili.aether.schema import AgentSpec, OutputFormat
+
+# Small, self-contained catalog used to isolate the per-model prompt-length
+# tests from the real (large, ever-growing) LLM_MODELS catalog.
+_MOCK_CATALOG = {
+    "remote_test_large_context": {
+        "models": [
+            {
+                "model_name": "Large Context Test Model",
+                "model_id": "large-context-test-model",
+                "max_input_tokens": 200000,
+            },
+        ]
+    },
+    "remote_test_small_context": {
+        "models": [
+            {
+                "model_name": "Small Context Test Model",
+                "model_id": "small-context-test-model",
+                "max_input_tokens": 1000,
+            },
+        ]
+    },
+    "cli_test": {
+        "models": [
+            {
+                # CLI-subprocess-style entry: no declared max_input_tokens,
+                # mirroring the real cli/cli_claude_code/cli_codex/
+                # cli_gemini_cli catalog entries.
+                "model_name": "CLI Test Model",
+                "model_id": "cli:test",
+            },
+        ]
+    },
+}
 
 
 def test_minimal_agent():
@@ -216,3 +252,153 @@ def test_consensus_vote_field_with_json():
         consensus_vote_field="decision",
     )
     assert agent.consensus_vote_field == "decision"
+
+
+# =========================================================================
+# SYSTEM PROMPT LENGTH TESTS (per-model, not a fixed hardcoded cap)
+# =========================================================================
+
+
+def test_system_prompt_no_hardcoded_cap_without_model():
+    """A long system_prompt validates fine when no model_name is bound.
+
+    There is no longer a fixed character ceiling (the old max_length=10000)
+    on this field -- a single number is wrong for the catalog as a whole
+    regardless of what it is. With no model_name to check against, there is
+    nothing to validate, so length is unconstrained.
+    """
+    agent = AgentSpec(
+        agent_id="test",
+        role="judge",
+        objective="Test objective for validation",
+        system_prompt="x" * 15000,
+    )
+    assert len(agent.system_prompt) == 15000
+
+
+def test_system_prompt_no_hardcoded_cap_with_unknown_model():
+    """A long system_prompt validates fine for a model absent from the catalog.
+
+    An unknown limit must never manifest as an arbitrary cap.
+    """
+    with patch("bili.iris.config.llm_config.LLM_MODELS", _MOCK_CATALOG):
+        agent = AgentSpec(
+            agent_id="test",
+            role="judge",
+            objective="Test objective for validation",
+            model_name="totally-unrecognized-model-xyz",
+            system_prompt="x" * 15000,
+        )
+        assert len(agent.system_prompt) == 15000
+
+
+def test_system_prompt_no_hardcoded_cap_for_cli_provider():
+    """A long system_prompt validates for a CLI-provider model with no declared limit.
+
+    CLI-subprocess and local providers do not declare max_input_tokens in the
+    catalog (their real limit depends on the underlying tool/hardware), so
+    they must be treated permissively, exactly like an unknown model.
+    """
+    with patch("bili.iris.config.llm_config.LLM_MODELS", _MOCK_CATALOG):
+        agent = AgentSpec(
+            agent_id="test",
+            role="judge",
+            objective="Test objective for validation",
+            model_name="cli:test",
+            system_prompt="x" * 15000,
+        )
+        assert len(agent.system_prompt) == 15000
+
+
+def test_get_prompt_length_limit_returns_none_without_model_name():
+    """get_prompt_length_limit() returns None when model_name is unset."""
+    agent = AgentSpec(
+        agent_id="test",
+        role="judge",
+        objective="Test objective for validation",
+    )
+    assert agent.get_prompt_length_limit() is None
+
+
+def test_get_prompt_length_limit_returns_none_for_unknown_model():
+    """get_prompt_length_limit() returns None for a model absent from the catalog."""
+    with patch("bili.iris.config.llm_config.LLM_MODELS", _MOCK_CATALOG):
+        agent = AgentSpec(
+            agent_id="test",
+            role="judge",
+            objective="Test objective for validation",
+            model_name="totally-unrecognized-model-xyz",
+        )
+        assert agent.get_prompt_length_limit() is None
+
+
+def test_get_prompt_length_limit_is_queryable_per_model():
+    """get_prompt_length_limit() surfaces the bound model's declared limit.
+
+    This is the mechanism a consumer uses to budget a composed prompt
+    against the model it will actually run on, by display name or model_id.
+    """
+    with patch("bili.iris.config.llm_config.LLM_MODELS", _MOCK_CATALOG):
+        large = AgentSpec(
+            agent_id="large",
+            role="judge",
+            objective="Test objective for validation",
+            model_name="large-context-test-model",
+        )
+        assert large.get_prompt_length_limit() == 200000
+
+        # Lookup by display name works too, matching resolve_model semantics.
+        large_by_name = AgentSpec(
+            agent_id="large2",
+            role="judge",
+            objective="Test objective for validation",
+            model_name="Large Context Test Model",
+        )
+        assert large_by_name.get_prompt_length_limit() == 200000
+
+        small = AgentSpec(
+            agent_id="small",
+            role="judge",
+            objective="Test objective for validation",
+            model_name="small-context-test-model",
+        )
+        assert small.get_prompt_length_limit() == 1000
+
+
+def test_system_prompt_over_10k_validates_for_large_context_model():
+    """A >10k-character prompt validates fine for a large-context model.
+
+    This is the concrete case the old hardcoded max_length=10000 got wrong:
+    a prompt well over 10k characters is entirely reasonable for a model
+    with a 200k-token input budget.
+    """
+    with patch("bili.iris.config.llm_config.LLM_MODELS", _MOCK_CATALOG):
+        agent = AgentSpec(
+            agent_id="test",
+            role="judge",
+            objective="Test objective for validation",
+            model_name="large-context-test-model",
+            system_prompt="x" * 15000,
+        )
+        assert len(agent.system_prompt) == 15000
+
+
+def test_system_prompt_rejected_for_small_context_model():
+    """An excessive prompt is rejected against a small-context model's own limit.
+
+    Confirms the per-model check has real teeth (not a permissive no-op that
+    always passes): a prompt that vastly exceeds the *bound* model's declared
+    budget is still caught, just against that model's real limit rather than
+    an arbitrary fixed number.
+    """
+    with patch("bili.iris.config.llm_config.LLM_MODELS", _MOCK_CATALOG):
+        with pytest.raises(ValidationError, match="system_prompt"):
+            AgentSpec(
+                agent_id="test",
+                role="judge",
+                objective="Test objective for validation",
+                model_name="small-context-test-model",
+                # small-context-test-model declares max_input_tokens=1000,
+                # i.e. an approximate 4000-character budget.
+                system_prompt="x" * 20000,
+            )

--- a/bili/aether/tests/test_compiler.py
+++ b/bili/aether/tests/test_compiler.py
@@ -1187,6 +1187,67 @@ class TestPromptedToolCalling:
             assert resolve_tool_strategy("o1-mini") == "none"
 
     # ------------------------------------------------------------------
+    # resolve_prompt_length_limit
+    # ------------------------------------------------------------------
+
+    def test_resolve_prompt_length_limit_returns_declared_limit(self):
+        """resolve_prompt_length_limit reads max_input_tokens by model_id or display name."""
+        from bili.aether.compiler.llm_resolver import resolve_prompt_length_limit
+
+        mock_models = {
+            "remote_anthropic": {
+                "models": [
+                    {
+                        "model_name": "Claude Opus 4.8",
+                        "model_id": "claude-opus-4-8",
+                        "max_input_tokens": 200000,
+                    },
+                ]
+            }
+        }
+        with patch("bili.iris.config.llm_config.LLM_MODELS", mock_models):
+            assert resolve_prompt_length_limit("claude-opus-4-8") == 200000
+            assert resolve_prompt_length_limit("Claude Opus 4.8") == 200000
+
+    def test_resolve_prompt_length_limit_none_for_unknown_model(self):
+        """resolve_prompt_length_limit returns None for a model absent from the catalog.
+
+        None means "no known limit"; callers must treat this permissively,
+        never as an implicit zero-length cap.
+        """
+        from bili.aether.compiler.llm_resolver import resolve_prompt_length_limit
+
+        mock_models = {"remote_openai": {"models": []}}
+        with patch("bili.iris.config.llm_config.LLM_MODELS", mock_models):
+            assert resolve_prompt_length_limit("unknown-model-xyz") is None
+
+    def test_resolve_prompt_length_limit_none_when_entry_declares_no_limit(self):
+        """resolve_prompt_length_limit returns None when the catalog entry has no limit.
+
+        Mirrors real CLI-subprocess and local-provider catalog entries, whose
+        actual limits depend on the underlying tool/hardware rather than
+        bili-core's catalog.
+        """
+        from bili.aether.compiler.llm_resolver import resolve_prompt_length_limit
+
+        mock_models = {
+            "cli_claude_code": {
+                "models": [
+                    {"model_name": "Claude Code CLI", "model_id": "cli:claude_code"},
+                ]
+            }
+        }
+        with patch("bili.iris.config.llm_config.LLM_MODELS", mock_models):
+            assert resolve_prompt_length_limit("cli:claude_code") is None
+
+    def test_resolve_prompt_length_limit_none_on_import_error(self):
+        """resolve_prompt_length_limit returns None when LLM_MODELS cannot be imported."""
+        from bili.aether.compiler.llm_resolver import resolve_prompt_length_limit
+
+        with patch.dict(sys.modules, {"bili.iris.config.llm_config": None}):
+            assert resolve_prompt_length_limit("any-model") is None
+
+    # ------------------------------------------------------------------
     # mcp and none routing in _generate_tool_agent_node
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`AgentSpec.system_prompt` carried a fixed `max_length=10000` that was dishonest on two counts: it was already silently bypassed in practice (consumers set `system_prompt` after construction, and pydantic does not re-validate on assignment by default), and it was the wrong kind of check regardless -- every model has a different prompt/context budget, so one hardcoded number can never be correct for the catalog as a whole.

This PR removes the hardcoded cap and makes prompt-length awareness **per model**:

- `bili.aether.compiler.llm_resolver.resolve_prompt_length_limit(model_name)` -- new resolver function, mirroring the existing `resolve_tool_strategy()` pattern, that looks up a model's declared `max_input_tokens` from the catalog (`bili.iris.config.llm_config.LLM_MODELS`) by model ID or display name. Returns `None` when the model is unknown or the catalog entry declares no limit (e.g. CLI-subprocess and local providers, whose real limits depend on the underlying tool/hardware rather than bili-core's catalog).
- `AgentSpec.get_prompt_length_limit()` -- convenience instance method that resolves the agent's own `model_name` to its declared limit, so a caller can budget a composed prompt against the model it will actually run on.
- `AgentSpec.validate_system_prompt_length` -- a new `model_validator` that checks `system_prompt` length against the *bound model's* declared limit (converted to an approximate, deliberately generous character budget) rather than a fixed number. When the model is unset or its limit is unknown, the check is skipped -- an unknown limit never becomes an arbitrary cap.

Docs (`bili/aether/README.md`, `bili/aether/docs/configuration.md`) updated to describe the new per-model behavior in place of the old "up to 10,000 chars" claim.

## Test plan

- [x] `pytest bili/aether/ -q` -- 1258 passed
- [x] New tests in `bili/aether/tests/test_agent_spec.py`: hardcoded cap is gone (no `model_name`, unrecognized `model_name`, and CLI-provider `model_name` all accept a >10k-character prompt); `get_prompt_length_limit()` returns `None` when unknown and the declared limit when known (by model ID and by display name); a >10k-character prompt validates for a large-context model; an excessive prompt is still rejected against a *small*-context model's own limit (proves the per-model check isn't a permissive no-op)
- [x] New tests in `bili/aether/tests/test_compiler.py`: `resolve_prompt_length_limit()` returns the declared limit, `None` for an unknown model, `None` for a catalog entry with no declared limit, and `None` on import error
- [x] `pylint bili/aether/ --fail-under=9` -- 9.55/10 (pre-existing findings only; no new warnings from this change)
- [x] Coverage on both touched files well above the 90% per-file gate (`agent_spec.py` 99%, `llm_resolver.py` 99% when run alongside the provider tests that also exercise the resolver)