### PR TITLE
feat: ask_user human-in-the-loop tool (native tool-calling pause/resume seam)

### DIFF
--- a/bili/aether/runtime/executor.py
+++ b/bili/aether/runtime/executor.py
@@ -48,6 +48,19 @@ Usage::
         elif event_type == "__node_complete__":
             print(f"\n[{event_data['node']} complete]")
 
+    # ask_user (or any tool calling langgraph.types.interrupt()) pauses the
+    # run_streaming() generator with a __ask_user_pending__ sentinel;
+    # resume_with_value() supplies the answer and continues execution:
+    for node_name, state_update in executor.run_streaming(
+        {"messages": [HumanMessage(content="Deploy the app.")]}, thread_id="my-thread"
+    ):
+        if node_name == "__ask_user_pending__":
+            question = state_update["interrupts"][0]["question"]
+            for node_name2, state_update2 in executor.resume_with_value(
+                "staging", thread_id="my-thread"
+            ):
+                print(f"{node_name2}: {state_update2}")
+
     # Or use the convenience function:
     result = execute_mas(config, {"messages": [HumanMessage(content="Hello")]})
 """
@@ -499,6 +512,104 @@ class MASExecutor:  # pylint: disable=too-many-instance-attributes
                     )
             except Exception as exc:  # pylint: disable=broad-exception-caught
                 LOGGER.warning("Could not inspect graph state for HITL check: %s", exc)
+
+        # Separately, check for a langgraph.types.interrupt() pause (e.g. the
+        # ask_user tool) — distinct from the human_in_loop / is_human whole-
+        # agent-slot mechanism above, and not gated on human_in_loop, since a
+        # tool-level interrupt can occur in any MAS regardless of that flag.
+        # Additive: existing __human_interrupt__ callers are unaffected.
+        if invoke_config:
+            try:
+                graph_state = self._compiled_graph.get_state(invoke_config)
+                pending_interrupts = [
+                    interrupt_obj
+                    for task in graph_state.tasks
+                    for interrupt_obj in task.interrupts
+                ]
+                if pending_interrupts:
+                    yield (
+                        "__ask_user_pending__",
+                        {
+                            # Raw interrupt payload(s) as passed to interrupt(...),
+                            # e.g. {"type": "ask_user", "question": ..., "options": ...}.
+                            "interrupts": [i.value for i in pending_interrupts],
+                            "thread_id": effective_thread_id,
+                        },
+                    )
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                LOGGER.warning(
+                    "Could not inspect graph state for ask_user interrupt check: %s",
+                    exc,
+                )
+
+    def resume_with_value(
+        self,
+        value: Any,
+        thread_id: str,
+    ) -> Generator[Tuple[str, Dict[str, Any]], None, None]:
+        """Resume a graph paused at a ``langgraph.types.interrupt()`` call.
+
+        Unlike :meth:`resume_streaming` (which injects a ``HumanMessage`` and
+        lets the graph continue routing normally — the ``human_in_loop`` /
+        ``is_human`` whole-agent-slot mechanism), this supplies *value*
+        directly as the return value of the ``interrupt(...)`` call that
+        paused execution, via ``Command(resume=value)``. Use this to resume
+        after a ``__ask_user_pending__`` sentinel from :meth:`run_streaming`.
+
+        The outer AETHER/IRIS node that called into the tool-calling agent
+        re-executes from its own start on resume (not just the single
+        interrupted tool call) — this is ``langgraph.types.interrupt()``'s
+        documented behavior, not a bili-core choice. Verified against
+        ``create_agent``'s tool-calling subgraph specifically: its own
+        internal LLM-call node is NOT re-invoked on resume (LangGraph tracks
+        that node's own already-completed task independently, even without
+        an explicit checkpointer passed to ``create_agent``, when the
+        subgraph is invoked from inside an already-checkpointed outer node —
+        which is how every bili-core tool-calling node uses it). Code in the
+        outer node before the tool-calling agent is invoked (e.g. system
+        prompt / comm-context assembly) does re-run; this is harmless as
+        long as it is pure computation with no external side effect, which
+        holds for AETHER's own pre-invoke bookkeeping today.
+
+        Args:
+            value: The value returned to the paused ``interrupt(...)`` call
+                (e.g. the human's answer to an ``ask_user`` question).
+            thread_id: Thread ID originally reported in the
+                ``__ask_user_pending__`` sentinel.
+
+        Yields:
+            ``(node_name, state_update)`` tuples for every node that executes
+            after the interrupt, in execution order.
+
+        Raises:
+            RuntimeError: If ``initialize()`` has not been called.
+        """
+        if self._compiled_graph is None:
+            raise RuntimeError(
+                "Executor not initialized. Call initialize() before resume_with_value()."
+            )
+
+        from langgraph.types import Command  # pylint: disable=import-outside-toplevel
+
+        invoke_config = {
+            "configurable": {"thread_id": thread_id},
+            "recursion_limit": self._config.max_iterations,
+        }
+
+        LOGGER.info("Resuming interrupt()-paused execution for thread '%s'", thread_id)
+        try:
+            for chunk in self._compiled_graph.stream(
+                Command(resume=value),
+                config=invoke_config,
+                stream_mode="updates",
+            ):
+                for node_name, state_update in chunk.items():
+                    yield (node_name, state_update)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            LOGGER.error("resume_with_value failed: %s", exc, exc_info=True)
+            raise
+        finally:
+            LOGGER.info("interrupt() resume complete for thread '%s'", thread_id)
 
     def run_streaming_tokens(
         self,

--- a/bili/aether/tests/test_ask_user_aether_integration.py
+++ b/bili/aether/tests/test_ask_user_aether_integration.py
@@ -1,0 +1,218 @@
+"""End-to-end integration test: ask_user through a real AETHER MAS.
+
+Builds a REAL single-agent sequential MAS (real MASExecutor.initialize() ->
+real compile_mas() -> real create_agent() subgraph), scripts a fake
+tool-calling model to call ask_user, drives it through
+langgraph.types.interrupt() pause and MASExecutor.resume_with_value()
+resume, and pins the double-fire risk named in the chunk-1 design review:
+does AETHER's outer-node bookkeeping (communication_log append, provenance/
+agent_outputs, the wrap_node performance timer) fire once or twice across a
+pause/resume cycle.
+
+Only create_llm and resolve_tool_strategy are mocked (provider resolution
+has nothing to do with the interrupt seam under test); resolve_tools,
+compile_mas, and the full LangGraph execution path are all real. This is
+deliberately NOT the same shape as the existing agent_generator tests in
+test_compiler.py, which mock create_agent itself -- that would hide the
+exact risk this test exists to pin.
+
+See test_ask_user_iris_integration.py for the equivalent one-graph-layer
+IRIS-only test this builds on.
+"""
+
+# pylint: disable=duplicate-code
+# _ScriptedToolCallingModel is intentionally re-declared (not shared via
+# import) from bili/iris/tools/tests/test_ask_user_iris_integration.py: see
+# that file's own duplicate-code disable comment for why.
+
+from typing import Any, List, Sequence
+from unittest.mock import patch
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolCall
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+from bili.aether.runtime.executor import MASExecutor
+from bili.aether.schema import AgentSpec, MASConfig, WorkflowType
+from bili.iris.tools.ask_user import (
+    ASK_USER_TOOL_NAME,
+    register_ask_user_tool,
+    unregister_ask_user_tool,
+)
+
+_MOCK_CREATE_LLM = "bili.aether.compiler.llm_resolver.create_llm"
+_MOCK_TOOL_STRATEGY = "bili.aether.compiler.llm_resolver.resolve_tool_strategy"
+
+
+class _ScriptedToolCallingModel(BaseChatModel):
+    """Fake chat model that supports bind_tools and cycles scripted responses.
+
+    Instrumented with three independent counters so the test can assert
+    exactly what re-executes on resume without conflating "which response is
+    next" (an index that must NOT double-advance) with "how many times was
+    _generate() really called" (a count that must be exactly 2, not 3, for
+    the double-fire assertion to be meaningful).
+    """
+
+    responses: List[BaseMessage] = []
+    next_response_index: int = 0
+    invocation_count: int = 0
+
+    def bind_tools(self, tools: Sequence[Any], **kwargs: Any) -> "BaseChatModel":
+        return self
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        self.invocation_count += 1
+        response = self.responses[self.next_response_index]
+        if self.next_response_index < len(self.responses) - 1:
+            self.next_response_index += 1
+        return ChatResult(generations=[ChatGeneration(message=response)])
+
+    @property
+    def _llm_type(self) -> str:
+        return "scripted-tool-calling-model"
+
+
+def _scripted_ask_user_model() -> _ScriptedToolCallingModel:
+    return _ScriptedToolCallingModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        name=ASK_USER_TOOL_NAME,
+                        args={"question": "Which environment should I deploy to?"},
+                        id="call_1",
+                    )
+                ],
+            ),
+            AIMessage(content="Deploying to the environment you specified."),
+        ]
+    )
+
+
+def _single_agent_config() -> MASConfig:
+    """A single-agent sequential MAS with ask_user in its tool list."""
+    agent = AgentSpec(
+        agent_id="deployer",
+        role="deployer",
+        objective="Deploy the application, asking the human which environment to use.",
+        model_name="gpt-4o",
+        tools=[ASK_USER_TOOL_NAME],
+    )
+    return MASConfig(
+        mas_id="ask_user_test_mas",
+        name="ask_user Integration Test MAS",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[agent],
+        checkpoint_enabled=True,
+    )
+
+
+class TestAskUserAetherIntegration:
+    """Proves the ask_user pause/resume seam through a real AETHER MAS."""
+
+    def setup_method(self):
+        """Register ask_user before each test."""
+        register_ask_user_tool()
+
+    def teardown_method(self):
+        """Unregister ask_user after each test."""
+        unregister_ask_user_tool()
+
+    def test_pause_and_resume_through_real_mas(  # pylint: disable=too-many-locals
+        self,
+    ):
+        """A real AETHER MAS pauses at ask_user and resumes with the answer.
+
+        THE GATING ASSERTIONS (chunk-1 design review deliverable): after
+        resume, the communication log and agent_outputs (AETHER's per-agent
+        provenance bookkeeping, appended only at the true end of the agent
+        node) each have exactly ONE entry for the deployer agent -- not two.
+        The interrupted tool-calling node genuinely re-executes from its own
+        start on resume (langgraph.types.interrupt()'s documented behavior),
+        but that does not mean the outer AETHER node's terminal bookkeeping
+        fires twice; this test is the evidence, not an assumption.
+        """
+        model = _scripted_ask_user_model()
+        config = _single_agent_config()
+
+        with (
+            patch(_MOCK_CREATE_LLM, return_value=model),
+            patch(_MOCK_TOOL_STRATEGY, return_value="native"),
+        ):
+            executor = MASExecutor(config)
+            executor.initialize()
+
+            thread_id = "aether-ask-user-thread"
+            events = list(
+                executor.run_streaming(
+                    {"messages": [HumanMessage(content="Please deploy the app.")]},
+                    thread_id=thread_id,
+                )
+            )
+
+            # --- Pause: expect exactly one __ask_user_pending__ sentinel. ---
+            pending_events = [e for e in events if e[0] == "__ask_user_pending__"]
+            assert len(pending_events) == 1
+            pending_data = pending_events[0][1]
+            assert pending_data["thread_id"] == thread_id
+            assert len(pending_data["interrupts"]) == 1
+            payload = pending_data["interrupts"][0]
+            assert payload["type"] == ASK_USER_TOOL_NAME
+            assert payload["question"] == "Which environment should I deploy to?"
+
+            # No __human_interrupt__ sentinel: human_in_loop / is_human is a
+            # distinct, unrelated mechanism and must not be touched by this
+            # additive check (config.human_in_loop defaults to False here).
+            assert not [e for e in events if e[0] == "__human_interrupt__"]
+
+            # The deployer agent must not have completed yet -- its node is
+            # still paused mid-execution, so no agent-level node_name event
+            # for "deployer" should have reached the caller.
+            assert not [e for e in events if e[0] == "deployer"]
+
+            assert model.invocation_count == 1
+
+            # --- Resume: supply the answer via resume_with_value(). ---
+            resume_events = list(
+                executor.resume_with_value("staging", thread_id=thread_id)
+            )
+
+        deployer_events = [e for e in resume_events if e[0] == "deployer"]
+        assert len(deployer_events) == 1, (
+            "the deployer agent node must complete exactly once after "
+            "resume -- more than one 'deployer' event in the resumed "
+            "stream would mean the outer AETHER node emitted its terminal "
+            "state update twice"
+        )
+        final_state_update = deployer_events[0][1]
+        final_messages = final_state_update["messages"]
+        assert final_messages[-1].content == (
+            "Deploying to the environment you specified."
+        )
+
+        # THE GATING ASSERTION: the model is invoked exactly twice total
+        # (once before the pause, once after resume), not three times. A
+        # third invocation would mean create_agent's already-completed
+        # pre-interrupt model call is being replayed on resume.
+        assert model.invocation_count == 2
+
+        # THE GATING ASSERTION for AETHER's own bookkeeping: agent_outputs
+        # and the communication log are written once at the true end of the
+        # outer _agent_node closure (agent_generator.py), after
+        # _invoke_executor() returns. If the outer node's full body were
+        # replayed to completion twice, both would show 2 entries instead
+        # of 1.
+        agent_outputs = final_state_update.get("agent_outputs", {})
+        assert "deployer" in agent_outputs
+        assert agent_outputs["deployer"]["status"] == "completed"
+
+        comm_log = final_state_update.get("communication_log", [])
+        deployer_comm_entries = [
+            entry for entry in comm_log if entry.get("sender") == "deployer"
+        ]
+        assert len(deployer_comm_entries) == 1, (
+            f"expected exactly one communication_log entry from 'deployer' "
+            f"after resume, got {len(deployer_comm_entries)}: {deployer_comm_entries}"
+        )

--- a/bili/aether/tests/test_executor_extended.py
+++ b/bili/aether/tests/test_executor_extended.py
@@ -662,6 +662,100 @@ class TestResumeStreaming:  # pylint: disable=too-few-public-methods
 
 
 # =========================================================================
+# resume_with_value (the ask_user Command(resume=...) resume path)
+# =========================================================================
+
+
+class TestResumeWithValue:
+    """Tests for MASExecutor.resume_with_value()."""
+
+    def test_resume_with_value_requires_initialize(self):
+        config = _seq_config()
+        executor = MASExecutor(config)
+        with pytest.raises(RuntimeError, match="not initialized"):
+            list(executor.resume_with_value("staging", "thread-1"))
+
+    def test_resume_with_value_propagates_graph_errors(self):
+        """A stream() failure during resume is logged and re-raised, not
+        swallowed -- mirrors resume_streaming's own error-propagation
+        contract so callers of either resume path get the same guarantee.
+        """
+        config = _seq_config()
+        executor = MASExecutor(config)
+        executor.initialize()
+        executor._compiled_graph = (  # pylint: disable=protected-access
+            _BrokenStreamingGraph()
+        )
+        with pytest.raises(RuntimeError, match="Simulated streaming failure"):
+            list(executor.resume_with_value("staging", "thread-1"))
+
+
+# =========================================================================
+# __ask_user_pending__ sentinel detection in run_streaming
+# =========================================================================
+
+
+class TestAskUserPendingSentinel:
+    """Tests for the __ask_user_pending__ sentinel run_streaming() yields."""
+
+    def test_get_state_failure_is_logged_not_raised(self, caplog):
+        """A get_state() failure during the ask_user interrupt check must not
+        break run_streaming() for callers who never use ask_user -- mirrors
+        the existing __human_interrupt__ check's own tolerance of a get_state
+        failure (executor.py already logs-and-continues there; this is the
+        same contract for the additive check).
+        """
+        config = _seq_config(checkpoint_enabled=True)
+        executor = MASExecutor(config)
+        executor.initialize()
+
+        class _FailingGetState:
+            """Wraps the real compiled graph but breaks get_state()."""
+
+            def __init__(self, inner):
+                self._inner = inner
+
+            def stream(self, *args, **kwargs):
+                return self._inner.stream(*args, **kwargs)
+
+            def get_state(self, *args, **kwargs):
+                raise RuntimeError("Simulated get_state failure")
+
+        executor._compiled_graph = _FailingGetState(  # pylint: disable=protected-access
+            executor._compiled_graph
+        )  # pylint: disable=protected-access
+
+        with caplog.at_level("WARNING"):
+            events = list(
+                executor.run_streaming(
+                    {"messages": [HumanMessage(content="hi")]}, thread_id="t-fail"
+                )
+            )
+
+        assert not [e for e in events if e[0] == "__ask_user_pending__"]
+        assert any(
+            "ask_user interrupt check" in record.message for record in caplog.records
+        )
+
+    def test_no_pending_interrupt_yields_no_sentinel(self):
+        """A normal run (no interrupt() call anywhere) yields no
+        __ask_user_pending__ sentinel -- the additive check is a no-op for
+        every MAS that does not use ask_user.
+        """
+        config = _seq_config(checkpoint_enabled=True, n_agents=1)
+        executor = MASExecutor(config)
+        executor.initialize()
+
+        events = list(
+            executor.run_streaming(
+                {"messages": [HumanMessage(content="hi")]}, thread_id="t-normal"
+            )
+        )
+
+        assert not [e for e in events if e[0] == "__ask_user_pending__"]
+
+
+# =========================================================================
 # Helper-method coverage
 # =========================================================================
 

--- a/bili/iris/config/tool_config.py
+++ b/bili/iris/config/tool_config.py
@@ -156,4 +156,18 @@ TOOLS = {
             },
         },
     },
+    "ask_user": {
+        "description": "Pauses the agent's turn to ask the human operating it a "
+        "question, then resumes with the answer. Requires a host to have called "
+        "bili.iris.tools.ask_user.register_ask_user_tool() and, on the native "
+        "tool-calling path, to resume the paused run via Command(resume=...).",
+        "enabled": False,
+        # Unused by the tool's actual behavior -- ask_user's description is
+        # fixed on the StructuredTool built by register_ask_user_tool() and
+        # does not read this value. Present only so initialize_tools() (which
+        # requires every registered tool to resolve a prompt) does not force
+        # every caller to supply a placeholder prompt for a tool that has none.
+        "default_prompt": "Ask the human operating this agent a question when a "
+        "decision requires their input, then continue with their answer.",
+    },
 }

--- a/bili/iris/tools/__init__.py
+++ b/bili/iris/tools/__init__.py
@@ -3,7 +3,9 @@ from . import (
     api_open_weather,
     api_serp,
     api_weather_gov,
+    ask_user,
     faiss_memory_indexing,
+    hitl,
     mock_tool,
 )
 
@@ -12,6 +14,8 @@ __all__ = [
     "api_open_weather",
     "api_serp",
     "api_weather_gov",
+    "ask_user",
     "faiss_memory_indexing",
+    "hitl",
     "mock_tool",
 ]

--- a/bili/iris/tools/ask_user.py
+++ b/bili/iris/tools/ask_user.py
@@ -1,0 +1,171 @@
+"""``ask_user`` -- a generic agent-callable human-in-the-loop tool.
+
+Lets an agent pause its own turn to ask the human operating it a question it
+cannot answer from the conversation or its other tools, then continue with
+the answer folded back into context. This is the native tool-calling path
+only (``tool_strategy="native"``, i.e. ``langchain.agents.create_agent`` /
+``bind_tools``): the tool's function calls :func:`langgraph.types.interrupt`,
+which requires a LangGraph node to call it from. The CLI/MCP tool-strategy
+path and the prompted (facilitated) ReAct loop need a different pause
+mechanism each (no LangGraph node to interrupt on either) and are not
+implemented by this module.
+
+Usage
+-----
+::
+
+    from bili.iris.tools.ask_user import register_ask_user_tool, unregister_ask_user_tool
+    from bili.iris.tools.hitl import ScriptedHitlResponder
+
+    register_ask_user_tool(ScriptedHitlResponder(["staging"]))
+    try:
+        tools = initialize_tools(active_tools=["ask_user"], tool_prompts={})
+        # ... build and run a graph whose agent has these tools ...
+    finally:
+        unregister_ask_user_tool()
+
+A host that never calls :func:`register_ask_user_tool` still gets a working
+``ask_user`` entry once it is registered with the default
+:class:`~bili.iris.tools.hitl.NullHitlResponder` (see that function's
+default), so a MAS config that lists ``ask_user`` does not fail to compile
+in an environment where no real responder is wired up -- it degrades to the
+no-response sentinel instead.
+"""
+
+from typing import List, Optional
+
+from langchain_core.tools import StructuredTool
+
+from bili.iris.loaders.tools_loader import TOOL_REGISTRY
+from bili.iris.tools.hitl import HitlResponder, NullHitlResponder
+from bili.utils.logging_utils import get_logger
+
+LOGGER = get_logger(__name__)
+
+#: The fixed TOOL_REGISTRY / tool name. Not user-configurable -- unlike the
+#: domain tools in tools_loader.py (weather, SERP, ...), ask_user has no
+#: per-deployment parameters, so there is nothing for a caller to customize
+#: by choosing a different registry key.
+ASK_USER_TOOL_NAME = "ask_user"
+
+_ASK_USER_DESCRIPTION = (
+    "Ask the human operating this agent a question and wait for their answer. "
+    "Use this when a decision requires information or judgment only that "
+    "person has -- not something inferable from the conversation or your "
+    "other tools. Do not use it for routine clarification the task "
+    "instructions already answer. The optional 'options' list is a "
+    "rendering hint for short suggested answers; the human can always "
+    "reply with free text instead. The response may be a sentinel "
+    "starting with '[no response:' if no human answer was available -- "
+    "treat that as 'no answer', not as a real answer, and proceed "
+    "accordingly (e.g. state your own best judgment and note that no "
+    "human input was available, rather than inventing an answer)."
+)
+
+
+def _build_ask_user_func():
+    """Return the tool ``func`` for the native tool-calling pause path.
+
+    Calls :func:`langgraph.types.interrupt` so the pause happens inside the
+    calling LangGraph node (native tool-calling / ``create_agent`` path
+    only). ``interrupt()`` raises ``GraphInterrupt`` on first invocation
+    within a task, which ``langgraph.prebuilt.tool_node.ToolNode`` re-raises
+    rather than converting into a ``ToolMessage(status="error")`` -- so the
+    pause propagates cleanly out of native tool execution instead of being
+    swallowed as a tool failure. On resume within the same task, the second
+    ``interrupt()`` call returns the previously supplied resume value instead
+    of pausing again.
+
+    Does not call a :class:`~bili.iris.tools.hitl.HitlResponder` -- on this
+    path the pause/resume IS the answer-delivery mechanism (the caller
+    resumes the graph with the answer via ``Command(resume=...)``, see
+    :meth:`~bili.aether.runtime.executor.MASExecutor.resume_with_value`).
+    A ``HitlResponder`` is only consulted on the CLI/MCP tool-strategy path,
+    where there is no LangGraph node to interrupt (tracked separately, not
+    built here).
+    """
+
+    def _ask_user(question: str, options: Optional[List[str]] = None) -> str:
+        # pylint: disable=import-outside-toplevel
+        from langgraph.types import interrupt
+
+        payload = {"type": ASK_USER_TOOL_NAME, "question": question, "options": options}
+        answer = interrupt(payload)
+        return str(answer)
+
+    return _ask_user
+
+
+def register_ask_user_tool(responder: Optional[HitlResponder] = None) -> None:
+    """Insert ``ask_user`` into ``TOOL_REGISTRY``.
+
+    Mirrors :func:`bili.iris.mcp.loader.register_mcp_tools`'s pattern of
+    inserting a pre-built LangChain tool into
+    :data:`~bili.iris.loaders.tools_loader.TOOL_REGISTRY` under a
+    ``(name, prompt, params) -> Tool`` factory that ignores its arguments,
+    since (unlike the domain tools in ``tools_loader.py``) ``ask_user`` has
+    no per-call configuration on the native tool-calling path.
+
+    Calling this twice without an intervening :func:`unregister_ask_user_tool`
+    replaces the previously registered tool; a warning is logged so a host
+    does not silently lose track of a prior registration.
+
+    :param responder: Reserved for the CLI/MCP tool-strategy path, where
+        there is no LangGraph node to interrupt and a
+        :class:`~bili.iris.tools.hitl.HitlResponder` is the only pause
+        mechanism available. The native (``create_agent``) tool built here
+        does not call *responder* -- on that path ``interrupt()`` /
+        ``Command(resume=...)`` IS the answer-delivery mechanism. Passing
+        *responder* now is forward-compatible with the CLI/MCP path landing
+        later; it has no effect on native tool-calling behavior today.
+        Defaults to :class:`~bili.iris.tools.hitl.NullHitlResponder` when
+        omitted.
+    """
+    if ASK_USER_TOOL_NAME in TOOL_REGISTRY:
+        LOGGER.warning(
+            "register_ask_user_tool: '%s' is already registered; replacing "
+            "the existing tool.",
+            ASK_USER_TOOL_NAME,
+        )
+
+    # Constructed for parity with the eventual CLI/MCP-path registration
+    # (which will actually call it) and to validate *responder* satisfies
+    # the HitlResponder protocol now rather than failing later, silently,
+    # the first time a CLI-path ask_user call needs it.
+    effective_responder = responder if responder is not None else NullHitlResponder()
+
+    tool = StructuredTool.from_function(
+        func=_build_ask_user_func(),
+        name=ASK_USER_TOOL_NAME,
+        description=_ASK_USER_DESCRIPTION,
+    )
+
+    # Ignores (name, prompt, params) -- ask_user has no per-registration
+    # config for a TOOL_REGISTRY caller to pass through initialize_tools().
+    TOOL_REGISTRY[ASK_USER_TOOL_NAME] = (
+        lambda _n, _p, _params, _t=tool: _t  # noqa: E731
+    )
+    LOGGER.info(
+        "TOOL_REGISTRY: registered '%s' (responder=%s reserved for the "
+        "CLI/MCP tool-strategy path)",
+        ASK_USER_TOOL_NAME,
+        type(effective_responder).__name__,
+    )
+
+
+def unregister_ask_user_tool() -> None:
+    """Remove ``ask_user`` from ``TOOL_REGISTRY``, if present.
+
+    No-op (not an error) when ``ask_user`` is not currently registered, so
+    callers can call this unconditionally in teardown/``finally`` blocks.
+    """
+    if ASK_USER_TOOL_NAME in TOOL_REGISTRY:
+        del TOOL_REGISTRY[ASK_USER_TOOL_NAME]
+        LOGGER.debug("TOOL_REGISTRY: removed '%s'", ASK_USER_TOOL_NAME)
+
+
+__all__ = [
+    "ASK_USER_TOOL_NAME",
+    "register_ask_user_tool",
+    "unregister_ask_user_tool",
+]

--- a/bili/iris/tools/hitl.py
+++ b/bili/iris/tools/hitl.py
@@ -1,0 +1,128 @@
+"""Human-in-the-loop responder seam for the ``ask_user`` tool.
+
+:class:`HitlResponder` is the one surface-agnostic contract a host implements
+to answer questions an agent raises mid-run via the ``ask_user`` tool
+(:mod:`bili.iris.tools.ask_user`). bili-core never renders a question itself
+and never picks a delivery surface (CLI prompt, HTTP endpoint, desktop modal,
+a message queue) -- that is entirely the host's responsibility. bili-core
+only defines the blocking call shape and the no-answer sentinel convention so
+an agent can tell "the human answered" apart from "no answer was available."
+
+This module carries no LLM-application concept beyond that seam: it does not
+know what a question is *about*, does not validate or store content, and does
+not impose a timeout policy. A host that needs a timeout implements it inside
+its own :meth:`HitlResponder.ask` (see :class:`ScriptedHitlResponder` for the
+shape of a minimal implementation).
+"""
+
+from typing import List, Optional, Protocol, runtime_checkable
+
+from bili.utils.logging_utils import get_logger
+
+LOGGER = get_logger(__name__)
+
+#: Prefix every no-answer sentinel returned by a HitlResponder must carry.
+#: Callers (agents, tests, and bili-core's own NullHitlResponder) check for
+#: this prefix rather than parsing free-text, so any HitlResponder
+#: implementation can signal "no answer" without bili-core needing to know
+#: why (timeout, explicit skip, or -- for NullHitlResponder -- "nothing was
+#: ever registered").
+NO_RESPONSE_PREFIX = "[no response:"
+
+
+@runtime_checkable
+# pylint: disable=too-few-public-methods
+# A single-method protocol by design: ask() is the entire seam, matching
+# HitlResponder's own docstring ("the ONE surface-agnostic contract").
+class HitlResponder(Protocol):
+    """Host-implemented callback that blocks until a human answers a question.
+
+    A single instance is registered once per process (or per run) via
+    :func:`bili.iris.tools.ask_user.register_ask_user_tool` and is shared by
+    every ``ask_user`` tool call that instance's registration produced. An
+    implementation backing more than one concurrent agent run (e.g. several
+    MAS runs fanned out in parallel by a host) must be safe to call from
+    multiple threads at once, since each in-flight ``ask_user`` call blocks
+    the thread that made it.
+    """
+
+    def ask(self, question: str, options: Optional[List[str]] = None) -> str:
+        """Block until a human answers *question*, then return the answer.
+
+        :param question: The question to surface to the human, already in
+            human-readable form -- bili-core does no further formatting.
+        :param options: Optional short list of suggested answers. Render as
+            quick-pick choices if the surface supports it; free-text must
+            always remain a valid answer regardless of *options*.
+        :returns: The human's answer as plain text. On timeout or an
+            explicit skip, return a string starting with
+            :data:`NO_RESPONSE_PREFIX` instead of raising, so the calling
+            agent can branch on "no answer" the same way it would on any
+            other tool observation.
+        """
+        # pylint: disable-next=unnecessary-ellipsis
+        ...  # pragma: no cover -- Protocol method body, never actually called
+
+
+# pylint: disable=too-few-public-methods
+# A single-method HitlResponder implementation by design -- see the
+# module-level disable comment on HitlResponder itself.
+class NullHitlResponder:
+    """Default responder when no host has registered one.
+
+    Exists so an agent whose config declares ``ask_user`` but runs in a host
+    that never wired up a real responder degrades to a clear sentinel answer
+    rather than crashing the whole run on a missing dependency. This is the
+    deliberate default of :func:`~bili.iris.tools.ask_user.register_ask_user_tool`
+    when called without an explicit *responder* -- it makes an unconfigured
+    ``ask_user`` visibly inert instead of silently unavailable.
+    """
+
+    def ask(  # pylint: disable=unused-argument
+        self, question: str, options: Optional[List[str]] = None
+    ) -> str:
+        """Return the no-responder sentinel without blocking."""
+        LOGGER.warning(
+            "ask_user called but no HitlResponder is registered; "
+            "returning the no-response sentinel. Call "
+            "register_ask_user_tool(responder=...) with a real HitlResponder "
+            "to enable ask_user for this process."
+        )
+        return f"{NO_RESPONSE_PREFIX} ask_user not configured]"
+
+
+class ScriptedHitlResponder:
+    """Test double that returns pre-scripted answers in order.
+
+    Not a production responder. Used by bili-core's own tests, and usable by
+    a host's tests, to exercise the ``ask_user`` pause/resume seam without a
+    real human or a real event loop.
+    """
+
+    def __init__(self, answers: List[str]) -> None:
+        """:param answers: Answers returned in order, one per :meth:`ask` call."""
+        self._answers = list(answers)
+        self._calls: List[dict] = []
+
+    def ask(self, question: str, options: Optional[List[str]] = None) -> str:
+        """Record the call and return the next scripted answer.
+
+        :raises IndexError: If called more times than there are scripted
+            answers -- a test bug (the script under-provisioned answers),
+            not a runtime condition to degrade gracefully from.
+        """
+        self._calls.append({"question": question, "options": options})
+        return self._answers[len(self._calls) - 1]
+
+    @property
+    def calls(self) -> List[dict]:
+        """The ``{"question", "options"}`` dicts recorded for each :meth:`ask` call."""
+        return list(self._calls)
+
+
+__all__ = [
+    "NO_RESPONSE_PREFIX",
+    "HitlResponder",
+    "NullHitlResponder",
+    "ScriptedHitlResponder",
+]

--- a/bili/iris/tools/tests/test_ask_user.py
+++ b/bili/iris/tools/tests/test_ask_user.py
@@ -1,0 +1,99 @@
+"""Unit tests for bili.iris.tools.ask_user registration/unregistration.
+
+End-to-end pause/resume behavior is covered by the integration tests
+(test_ask_user_iris_integration.py, and AETHER's
+test_ask_user_aether_integration.py) -- this module covers the registration
+lifecycle and edge cases those don't exercise: double registration,
+unregister when absent, and the tool's shape (name/description/schema)
+independent of a running graph.
+"""
+
+# pylint: disable=missing-function-docstring
+
+import logging
+
+import pytest
+
+from bili.iris.loaders.tools_loader import TOOL_REGISTRY
+from bili.iris.tools.ask_user import (
+    ASK_USER_TOOL_NAME,
+    register_ask_user_tool,
+    unregister_ask_user_tool,
+)
+from bili.iris.tools.hitl import ScriptedHitlResponder
+
+
+class TestRegisterAskUserTool:
+    """Tests for register_ask_user_tool()."""
+
+    def teardown_method(self):
+        unregister_ask_user_tool()
+
+    def test_registers_into_tool_registry(self):
+        register_ask_user_tool()
+        assert ASK_USER_TOOL_NAME in TOOL_REGISTRY
+
+    def test_registered_tool_has_expected_name_and_description(self):
+        register_ask_user_tool()
+        tool = TOOL_REGISTRY[ASK_USER_TOOL_NAME](None, None, {})
+        assert tool.name == ASK_USER_TOOL_NAME
+        assert "human" in tool.description.lower()
+
+    def test_registered_tool_accepts_question_and_optional_options(self):
+        register_ask_user_tool()
+        tool = TOOL_REGISTRY[ASK_USER_TOOL_NAME](None, None, {})
+        schema_fields = tool.args_schema.model_fields
+        assert "question" in schema_fields
+        assert "options" in schema_fields
+        assert schema_fields["question"].is_required()
+        assert not schema_fields["options"].is_required()
+
+    def test_tool_func_reaches_interrupt_outside_a_graph(self):
+        """Confirms the native tool's func calls langgraph.types.interrupt()
+        rather than silently returning a placeholder, by observing the
+        specific failure interrupt() itself raises when called with no
+        active LangGraph runnable context: RuntimeError from
+        langgraph.config.get_config(), not GraphInterrupt (GraphInterrupt
+        requires the runnable-context machinery interrupt() failed to find
+        here). The pause/resume-with-an-answer path is exercised for real
+        inside a compiled graph by the integration tests
+        (test_ask_user_iris_integration.py, test_ask_user_aether_integration.py).
+        """
+        register_ask_user_tool()
+        tool = TOOL_REGISTRY[ASK_USER_TOOL_NAME](None, None, {})
+        with pytest.raises(RuntimeError, match="runnable context"):
+            tool.func(question="Which environment?")
+
+    def test_double_registration_replaces_and_warns(self, caplog):
+        register_ask_user_tool()
+        first_tool = TOOL_REGISTRY[ASK_USER_TOOL_NAME](None, None, {})
+
+        with caplog.at_level(logging.WARNING):
+            register_ask_user_tool()
+
+        assert any("already registered" in record.message for record in caplog.records)
+        second_tool = TOOL_REGISTRY[ASK_USER_TOOL_NAME](None, None, {})
+        assert first_tool is not second_tool
+
+    def test_accepts_explicit_responder_without_error(self):
+        # Chunk 1: the native tool does not call *responder* (see
+        # _build_ask_user_func's docstring) -- this test only verifies
+        # register_ask_user_tool() accepts one without raising, ahead of the
+        # CLI/MCP-path wiring that will consume it.
+        responder = ScriptedHitlResponder(["staging"])
+        register_ask_user_tool(responder)
+        assert ASK_USER_TOOL_NAME in TOOL_REGISTRY
+
+
+class TestUnregisterAskUserTool:
+    """Tests for unregister_ask_user_tool()."""
+
+    def test_removes_from_tool_registry(self):
+        register_ask_user_tool()
+        unregister_ask_user_tool()
+        assert ASK_USER_TOOL_NAME not in TOOL_REGISTRY
+
+    def test_noop_when_not_registered(self):
+        unregister_ask_user_tool()  # already absent; must not raise
+        unregister_ask_user_tool()  # calling twice must also not raise
+        assert ASK_USER_TOOL_NAME not in TOOL_REGISTRY

--- a/bili/iris/tools/tests/test_ask_user_iris_integration.py
+++ b/bili/iris/tools/tests/test_ask_user_iris_integration.py
@@ -1,0 +1,188 @@
+"""End-to-end integration test: ask_user through IRIS's native tool-calling path.
+
+Builds a REAL compiled IRIS agent graph (``build_agent_graph``) with a fake
+tool-calling chat model scripted to call ``ask_user``, drives it through
+``langgraph.types.interrupt()`` pause and ``Command(resume=...)`` resume, and
+asserts the second half of the turn genuinely receives the injected answer.
+
+This is the IRIS half of the chunk-1 gating deliverable: prove the seam
+end-to-end with one graph layer (outer StateGraph -> react_agent node ->
+inner create_agent subgraph) before adding AETHER's extra provenance layer
+on top (see test_ask_user_aether_integration.py).
+"""
+
+# pylint: disable=duplicate-code
+# _ScriptedToolCallingModel is intentionally re-declared (not shared via
+# import) in bili/aether/tests/test_ask_user_aether_integration.py: the two
+# tests live in different packages (IRIS vs AETHER) with no existing
+# cross-package test-helper module, and each file's fake model is a small,
+# self-contained fixture scoped to that file's own test -- mirroring this
+# codebase's existing precedent for pylint duplicate-code suppressions on
+# intentionally-parallel test fixtures (e.g. bili/aegis/tests/conftest.py).
+
+from typing import Any, List, Sequence
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolCall
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langgraph.types import Command
+
+from bili.iris.graph_builder.classes.node import Node
+from bili.iris.loaders.langchain_loader import build_agent_graph, react_agent_node
+from bili.iris.tools.ask_user import (
+    ASK_USER_TOOL_NAME,
+    register_ask_user_tool,
+    unregister_ask_user_tool,
+)
+
+
+def _single_node_graph_definition() -> List[Node]:
+    """A minimal graph_definition with just react_agent as entry + exit.
+
+    Isolates the interrupt/resume seam from the default pipeline's other
+    nodes (persona, datetime, memory, normalization), which have their own
+    required kwargs unrelated to what this test exercises.
+    """
+    node = react_agent_node()
+    node.is_entry = True
+    node.routes_to_end = True
+    return [node]
+
+
+class _ScriptedToolCallingModel(BaseChatModel):
+    """Fake chat model that supports ``bind_tools`` and cycles scripted responses.
+
+    LangChain's stock fakes (``FakeListChatModel``, ``FakeMessagesListChatModel``)
+    do not override ``bind_tools``, so ``create_agent`` would reject them with
+    ``NotImplementedError``. This minimal fake exists to unblock testing the
+    native tool-calling path without a real LLM.
+    """
+
+    responses: List[BaseMessage] = []
+    #: Index of the next scripted response to serve (cycles, does not advance
+    #: past the last entry). Distinct from invocation_count below, which
+    #: counts real _generate() calls -- the two would collapse into a single,
+    #: ambiguous counter if conflated, exactly the kind of measurement
+    #: confusion that must not leak into a test asserting exact call counts.
+    next_response_index: int = 0
+    invocation_count: int = 0
+
+    def bind_tools(self, tools: Sequence[Any], **kwargs: Any) -> "BaseChatModel":
+        return self
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        self.invocation_count += 1
+        response = self.responses[self.next_response_index]
+        if self.next_response_index < len(self.responses) - 1:
+            self.next_response_index += 1
+        return ChatResult(generations=[ChatGeneration(message=response)])
+
+    @property
+    def _llm_type(self) -> str:
+        return "scripted-tool-calling-model"
+
+
+def _scripted_ask_user_model() -> _ScriptedToolCallingModel:
+    """Model scripted to call ask_user, then produce a final answer."""
+    return _ScriptedToolCallingModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    ToolCall(
+                        name=ASK_USER_TOOL_NAME,
+                        args={"question": "Which environment should I deploy to?"},
+                        id="call_1",
+                    )
+                ],
+            ),
+            AIMessage(content="Deploying to the environment you specified."),
+        ]
+    )
+
+
+class TestAskUserIrisIntegration:
+    """Proves the ask_user pause/resume seam through a real IRIS graph."""
+
+    def setup_method(self):
+        """Register ask_user before each test."""
+        register_ask_user_tool()
+
+    def teardown_method(self):
+        """Unregister ask_user after each test."""
+        unregister_ask_user_tool()
+
+    def test_pause_and_resume_through_real_graph(self):
+        """A real IRIS graph pauses at ask_user and resumes with the answer."""
+        # pylint: disable=import-outside-toplevel
+        from bili.iris.loaders.tools_loader import initialize_tools
+
+        tools = initialize_tools(active_tools=[ASK_USER_TOOL_NAME], tool_prompts={})
+        assert len(tools) == 1
+
+        model = _scripted_ask_user_model()
+        agent = build_agent_graph(
+            graph_definition=_single_node_graph_definition(),
+            node_kwargs={
+                "llm_model": model,
+                "tools": tools,
+                "tool_strategy": "native",
+            },
+        )
+
+        thread_id = "iris-ask-user-thread"
+        config = {"configurable": {"thread_id": thread_id}}
+
+        # --- First invoke: expect the graph to pause at the interrupt. ---
+        result = agent.invoke(
+            {"messages": [HumanMessage(content="Please deploy the app.")]},
+            config=config,
+        )
+
+        assert "__interrupt__" in result, (
+            "graph.invoke() must return early with a pending interrupt "
+            "instead of completing the turn"
+        )
+        pending_interrupts = result["__interrupt__"]
+        assert len(pending_interrupts) == 1
+        payload = pending_interrupts[0].value
+        assert payload["type"] == ASK_USER_TOOL_NAME
+        assert payload["question"] == "Which environment should I deploy to?"
+
+        # The model must have been invoked exactly once so far (the call
+        # that produced the ask_user tool_call) -- not yet the post-answer
+        # call.
+        assert model.invocation_count == 1
+
+        # --- Resume: supply the answer via Command(resume=...). ---
+        final = agent.invoke(Command(resume="staging"), config=config)
+
+        assert "__interrupt__" not in final, "the turn must complete after resume"
+        final_message = final["messages"][-1]
+        assert final_message.content == "Deploying to the environment you specified."
+
+        # THE GATING ASSERTION: the model must be invoked exactly twice total
+        # (once before the pause, once after resume with the answer folded
+        # into a ToolMessage), not three times. A third call would mean the
+        # pre-interrupt model call is being re-executed on resume -- the
+        # double-fire risk this test exists to pin. See
+        # test_ask_user_aether_integration.py for the equivalent assertion
+        # with AETHER's extra provenance-wrapping layer on top.
+        assert model.invocation_count == 2
+
+        # The answer must have reached the model as a ToolMessage, not been
+        # dropped or re-asked.
+        tool_messages = [
+            m for m in final["messages"] if type(m).__name__ == "ToolMessage"
+        ]
+        assert len(tool_messages) == 1
+        assert tool_messages[0].content == "staging"
+
+    def test_null_responder_default_does_not_block_registration(self):
+        """register_ask_user_tool() with no responder still registers a usable tool."""
+        # pylint: disable=import-outside-toplevel
+        from bili.iris.loaders.tools_loader import TOOL_REGISTRY
+
+        assert ASK_USER_TOOL_NAME in TOOL_REGISTRY
+        tool = TOOL_REGISTRY[ASK_USER_TOOL_NAME](None, None, {})
+        assert tool.name == ASK_USER_TOOL_NAME

--- a/bili/iris/tools/tests/test_hitl.py
+++ b/bili/iris/tools/tests/test_hitl.py
@@ -1,0 +1,70 @@
+"""Tests for bili.iris.tools.hitl.
+
+Covers:
+- NullHitlResponder returns the no-response sentinel without blocking.
+- ScriptedHitlResponder cycles scripted answers and records calls.
+- ScriptedHitlResponder raises when the script is exhausted (a test-authoring
+  bug, not a runtime condition to degrade from).
+- HitlResponder is runtime_checkable and isinstance-matches any object with
+  a compatible ask() method (structural typing, not a required base class).
+"""
+
+# pylint: disable=missing-function-docstring
+
+import pytest
+
+from bili.iris.tools.hitl import (
+    NO_RESPONSE_PREFIX,
+    HitlResponder,
+    NullHitlResponder,
+    ScriptedHitlResponder,
+)
+
+
+class TestNullHitlResponder:
+    """Tests for NullHitlResponder."""
+
+    def test_returns_no_response_sentinel(self):
+        responder = NullHitlResponder()
+        answer = responder.ask("Which environment?")
+        assert answer.startswith(NO_RESPONSE_PREFIX)
+
+    def test_ignores_options(self):
+        responder = NullHitlResponder()
+        answer = responder.ask("Pick one", options=["a", "b"])
+        assert answer.startswith(NO_RESPONSE_PREFIX)
+
+    def test_satisfies_hitl_responder_protocol(self):
+        assert isinstance(NullHitlResponder(), HitlResponder)
+
+
+class TestScriptedHitlResponder:
+    """Tests for ScriptedHitlResponder."""
+
+    def test_returns_answers_in_order(self):
+        responder = ScriptedHitlResponder(["staging", "yes"])
+        assert responder.ask("Which environment?") == "staging"
+        assert responder.ask("Proceed?") == "yes"
+
+    def test_records_calls(self):
+        responder = ScriptedHitlResponder(["staging"])
+        responder.ask("Which environment?", options=["staging", "prod"])
+        assert responder.calls == [
+            {"question": "Which environment?", "options": ["staging", "prod"]}
+        ]
+
+    def test_calls_property_returns_a_copy(self):
+        responder = ScriptedHitlResponder(["staging"])
+        responder.ask("q")
+        calls = responder.calls
+        calls.append({"question": "tampered", "options": None})
+        assert len(responder.calls) == 1
+
+    def test_raises_when_script_exhausted(self):
+        responder = ScriptedHitlResponder(["only-one"])
+        responder.ask("first question")
+        with pytest.raises(IndexError):
+            responder.ask("second question, no script left")
+
+    def test_satisfies_hitl_responder_protocol(self):
+        assert isinstance(ScriptedHitlResponder([]), HitlResponder)


### PR DESCRIPTION
## Summary

Adds a generic, agent-callable `ask_user` tool: an LLM agent pauses its own
turn mid-run to ask the human operating it a question, then continues with
the answer folded back into context. This is chunk 1 of a larger HITL
effort, scoped narrowly to the native tool-calling path
(`langchain.agents.create_agent` / `bind_tools`) to prove the pause/resume
seam works end to end before extending to the CLI/MCP tool-strategy path and
the prompted (facilitated) ReAct loop.

- `bili/iris/tools/hitl.py` -- `HitlResponder` (the surface-agnostic
  contract a host implements to answer questions; bili-core never renders a
  question or picks a delivery surface), `NullHitlResponder` (graceful
  default when no host has registered one), `ScriptedHitlResponder` (test
  double).
- `bili/iris/tools/ask_user.py` -- the tool itself. Its `func` calls
  `langgraph.types.interrupt()`, which `ToolNode` re-raises rather than
  converting into a tool-error message, so the pause propagates cleanly
  through IRIS's and AETHER's `create_agent`-based tool-calling nodes.
  Registered into `TOOL_REGISTRY` via `register_ask_user_tool()` /
  `unregister_ask_user_tool()`, mirroring the existing MCP-tool
  registration pattern in `bili/iris/mcp/loader.py`.
- `bili/aether/runtime/executor.py` -- `MASExecutor.resume_with_value()`
  (the `Command(resume=...)` counterpart to the existing
  `HumanMessage`-based `resume_streaming()`) and an additive
  `__ask_user_pending__` sentinel in `run_streaming()`, independent of the
  existing `human_in_loop` / `is_human` whole-agent-slot HITL mechanism
  (that mechanism pauses *before* an entire agent node runs; `ask_user`
  pauses *inside* a tool call and resumes the same agent with an answer).

## Design review finding (the gating question for this chunk)

`langgraph.types.interrupt()`'s own docs warn that on resume, "the graph
resumes from the start of the node, re-executing all logic." The open
question going in: does that re-execution cause AETHER's per-agent
bookkeeping (`agent_outputs`, the communication log) to double-fire, or an
already-completed LLM call inside `create_agent`'s internal tool-calling
loop to be re-invoked?

Verified empirically (both an isolated prototype and the integration test
below): the outer node does re-execute from its start, and any pure
computation in it before the tool call runs again -- but `agent_outputs`
and the communication log entries, which are only written once at the true
end of the node body, do NOT double-fire, and the LLM is invoked exactly
twice total across a full pause/resume cycle (once before the pause, once
after resume), not three times. `test_ask_user_aether_integration.py`
pins both of these with explicit assertions.

## Test plan

- [x] `bili/iris/tools/tests/test_ask_user_iris_integration.py` -- a real
  compiled IRIS graph (not mocked at the `create_agent` boundary) pauses at
  `ask_user`, resumes via `Command(resume=...)`, and the second half of the
  turn genuinely receives the answer as a `ToolMessage`.
- [x] `bili/aether/tests/test_ask_user_aether_integration.py` -- the same
  seam through a real single-agent AETHER MAS, with the double-fire
  assertions described above.
- [x] `bili/iris/tools/tests/test_ask_user.py`, `test_hitl.py` -- unit
  coverage for registration/unregistration, the `HitlResponder` protocol,
  and the no-response sentinel.
- [x] New tests for `MASExecutor.resume_with_value()` and the
  `__ask_user_pending__` sentinel's error-tolerance path in
  `test_executor_extended.py`.
- [x] Full `bili/iris/` (1856 tests) and `bili/aether/` (1352 of 1353;
  1 pre-existing worktree-only failure in `bili/aegis`, unrelated to this
  change and confirmed to fail identically on a clean `develop` checkout in
  the same worktree) pass.
- [x] `pylint bili/ --fail-under=9`: 9.64/10 (new files individually score
  10.00/10).

## Explicitly out of scope for this PR

- The CLI/MCP tool-strategy path (`ask_user` served over the ephemeral MCP
  server to a spawned CLI agent) -- there is no LangGraph node to interrupt
  there; needs its own `HitlResponder`-driven blocking design.
- The prompted/facilitated ReAct loop -- its hand-rolled tool-execution
  `except Exception` would currently swallow the interrupt's
  `GraphInterrupt` into an error observation instead of propagating the
  pause.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

https://claude.ai/code/session_01XpXRrbE4UhL22Usj6UdEVQ