### PR TITLE
dev: add detached mode to start-container + stop-container

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,16 +21,31 @@ BiliCore is an open-source framework for benchmarking and building dynamic RAG (
 
 ### Container-Based Development (Recommended)
 ```bash
-# Start development environment
+# Start development environment (foreground; auto-detects cpu/gpu profile)
 cd scripts/development
-./start-container.sh
+./start-container
 
 # Attach to container
-./attach-container.sh
+./attach-container
 
 # Inside container
-streamlit  # Start Streamlit UI
-flask      # Start Flask API
+streamlit  # Start Streamlit UI (:8501)
+flask      # Start Flask API (:5001)
+```
+
+Detached mode brings the same environment up in the background (for automation, CI, or a hands-off bringup). It starts Flask and Streamlit inside the container, waits for the Flask API on `:5001`, and prints log-tail and stop commands. The foreground path is unchanged.
+
+```bash
+# Background bringup; optional cpu|gpu arg forces the profile
+./scripts/development/start-container -d
+./scripts/development/start-container -d cpu
+
+# Tail the in-container logs
+docker exec bili-core tail -f /tmp/flask.log
+docker exec bili-core tail -f /tmp/streamlit.log
+
+# Tear down (foreground or detached; idempotent)
+./scripts/development/stop-container
 ```
 
 ### Code Quality Commands

--- a/README.MD
+++ b/README.MD
@@ -86,11 +86,11 @@ cp .env.example .env
 
 ```bash
 cd scripts/development
-./start-container.sh
-./attach-container.sh
+./start-container
+./attach-container
 ```
 
-This starts the bili-core container along with PostgreSQL (with PostGIS), MongoDB, and LocalStack services. The container automatically activates a Python virtual environment and sets up shell aliases.
+This starts the bili-core container along with PostgreSQL (with PostGIS), MongoDB, and LocalStack services. The container automatically activates a Python virtual environment and sets up shell aliases. The compute profile (`cpu` or `gpu`) is auto-detected from the presence of an NVIDIA GPU; pass `cpu` or `gpu` as an argument to force one.
 
 ### 3. Run the application
 
@@ -99,6 +99,30 @@ Inside the container:
 ```bash
 streamlit    # Start the Streamlit UI on port 8501
 flask        # Start the Flask API on port 5001
+```
+
+#### Detached mode (background bringup)
+
+To bring the same environment up in the background without holding a terminal (useful for automation, CI, or when you just want the services running), pass `-d`:
+
+```bash
+./scripts/development/start-container -d          # auto-detect cpu/gpu profile
+./scripts/development/start-container -d cpu       # force the cpu profile
+```
+
+Detached mode brings up compose, starts Flask (`:5001`) and Streamlit (`:8501`) inside the container, waits for the Flask API to respond, and prints the log-tail and stop commands. The foreground behavior above is unchanged.
+
+Tail the logs:
+
+```bash
+docker exec bili-core tail -f /tmp/flask.log
+docker exec bili-core tail -f /tmp/streamlit.log
+```
+
+Tear the environment down (works for foreground or detached, safe to run when nothing is up):
+
+```bash
+./scripts/development/stop-container
 ```
 
 ### 4. Access the application

--- a/scripts/development/start-container
+++ b/scripts/development/start-container
@@ -71,16 +71,16 @@ docker compose --profile "$profile" up -d
 # attaches and runs those by hand. We invoke the identical aliases here so the
 # same processes start the same way. Both aliases already run the
 # `createpgdb && deps` provisioning preamble inline, so no extra setup step is
-# needed. The streamlit alias tees to /tmp/streamlit.log itself; the flask
-# alias does not, so only flask gets an exec-layer tee (tee-ing streamlit here
-# too would double-tee and garble its log).
+# needed. Both aliases tee their own output to /tmp (the lab-wide convention:
+# the alias owns its log), so no tee is added here; a second tee at this layer
+# would double-tee and garble the logs.
 #
 # `bash -ic` (interactive) is required: bash does NOT expand aliases in non-
 # interactive shells, so `flask` / `streamlit` (aliases, not functions) would
 # silently no-op under a plain `bash -c`. An interactive shell auto-sources
 # ~/.bashrc and expands aliases. The "no job control in this shell" warning
 # under `exec -d` is harmless.
-docker exec -d bili-core bash -ic 'flask 2>&1 | tee /tmp/flask.log'
+docker exec -d bili-core bash -ic 'flask'
 docker exec -d bili-core bash -ic 'streamlit'
 echo "Starting Flask (:5001) + Streamlit (:8501) in the container."
 

--- a/scripts/development/start-container
+++ b/scripts/development/start-container
@@ -14,8 +14,11 @@ set -e
 detach=false
 profile=""
 usage="Usage: $0 [-d|--detach] [cpu|gpu]"
+# A bare cpu|gpu first arg forces the profile for the FOREGROUND path too
+# (matches the README); -d may be followed by an optional profile.
 case "$1" in
     -d|--detach) detach=true ;;
+    cpu|gpu) profile="$1"; if [ -n "$2" ]; then echo "$usage"; exit 1; fi ;;
     "") ;;
     *) echo "$usage"; exit 1 ;;
 esac
@@ -68,8 +71,9 @@ docker compose --profile "$profile" up -d
 # attaches and runs those by hand. We invoke the identical aliases here so the
 # same processes start the same way. Both aliases already run the
 # `createpgdb && deps` provisioning preamble inline, so no extra setup step is
-# needed. We tee each to /tmp so the logs are tail-able (the flask alias does
-# not tee on its own).
+# needed. The streamlit alias tees to /tmp/streamlit.log itself; the flask
+# alias does not, so only flask gets an exec-layer tee (tee-ing streamlit here
+# too would double-tee and garble its log).
 #
 # `bash -ic` (interactive) is required: bash does NOT expand aliases in non-
 # interactive shells, so `flask` / `streamlit` (aliases, not functions) would
@@ -77,7 +81,7 @@ docker compose --profile "$profile" up -d
 # ~/.bashrc and expands aliases. The "no job control in this shell" warning
 # under `exec -d` is harmless.
 docker exec -d bili-core bash -ic 'flask 2>&1 | tee /tmp/flask.log'
-docker exec -d bili-core bash -ic 'streamlit 2>&1 | tee /tmp/streamlit.log'
+docker exec -d bili-core bash -ic 'streamlit'
 echo "Starting Flask (:5001) + Streamlit (:8501) in the container."
 
 # Poll until the Flask API answers on :5001 (bounded ~90s). First boot installs

--- a/scripts/development/start-container
+++ b/scripts/development/start-container
@@ -3,27 +3,118 @@
 # Exit on error
 set -e
 
+# Detached mode brings up the same environment as the interactive flow but
+# without holding a foreground terminal. Use it for agents, automation, CI, or
+# any background bringup. Default (no flag) is unchanged: foreground compose.
+#
+# The optional positional arg forces the compute profile (cpu or gpu),
+# overriding the nvidia-smi auto-detect. Agents and CI use this to force cpu on
+# a machine that happens to have a GPU. With no arg the profile is auto-detected
+# exactly as before.
+detach=false
+profile=""
+usage="Usage: $0 [-d|--detach] [cpu|gpu]"
+case "$1" in
+    -d|--detach) detach=true ;;
+    "") ;;
+    *) echo "$usage"; exit 1 ;;
+esac
+case "$2" in
+    cpu|gpu) profile="$2" ;;
+    "") ;;
+    *) echo "$usage"; exit 1 ;;
+esac
+
 # Change to the directory of the script
 cd "$(dirname "$0")"
 
-# Check for NVIDIA GPU
-if command -v nvidia-smi &> /dev/null; then
-    echo "NVIDIA GPU detected. Using GPU profile."
-    profile="gpu"
+# Pick the compute profile: explicit arg wins, otherwise auto-detect an NVIDIA
+# GPU. The compose file exposes the same container_name (bili-core) under two
+# profiles: "gpu" reserves the GPU device, "cpu" does not.
+if [ -z "$profile" ]; then
+    if command -v nvidia-smi &> /dev/null; then
+        echo "NVIDIA GPU detected. Using GPU profile."
+        profile="gpu"
+    else
+        echo "No NVIDIA GPU detected. Using CPU profile."
+        profile="cpu"
+    fi
 else
-    echo "No NVIDIA GPU detected. Using CPU profile."
-    profile="cpu"
+    echo "Using $profile profile (explicit override)."
 fi
 
 docker build ../../ -t bili-core
 docker compose build
 docker network create bili-core || true
 
-docker compose --profile $profile up
+if [ "$detach" = false ]; then
+    docker compose --profile "$profile" up
 
-docker stop bili-core
-docker stop bili-core-postgis
-docker stop bili-core-mongodb
-docker stop bili-core-localstack
+    docker stop bili-core
+    docker stop bili-core-postgis
+    docker stop bili-core-mongodb
+    docker stop bili-core-localstack
 
-docker compose down
+    docker compose down
+    exit 0
+fi
+
+# --- Detached mode -----------------------------------------------------------
+
+docker compose --profile "$profile" up -d
+
+# The container entrypoint (wait.sh) writes ~/.bashrc with the `flask` and
+# `streamlit` aliases, then idles on `tail -f /dev/null`. The interactive flow
+# attaches and runs those by hand. We invoke the identical aliases here so the
+# same processes start the same way. Both aliases already run the
+# `createpgdb && deps` provisioning preamble inline, so no extra setup step is
+# needed. We tee each to /tmp so the logs are tail-able (the flask alias does
+# not tee on its own).
+#
+# `bash -ic` (interactive) is required: bash does NOT expand aliases in non-
+# interactive shells, so `flask` / `streamlit` (aliases, not functions) would
+# silently no-op under a plain `bash -c`. An interactive shell auto-sources
+# ~/.bashrc and expands aliases. The "no job control in this shell" warning
+# under `exec -d` is harmless.
+docker exec -d bili-core bash -ic 'flask 2>&1 | tee /tmp/flask.log'
+docker exec -d bili-core bash -ic 'streamlit 2>&1 | tee /tmp/streamlit.log'
+echo "Starting Flask (:5001) + Streamlit (:8501) in the container."
+
+# Poll until the Flask API answers on :5001 (bounded ~90s). First boot installs
+# deps and creates the database, so the first response can lag well behind
+# `up -d`. The trailing `|| true` is required because this script runs under
+# `set -e`: curl exits non-zero while the API is still starting (connection
+# refused), and an unguarded command substitution in an assignment would abort
+# the whole script on the first poll. With the guard, curl still writes "000"
+# on failure, so the loop condition below is unchanged.
+echo "Waiting for Flask API on :5001 ..."
+api_status=""
+for _ in $(seq 1 45); do
+    api_status=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:5001/ 2>/dev/null || true)
+    # Any HTTP response (even 404) means the server process is accepting requests.
+    if [ "$api_status" != "000" ] && [ -n "$api_status" ]; then
+        break
+    fi
+    sleep 2
+done
+
+echo ""
+echo "=== bili-core (detached) ==="
+docker compose --profile "$profile" ps
+echo ""
+if [ "$api_status" != "000" ] && [ -n "$api_status" ]; then
+    echo "Flask API on :5001 responding (HTTP $api_status)."
+else
+    echo "Flask API on :5001 not responding yet (still building?). Tail the logs to watch startup."
+fi
+echo ""
+echo "URLs:"
+echo "  Streamlit UI: http://localhost:8501"
+echo "  Flask API:    http://localhost:5001"
+echo ""
+echo "Tail logs:"
+echo "  docker exec bili-core tail -f /tmp/flask.log"
+echo "  docker exec bili-core tail -f /tmp/streamlit.log"
+echo ""
+echo "Stop:"
+echo "  ./scripts/development/stop-container"

--- a/scripts/development/stop-container
+++ b/scripts/development/stop-container
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Tears down the detached (or foreground) dev environment. Idempotent: safe to
+# run when nothing is up. Mirrors the teardown the foreground start-container
+# does on exit, so a `start-container -d` bringup ends the same way.
+
+# Change to the directory of the script
+cd "$(dirname "$0")"
+
+# If the bili-core container is up, stop the Flask/Streamlit processes first so
+# their `tee` pipes flush before compose removes anything. The flask alias runs
+# `flask run`; the streamlit alias runs `streamlit run`.
+if [ "$(docker inspect -f '{{.State.Running}}' bili-core 2>&1)" = "true" ]; then
+    echo "Stopping Flask/Streamlit processes."
+    docker exec bili-core bash -c 'pkill -f "flask run"; pkill -f "streamlit run"' || true
+fi
+
+echo "Bringing down containers."
+docker compose down
+
+echo "Done."

--- a/scripts/development/wait.sh
+++ b/scripts/development/wait.sh
@@ -9,7 +9,7 @@ alias createpgdb='psql "${POSTGRES_CONNECTION_STRING%/*}/postgres" -c "CREATE DA
 alias deps='cd /app/bili-core/scripts/development && ./install-deps'
 alias seeds3='cd /app/bili-core/scripts/development && ./upload-to-localstack-s3'
 alias streamlit='createpgdb && deps && cd /app/bili-core/scripts/development && ./start-streamlit-server 2>&1 | tee /tmp/streamlit.log'
-alias flask='createpgdb && deps && cd /app/bili-core/scripts/development && ./start-flask-server'
+alias flask='createpgdb && deps && cd /app/bili-core/scripts/development && ./start-flask-server 2>&1 | tee /tmp/flask.log'
 export LOCALSTACK_ENDPOINT='http://bili-core-localstack:4566'
 [ -f "$GOOGLE_APPLICATION_CREDENTIALS" ] && gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS"
 [ -f "$GOOGLE_APPLICATION_CREDENTIALS" ] && gcloud config set project "$GOOGLE_PROJECT_ID"


### PR DESCRIPTION
## What this adds

A background (detached) bringup for the local dev environment, plus a matching teardown script.

- **`start-container -d [cpu|gpu]`** brings the same environment up as the normal foreground `start-container`, but without holding a terminal open. It starts the Flask API (`:5001`) and Streamlit UI (`:8501`) inside the container, waits for the API to respond, then prints the container status, log-tail commands, and the stop command.
- **`stop-container`** tears the environment down. It stops the Flask/Streamlit processes cleanly, then runs `docker compose down`. Safe to run when nothing is up.

This is handy for automation, CI, or any time you just want the services running in the background instead of tying up a terminal.

## Usage

```bash
# Foreground (unchanged): auto-detects the cpu/gpu profile
./scripts/development/start-container

# Background bringup; optional cpu|gpu forces the profile
./scripts/development/start-container -d
./scripts/development/start-container -d cpu

# Watch startup / logs
docker exec bili-core tail -f /tmp/flask.log
docker exec bili-core tail -f /tmp/streamlit.log

# Tear down (foreground or detached; idempotent)
./scripts/development/stop-container
```

Once it is up: Streamlit UI at http://localhost:8501, Flask API at http://localhost:5001.

## Parity guarantee

The foreground path is unchanged in behavior. Running `./start-container` with no flag does exactly what it did before (build, bring compose up in the foreground, and tear down on exit). The one addition to the foreground path is that it now accepts an optional `cpu` or `gpu` argument to override the automatic GPU detection, which is what lets a machine with a GPU force the cpu profile.

## The `bash -ic` alias gotcha

Detached mode runs the dev processes with `docker exec -d bili-core bash -ic '<alias>'`. The `-i` (interactive) flag matters: `flask` and `streamlit` are shell **aliases** (defined in `~/.bashrc` by the container entrypoint `wait.sh`), not functions or scripts on the PATH. Bash does **not** expand aliases in non-interactive shells, so a plain `bash -c 'flask'` would silently do nothing. An interactive shell (`-i`) auto-sources `~/.bashrc` and expands the aliases. The "no job control in this shell" warning that `exec -d` prints is harmless.

Both aliases already run the `createpgdb && deps` setup step inline, so detached mode does not add a separate provisioning step; it just invokes the same aliases the interactive workflow uses. Each is teed to `/tmp/flask.log` and `/tmp/streamlit.log` so the logs can be tailed (the flask alias does not tee on its own).

One `set -e` detail worth calling out for reviewers: the readiness poll's `curl` is guarded with `|| true` because this script runs under `set -e`. While the API is still starting, curl exits non-zero (connection refused), and an unguarded command substitution in an assignment would abort the whole script on the first poll. With the guard, curl still writes `000` on failure, so the loop logic is unchanged.

## Where this comes from

This ports the detached-mode pattern from `roadrunner-connect-server` [PR #175](https://github.com/msu-denver/roadrunner-connect-server/pull/175), which was validated live there. It is adapted to bili-core's specifics: the Flask/Streamlit aliases, the `:5001` readiness poll, the `cpu`/`gpu` compose profile pass-through, and the `bili-core` container/network names.

## How to review

No compose, Dockerfile, or Python source changed. `bash -n` passes on both scripts. The meaningful check is a local Docker bringup:

1. `./scripts/development/start-container -d`
2. Confirm the Flask API answers at http://localhost:5001 and the Streamlit UI loads at http://localhost:8501.
3. `./scripts/development/stop-container`