### PR TITLE
feat: ask_user CLI/MCP tool-strategy pause path (blocking HitlResponder)

### DIFF
--- a/bili/aether/tests/test_validator.py
+++ b/bili/aether/tests/test_validator.py
@@ -391,6 +391,163 @@ def test_human_in_loop_missing_condition_warning():
 
 
 # =========================================================================
+# W14: ask_user + CLI tool_strategy='mcp' short timeout
+# =========================================================================
+
+
+def _ask_user_cli_agent(agent_id: str = "a", **kwargs) -> AgentSpec:
+    """An agent with ask_user in tools on the Claude Code CLI preset (mcp)."""
+    defaults = {
+        "model_name": "Claude Code CLI",
+        "tools": ["ask_user"],
+    }
+    defaults.update(kwargs)
+    return _agent(agent_id, **defaults)
+
+
+def test_ask_user_cli_short_timeout_warns():
+    """W14: an explicit short cli_subprocess_timeout on an ask_user CLI agent warns."""
+    config = MASConfig(
+        mas_id="test",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_ask_user_cli_agent(cli_subprocess_timeout=30.0)],
+    )
+
+    result = validate_mas(config)
+
+    assert result.valid is True
+    assert any(
+        "ask_user" in w and "cli_subprocess_timeout" in w for w in result.warnings
+    )
+
+
+def test_ask_user_cli_unset_timeout_no_warning():
+    """W14: an unset cli_subprocess_timeout (preset default) does not warn."""
+    config = MASConfig(
+        mas_id="test",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_ask_user_cli_agent()],
+    )
+
+    result = validate_mas(config)
+
+    assert not any("cli_subprocess_timeout" in w for w in result.warnings)
+
+
+def test_ask_user_cli_zero_timeout_no_warning():
+    """W14: cli_subprocess_timeout=0 (explicit no-timeout) does not warn."""
+    config = MASConfig(
+        mas_id="test",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_ask_user_cli_agent(cli_subprocess_timeout=0.0)],
+    )
+
+    result = validate_mas(config)
+
+    assert not any("cli_subprocess_timeout" in w for w in result.warnings)
+
+
+def test_ask_user_cli_generous_timeout_no_warning():
+    """W14: a timeout at or above the floor does not warn."""
+    config = MASConfig(
+        mas_id="test",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_ask_user_cli_agent(cli_subprocess_timeout=1800.0)],
+    )
+
+    result = validate_mas(config)
+
+    assert not any("cli_subprocess_timeout" in w for w in result.warnings)
+
+
+def test_ask_user_without_cli_model_no_warning():
+    """W14: ask_user on a non-CLI (native tool-calling) model does not warn.
+
+    The short-timeout footgun only exists on the CLI/MCP subprocess path;
+    a native tool-calling model has no subprocess timeout to discard the
+    turn.
+    """
+    config = MASConfig(
+        mas_id="test",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[
+            _agent(
+                "a",
+                model_name="gpt-4o",
+                tools=["ask_user"],
+                cli_subprocess_timeout=10.0,
+            )
+        ],
+    )
+
+    result = validate_mas(config)
+
+    assert not any("cli_subprocess_timeout" in w for w in result.warnings)
+
+
+def test_cli_model_without_ask_user_no_warning():
+    """W14: a short timeout on a CLI model without ask_user does not warn.
+
+    cli_subprocess_timeout is a legitimate, unrelated knob for any CLI
+    agent; the warning is specific to ask_user's turn-discarding footgun,
+    not a general opinion on short CLI timeouts.
+    """
+    config = MASConfig(
+        mas_id="test",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[
+            _agent(
+                "a",
+                model_name="Claude Code CLI",
+                tools=[],
+                cli_subprocess_timeout=10.0,
+            )
+        ],
+    )
+
+    result = validate_mas(config)
+
+    assert not any("cli_subprocess_timeout" in w for w in result.warnings)
+
+
+def test_ask_user_cli_timeout_skipped_when_llm_resolver_unavailable(monkeypatch):
+    """W14: the check is skipped (not raised) when llm_resolver can't be imported.
+
+    Config construction happens BEFORE the import block: AgentSpec's own
+    system_prompt length-limit validator also imports llm_resolver, so
+    blocking the import unconditionally would break AgentSpec construction
+    itself, not just the check under test.
+    """
+    config = MASConfig(
+        mas_id="test",
+        name="Test",
+        workflow_type=WorkflowType.SEQUENTIAL,
+        agents=[_ask_user_cli_agent(cli_subprocess_timeout=30.0)],
+    )
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blocked_import(name, *args, **kwargs):
+        if name == "bili.aether.compiler.llm_resolver":
+            raise ImportError("simulated: llm_resolver unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+
+    result = validate_mas(config)
+
+    assert not any("cli_subprocess_timeout" in w for w in result.warnings)
+
+
+# =========================================================================
 # INTEGRATION TESTS
 # =========================================================================
 

--- a/bili/aether/validation/validator.py
+++ b/bili/aether/validation/validator.py
@@ -72,6 +72,7 @@ class MASValidator:
     def _check_agents(self) -> None:
         self._check_orphaned_agents()
         self._check_supervisor_capabilities()
+        self._check_ask_user_cli_timeout()
 
     def _check_orphaned_agents(self) -> None:
         """W1: Warn about agents with no channel connections.
@@ -103,6 +104,61 @@ class MASValidator:
                         f"Supervisor agent '{agent.agent_id}' should have "
                         f"'inter_agent_communication' capability"
                     )
+
+    #: Floor below which an explicit cli_subprocess_timeout on an ask_user
+    #: agent is flagged.  A human needs time to notice a pending question and
+    #: respond; the CLI subprocess timeout kills the WHOLE turn (not just the
+    #: pending question) if it expires first, so a short explicit override is
+    #: very likely a footgun rather than an intentional choice.  5 minutes is
+    #: a floor, not a recommendation -- most ask_user-enabled agents should
+    #: leave cli_subprocess_timeout unset (the 1800s preset default) or set
+    #: it to 0 (no timeout) rather than tune it down.
+    _ASK_USER_CLI_TIMEOUT_FLOOR_SECONDS = 300.0
+
+    def _check_ask_user_cli_timeout(self) -> None:
+        """W14: Warn if an ask_user agent on a CLI/MCP model has a too-short timeout.
+
+        The CLI subprocess path (tool_strategy='mcp') has no LangGraph node to
+        interrupt; ask_user blocks the subprocess call itself on a
+        HitlResponder. The subprocess's own cli_subprocess_timeout is a blunt
+        instrument: if it expires before the human answers, the ENTIRE turn is
+        discarded (CliLLMError), not just the pending question. An explicit
+        override below _ASK_USER_CLI_TIMEOUT_FLOOR_SECONDS is flagged; leaving
+        cli_subprocess_timeout unset (preset default 1800s) or 0 (no timeout)
+        is not.
+
+        Skipped entirely when resolve_tool_strategy is unavailable (mirrors
+        that function's own ImportError tolerance) or when an agent has no
+        model_name (nothing to resolve).
+        """
+        try:
+            from bili.aether.compiler.llm_resolver import (  # pylint: disable=import-outside-toplevel
+                resolve_tool_strategy,
+            )
+        except ImportError:
+            return
+
+        for agent in self._config.agents:
+            if "ask_user" not in agent.tools or not agent.model_name:
+                continue
+            if agent.cli_subprocess_timeout is None:
+                continue  # preset default (1800s) -- generous, not flagged
+            if agent.cli_subprocess_timeout == 0.0:
+                continue  # explicit "no timeout" -- the safe extreme
+            if agent.cli_subprocess_timeout >= self._ASK_USER_CLI_TIMEOUT_FLOOR_SECONDS:
+                continue
+            if resolve_tool_strategy(agent.model_name) != "mcp":
+                continue
+            self._result.add_warning(
+                f"Agent '{agent.agent_id}' has 'ask_user' in tools and a CLI "
+                f"tool_strategy='mcp' model with cli_subprocess_timeout="
+                f"{agent.cli_subprocess_timeout}s. If the human has not "
+                f"answered by then, the ENTIRE turn is discarded, not just "
+                f"the pending question. Leave cli_subprocess_timeout unset "
+                f"(preset default 1800s) or set it to 0 (no timeout) unless "
+                f"you have a specific reason to bound how long this agent "
+                f"waits for a human."
+            )
 
     # ==================================================================
     # Channel checks

--- a/bili/iris/mcp/server.py
+++ b/bili/iris/mcp/server.py
@@ -71,6 +71,7 @@ Typical usage
     # node_callable is a (state: dict) -> dict callable suitable for LangGraph.
 """
 
+import contextvars
 import inspect
 import logging
 import os
@@ -85,6 +86,21 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 LOGGER = logging.getLogger(__name__)
+
+#: Set (via a token-scoped context, see ``_build_mcp_fn``) for the duration
+#: of every ``tool.invoke(...)`` call made on behalf of an MCP-served tool
+#: request.  A tool implementation that needs to tell "I am being called
+#: through the ephemeral MCP bridge" apart from "I am being called through
+#: LangGraph's own tool-execution node" cannot rely on
+#: ``langchain_core.runnables.RunnableConfig`` propagation for this: calling
+#: ``Runnable.invoke()`` at all (as this module and LangGraph's own
+#: ``ToolNode`` both do) sets that ambient config regardless of whether a
+#: LangGraph graph is actually driving the call, so it cannot distinguish
+#: the two contexts.  This contextvar is bili-core's own, narrower signal,
+#: true only for the duration of a call this module itself makes.
+IN_MCP_TOOL_CALL: "contextvars.ContextVar[bool]" = contextvars.ContextVar(
+    "bili_iris_mcp_in_tool_call", default=False
+)
 
 # ---------------------------------------------------------------------------
 # Optional heavy dependencies — deferred so importing this module does not
@@ -275,6 +291,12 @@ def _build_mcp_fn(tool: Any) -> Callable:
     In both cases the function's ``__name__`` is set to ``tool.name`` so
     FastMCP registers it under the correct tool name.
 
+    Sets :data:`IN_MCP_TOOL_CALL` to ``True`` for the duration of the
+    ``tool.invoke(...)`` call so a tool implementation that dispatches on
+    calling context (e.g. ``ask_user``, which has no LangGraph node to
+    ``interrupt()`` on this path) can tell it apart from a native
+    ``ToolNode`` invocation.
+
     :param tool: A LangChain :class:`~langchain_core.tools.BaseTool`.
     :returns: A callable suitable for ``FastMCP.add_tool(fn, ...)``.
     """
@@ -286,7 +308,11 @@ def _build_mcp_fn(tool: Any) -> Callable:
     if not model_fields:
         # Plain single-string-input tool.
         def _plain_fn(tool_input: str) -> str:
-            return str(tool.invoke(tool_input))
+            token = IN_MCP_TOOL_CALL.set(True)
+            try:
+                return str(tool.invoke(tool_input))
+            finally:
+                IN_MCP_TOOL_CALL.reset(token)
 
         _plain_fn.__name__ = tool.name
         _plain_fn.__doc__ = tool.description or ""
@@ -312,7 +338,11 @@ def _build_mcp_fn(tool: Any) -> Callable:
         )
 
     def _structured_fn(**kwargs: Any) -> str:
-        return str(tool.invoke(kwargs))
+        token = IN_MCP_TOOL_CALL.set(True)
+        try:
+            return str(tool.invoke(kwargs))
+        finally:
+            IN_MCP_TOOL_CALL.reset(token)
 
     _structured_fn.__signature__ = inspect.Signature(
         parameters=params, return_annotation=str

--- a/bili/iris/mcp/tests/test_ask_user_mcp_integration.py
+++ b/bili/iris/mcp/tests/test_ask_user_mcp_integration.py
@@ -1,0 +1,344 @@
+"""Real end-to-end integration test: ask_user through the ephemeral MCP server.
+
+Unlike every other test in bili/iris/mcp/tests/ (which mock the server and
+transport entirely -- see test_server.py's own module docstring: "All tests
+run without a real MCP server or CLI binary. Network I/O is mocked."), this
+test spins up a REAL EphemeralMcpServer (real uvicorn thread, real FastMCP
+tool registration) and drives it with a REAL MCP client
+(streamable-HTTP transport, matching what EphemeralMcpServer actually
+serves) making a genuine HTTP tool call.
+
+The fake CLI agent here is a real MCP client session standing in for what
+claude -p / codex / gemini would do internally when they call an MCP tool --
+the actual CLI subprocess spawn (build_mcp_node's subprocess.run) is
+exercised separately and with mocks in test_server.py; this test's job is
+proving the tool CALL itself, over the real transport, reaches a real
+HitlResponder and blocks correctly.
+
+Requires the [mcp] extra (mcp + uvicorn). Skipped, not failed, when it is
+not installed -- mirrors bili.iris.mcp.server's own optional-dependency
+handling rather than making this a hard requirement for the base install.
+"""
+
+# pylint: disable=import-outside-toplevel
+# Every mcp/uvicorn/ask_user import in this module is deferred to inside
+# test functions and async closures, matching the optional-[mcp]-extra
+# pattern bili.iris.mcp.server itself uses (importing at module level would
+# make collecting this file fail entirely when the extra is not installed,
+# defeating the pytestmark skip above).
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from bili.iris.mcp.server import _MCP_AVAILABLE
+
+pytestmark = pytest.mark.skipif(
+    not _MCP_AVAILABLE, reason="requires the [mcp] extra (mcp + uvicorn)"
+)
+
+
+def _register_and_get_tool(responder):
+    """Register ask_user with *responder* and return the built LangChain tool."""
+    from bili.iris.loaders.tools_loader import TOOL_REGISTRY
+    from bili.iris.tools.ask_user import ASK_USER_TOOL_NAME, register_ask_user_tool
+
+    register_ask_user_tool(responder)
+    return TOOL_REGISTRY[ASK_USER_TOOL_NAME](None, None, {})
+
+
+class TestAskUserMcpIntegration:
+    """Proves the ask_user MCP-path seam end-to-end over a real server."""
+
+    def teardown_method(self):
+        """Unregister ask_user after each test."""
+        from bili.iris.tools.ask_user import unregister_ask_user_tool
+
+        unregister_ask_user_tool()
+
+    def test_real_mcp_call_blocks_on_responder_and_returns_answer(self):
+        """A real MCP client calls ask_user; the call blocks on a real
+        ScriptedHitlResponder and the answer comes back as the tool result
+        -- the exact round trip a spawned CLI subprocess's own internal
+        tool-calling loop would make against the ephemeral server.
+        """
+        from bili.iris.mcp.server import EphemeralMcpServer
+        from bili.iris.tools.hitl import ScriptedHitlResponder
+
+        responder = ScriptedHitlResponder(["staging"])
+        tool = _register_and_get_tool(responder)
+
+        async def _run():
+            from mcp import ClientSession
+            from mcp.client.streamable_http import streamablehttp_client
+
+            with EphemeralMcpServer([tool]) as handle:
+                headers = {"Authorization": f"Bearer {handle.token}"}
+                async with streamablehttp_client(
+                    handle.server_url, headers=headers
+                ) as (
+                    read,
+                    write,
+                    _get_session_id,
+                ):
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        tools_result = await session.list_tools()
+                        assert [t.name for t in tools_result.tools] == ["ask_user"]
+
+                        result = await session.call_tool(
+                            "ask_user",
+                            arguments={
+                                "question": "Which environment should I deploy to?"
+                            },
+                        )
+                        return result
+
+        result = asyncio.run(_run())
+
+        assert result.isError is False
+        text_blocks = [
+            block.text
+            for block in result.content
+            if getattr(block, "type", None) == "text"
+        ]
+        assert text_blocks == ["staging"]
+
+        # The responder genuinely received the call -- not a placeholder
+        # short-circuit somewhere upstream of the real HTTP round trip.
+        assert responder.calls == [
+            {"question": "Which environment should I deploy to?", "options": None}
+        ]
+
+    def test_real_mcp_call_forwards_options(self):
+        """The 'options' rendering hint reaches the responder over the wire."""
+        from bili.iris.mcp.server import EphemeralMcpServer
+        from bili.iris.tools.hitl import ScriptedHitlResponder
+
+        responder = ScriptedHitlResponder(["staging"])
+        tool = _register_and_get_tool(responder)
+
+        async def _run():
+            from mcp import ClientSession
+            from mcp.client.streamable_http import streamablehttp_client
+
+            with EphemeralMcpServer([tool]) as handle:
+                headers = {"Authorization": f"Bearer {handle.token}"}
+                async with streamablehttp_client(
+                    handle.server_url, headers=headers
+                ) as (
+                    read,
+                    write,
+                    _get_session_id,
+                ):
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        return await session.call_tool(
+                            "ask_user",
+                            arguments={
+                                "question": "Which environment?",
+                                "options": ["staging", "production"],
+                            },
+                        )
+
+        asyncio.run(_run())
+
+        assert responder.calls == [
+            {
+                "question": "Which environment?",
+                "options": ["staging", "production"],
+            }
+        ]
+
+    def test_real_mcp_call_with_no_responder_returns_null_sentinel(self):
+        """No responder registered (NullHitlResponder default): the real MCP
+        round trip returns the no-response sentinel instead of hanging or
+        raising -- an unconfigured CLI-path deployment degrades gracefully.
+        """
+        from bili.iris.mcp.server import EphemeralMcpServer
+        from bili.iris.tools.hitl import NO_RESPONSE_PREFIX
+
+        tool = _register_and_get_tool(None)
+
+        async def _run():
+            from mcp import ClientSession
+            from mcp.client.streamable_http import streamablehttp_client
+
+            with EphemeralMcpServer([tool]) as handle:
+                headers = {"Authorization": f"Bearer {handle.token}"}
+                async with streamablehttp_client(
+                    handle.server_url, headers=headers
+                ) as (
+                    read,
+                    write,
+                    _get_session_id,
+                ):
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        return await session.call_tool(
+                            "ask_user", arguments={"question": "Which environment?"}
+                        )
+
+        result = asyncio.run(_run())
+
+        text_blocks = [
+            block.text
+            for block in result.content
+            if getattr(block, "type", None) == "text"
+        ]
+        assert len(text_blocks) == 1
+        assert text_blocks[0].startswith(NO_RESPONSE_PREFIX)
+
+    def test_call_blocks_the_calling_thread_until_responder_returns(self):
+        """The tool call genuinely BLOCKS for as long as the responder takes
+        to answer -- proving the seam is a real blocking call, not something
+        that returns immediately with a promise/future the CLI subprocess
+        would then have to poll (which is not how MCP tool calls work; the
+        subprocess's own request blocks on this call by construction, but
+        this test pins the seam's own blocking behavior directly, independent
+        of MCP transport semantics).
+        """
+        from bili.iris.mcp.server import EphemeralMcpServer
+
+        # pylint: disable=too-few-public-methods
+        # A single-method HitlResponder test double by design -- see hitl.py's
+        # own module-level disable comment on the same shape.
+        class _SlowResponder:
+            """Sleeps briefly before answering, to make blocking observable."""
+
+            def __init__(self, delay_seconds, answer):
+                self._delay = delay_seconds
+                self._answer = answer
+                self.answered_at = None
+
+            def ask(self, question, options=None):  # pylint: disable=unused-argument
+                """Sleep, then return the scripted answer."""
+                time.sleep(self._delay)
+                self.answered_at = time.monotonic()
+                return self._answer
+
+        responder = _SlowResponder(delay_seconds=0.3, answer="staging")
+        tool = _register_and_get_tool(responder)
+
+        async def _run():
+            from mcp import ClientSession
+            from mcp.client.streamable_http import streamablehttp_client
+
+            with EphemeralMcpServer([tool]) as handle:
+                headers = {"Authorization": f"Bearer {handle.token}"}
+                async with streamablehttp_client(
+                    handle.server_url, headers=headers
+                ) as (
+                    read,
+                    write,
+                    _get_session_id,
+                ):
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        before = time.monotonic()
+                        result = await session.call_tool(
+                            "ask_user", arguments={"question": "Which environment?"}
+                        )
+                        after = time.monotonic()
+                        return result, before, after
+
+        _result, before, after = asyncio.run(_run())
+
+        assert (after - before) >= 0.3, (
+            "the call returned before the responder's delay elapsed -- "
+            "the seam is not genuinely blocking"
+        )
+        assert responder.answered_at is not None
+        assert before <= responder.answered_at <= after
+
+    def test_two_concurrent_agent_runs_against_one_responder_do_not_cross_answers(self):
+        """Two ask_user calls in flight at once against ONE shared responder
+        (the fan-out-batch scenario HitlResponder's docstring names) get
+        their own distinct, correctly-matched answers -- not a race where
+        one call's answer leaks into the other's result.
+
+        Uses two separate EphemeralMcpServer instances (each call is its own
+        MCP server + subprocess in the real architecture) driven from two
+        threads, both hitting the SAME ScriptedHitlResponder instance, which
+        is exactly the shape a host's ScriptedHitlResponder must be safe
+        under (see hitl.py's thread-safety contract).
+        """
+        from bili.iris.mcp.server import EphemeralMcpServer
+        from bili.iris.tools.hitl import ScriptedHitlResponder
+
+        responder = ScriptedHitlResponder(["staging", "production"])
+
+        results = {}
+        errors = []
+
+        def _run_one(index, question):
+            try:
+                tool = _register_and_get_tool_isolated(responder)
+
+                async def _run():
+                    from mcp import ClientSession
+                    from mcp.client.streamable_http import streamablehttp_client
+
+                    with EphemeralMcpServer([tool]) as handle:
+                        headers = {"Authorization": f"Bearer {handle.token}"}
+                        async with streamablehttp_client(
+                            handle.server_url, headers=headers
+                        ) as (read, write, _get_session_id):
+                            async with ClientSession(read, write) as session:
+                                await session.initialize()
+                                return await session.call_tool(
+                                    "ask_user", arguments={"question": question}
+                                )
+
+                results[index] = asyncio.run(_run())
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                errors.append((index, exc))
+
+        threads = [
+            threading.Thread(target=_run_one, args=(0, "Which environment (a)?")),
+            threading.Thread(target=_run_one, args=(1, "Which environment (b)?")),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"concurrent calls raised: {errors}"
+        assert set(results.keys()) == {0, 1}
+
+        answers = set()
+        for result in results.values():
+            text_blocks = [
+                block.text
+                for block in result.content
+                if getattr(block, "type", None) == "text"
+            ]
+            answers.add(text_blocks[0])
+
+        # Both scripted answers were consumed exactly once each, with no
+        # duplicate/lost/crossed answer -- the lock in ScriptedHitlResponder
+        # (see hitl.py) is what makes this deterministic instead of racy.
+        assert answers == {"staging", "production"}
+        assert len(responder.calls) == 2
+
+
+def _register_and_get_tool_isolated(responder):
+    """Like _register_and_get_tool but does not mutate TOOL_REGISTRY.
+
+    Used by the concurrency test, which needs two independent tool
+    instances bound to the SAME responder without one registration
+    clobbering the other via the shared TOOL_REGISTRY dict (register_ask_user_tool
+    is a process-global registration, not meant to be called concurrently
+    from two threads for two different tool instances).
+    """
+    from langchain_core.tools import StructuredTool
+
+    from bili.iris.tools.ask_user import _ASK_USER_DESCRIPTION, _build_ask_user_func
+
+    return StructuredTool.from_function(
+        func=_build_ask_user_func(responder),
+        name="ask_user",
+        description=_ASK_USER_DESCRIPTION,
+    )

--- a/bili/iris/tools/ask_user.py
+++ b/bili/iris/tools/ask_user.py
@@ -2,13 +2,54 @@
 
 Lets an agent pause its own turn to ask the human operating it a question it
 cannot answer from the conversation or its other tools, then continue with
-the answer folded back into context. This is the native tool-calling path
-only (``tool_strategy="native"``, i.e. ``langchain.agents.create_agent`` /
-``bind_tools``): the tool's function calls :func:`langgraph.types.interrupt`,
-which requires a LangGraph node to call it from. The CLI/MCP tool-strategy
-path and the prompted (facilitated) ReAct loop need a different pause
-mechanism each (no LangGraph node to interrupt on either) and are not
-implemented by this module.
+the answer folded back into context.
+
+One ``TOOL_REGISTRY`` entry serves TWO pause mechanisms, because
+:func:`~bili.aether.compiler.llm_resolver.resolve_tools` resolves an agent's
+tool list before ``tool_strategy`` is known (a compile-time ordering this
+module does not control), so the same tool object must work correctly
+whichever path ends up calling it:
+
+- **Native tool-calling** (``tool_strategy="native"``, i.e.
+  ``langchain.agents.create_agent`` / ``bind_tools``): the tool's ``func``
+  calls :func:`langgraph.types.interrupt`, which requires a LangGraph node to
+  call it from and pauses the whole graph until
+  :meth:`~bili.aether.runtime.executor.MASExecutor.resume_with_value` supplies
+  the answer.
+- **CLI/MCP** (``tool_strategy="mcp"``): the tool is served over the
+  ephemeral authenticated MCP server (:mod:`bili.iris.mcp.server`) to a
+  spawned CLI agent that self-orchestrates. There is no LangGraph node to
+  interrupt there, so the tool's ``func`` instead blocks by calling the
+  registered :class:`~bili.iris.tools.hitl.HitlResponder` directly.
+
+``func`` therefore dispatches to exactly one of two separate, single-purpose
+implementations (:func:`_ask_user_native_impl`, :func:`_ask_user_mcp_impl`);
+the dispatcher itself carries no HITL logic of its own. The prompted
+(facilitated) ReAct loop needs a third mechanism and is not implemented by
+this module.
+
+Dispatch signal
+----------------
+Calling ``langchain_core.runnables.Runnable.invoke()`` at all -- which both
+``langgraph.prebuilt.tool_node.ToolNode`` (native path) and
+:func:`bili.iris.mcp.server._build_mcp_fn` (MCP path) do -- sets LangChain's
+own ambient ``RunnableConfig`` propagation contextvar regardless of whether a
+LangGraph graph is actually driving the call. That makes
+``langgraph.config.get_config()`` indistinguishable between the two paths: it
+succeeds in BOTH, so it cannot be used as the dispatch signal (confirmed by a
+real MCP round trip: a bare ``tool.invoke()`` call already populates
+``RunnableConfig``, so ``get_config()`` returns cleanly outside any graph).
+The dispatcher instead reads :data:`bili.iris.mcp.server.IN_MCP_TOOL_CALL`,
+a contextvar bili-core's own MCP bridge sets around its ``tool.invoke(...)``
+call -- true only for the duration of a call the ephemeral MCP server itself
+made, which is the actual distinction needed.
+
+No ``ask_user``-specific server code was added for this: ``IN_MCP_TOOL_CALL``
+is generic (any tool wanting to detect "am I being called through the MCP
+bridge" can read it), and ``EphemeralMcpServer`` still registers whatever
+LangChain tool it is given without knowing anything about ``ask_user``
+itself -- ``ask_user`` reaches it through the exact same
+``resolve_tools -> build_mcp_node`` route as every other tool.
 
 Usage
 -----
@@ -63,15 +104,13 @@ _ASK_USER_DESCRIPTION = (
 )
 
 
-def _build_ask_user_func():
-    """Return the tool ``func`` for the native tool-calling pause path.
+def _ask_user_native_impl(question: str, options: Optional[List[str]]) -> str:
+    """Native tool-calling pause: block via ``langgraph.types.interrupt``.
 
-    Calls :func:`langgraph.types.interrupt` so the pause happens inside the
-    calling LangGraph node (native tool-calling / ``create_agent`` path
-    only). ``interrupt()`` raises ``GraphInterrupt`` on first invocation
-    within a task, which ``langgraph.prebuilt.tool_node.ToolNode`` re-raises
-    rather than converting into a ``ToolMessage(status="error")`` -- so the
-    pause propagates cleanly out of native tool execution instead of being
+    ``interrupt()`` raises ``GraphInterrupt`` on first invocation within a
+    task, which ``langgraph.prebuilt.tool_node.ToolNode`` re-raises rather
+    than converting into a ``ToolMessage(status="error")`` -- so the pause
+    propagates cleanly out of native tool execution instead of being
     swallowed as a tool failure. On resume within the same task, the second
     ``interrupt()`` call returns the previously supplied resume value instead
     of pausing again.
@@ -80,18 +119,65 @@ def _build_ask_user_func():
     path the pause/resume IS the answer-delivery mechanism (the caller
     resumes the graph with the answer via ``Command(resume=...)``, see
     :meth:`~bili.aether.runtime.executor.MASExecutor.resume_with_value`).
-    A ``HitlResponder`` is only consulted on the CLI/MCP tool-strategy path,
-    where there is no LangGraph node to interrupt (tracked separately, not
-    built here).
+    """
+    from langgraph.types import interrupt  # pylint: disable=import-outside-toplevel
+
+    payload = {"type": ASK_USER_TOOL_NAME, "question": question, "options": options}
+    answer = interrupt(payload)
+    return str(answer)
+
+
+def _ask_user_mcp_impl(
+    question: str, options: Optional[List[str]], responder: HitlResponder
+) -> str:
+    """CLI/MCP pause: block by calling *responder* directly.
+
+    There is no LangGraph node to interrupt here -- the FastMCP tool handler
+    runs as a plain function on the ephemeral server's own event loop
+    (:mod:`bili.iris.mcp.server`), invoked by a spawned CLI subprocess that
+    self-orchestrates outside any graph bili-core drives. The block IS the
+    delivery mechanism: this call does not return until *responder* does,
+    which is exactly what leaves the CLI subprocess's own outstanding tool
+    call pending for as long as the human takes to answer.
+    """
+    return responder.ask(question, options)
+
+
+def _called_via_mcp_bridge() -> bool:
+    """True if the current call originated from the ephemeral MCP server.
+
+    Reads :data:`bili.iris.mcp.server.IN_MCP_TOOL_CALL`, set by
+    :func:`bili.iris.mcp.server._build_mcp_fn` around its ``tool.invoke(...)``
+    call. This is NOT the same question as "is a LangGraph graph driving this
+    call" -- ``langgraph.config.get_config()`` cannot answer that reliably
+    here, because calling ``Runnable.invoke()`` at all (which both the native
+    ``ToolNode`` path and the MCP bridge do) populates LangChain's ambient
+    ``RunnableConfig`` regardless of LangGraph involvement (see the module
+    docstring's "Dispatch signal" section for the concrete finding). Lazily
+    imports :mod:`bili.iris.mcp.server` so that importing this module does
+    not require the ``[mcp]`` extra when the MCP path is never used.
+    """
+    from bili.iris.mcp.server import (  # pylint: disable=import-outside-toplevel
+        IN_MCP_TOOL_CALL,
+    )
+
+    return IN_MCP_TOOL_CALL.get()
+
+
+def _build_ask_user_func(responder: HitlResponder):
+    """Return the tool ``func``, dispatching to the native or MCP pause path.
+
+    A thin context check, not business logic: the two pause mechanisms
+    (:func:`_ask_user_native_impl`, :func:`_ask_user_mcp_impl`) are separate
+    functions because they are genuinely different operations (one raises to
+    pause a graph, one blocks synchronously calling out to a host callback),
+    not two branches of one algorithm.
     """
 
     def _ask_user(question: str, options: Optional[List[str]] = None) -> str:
-        # pylint: disable=import-outside-toplevel
-        from langgraph.types import interrupt
-
-        payload = {"type": ASK_USER_TOOL_NAME, "question": question, "options": options}
-        answer = interrupt(payload)
-        return str(answer)
+        if _called_via_mcp_bridge():
+            return _ask_user_mcp_impl(question, options, responder)
+        return _ask_user_native_impl(question, options)
 
     return _ask_user
 
@@ -104,22 +190,21 @@ def register_ask_user_tool(responder: Optional[HitlResponder] = None) -> None:
     :data:`~bili.iris.loaders.tools_loader.TOOL_REGISTRY` under a
     ``(name, prompt, params) -> Tool`` factory that ignores its arguments,
     since (unlike the domain tools in ``tools_loader.py``) ``ask_user`` has
-    no per-call configuration on the native tool-calling path.
+    no per-call configuration.
 
     Calling this twice without an intervening :func:`unregister_ask_user_tool`
-    replaces the previously registered tool; a warning is logged so a host
-    does not silently lose track of a prior registration.
+    replaces the previously registered tool (and its responder); a warning is
+    logged so a host does not silently lose track of a prior registration.
 
-    :param responder: Reserved for the CLI/MCP tool-strategy path, where
-        there is no LangGraph node to interrupt and a
-        :class:`~bili.iris.tools.hitl.HitlResponder` is the only pause
-        mechanism available. The native (``create_agent``) tool built here
-        does not call *responder* -- on that path ``interrupt()`` /
-        ``Command(resume=...)`` IS the answer-delivery mechanism. Passing
-        *responder* now is forward-compatible with the CLI/MCP path landing
-        later; it has no effect on native tool-calling behavior today.
+    :param responder: The host's :class:`~bili.iris.tools.hitl.HitlResponder`,
+        consulted on the CLI/MCP tool-strategy path (there is no LangGraph
+        node to interrupt there). The native (``create_agent``) path does
+        not call *responder* -- ``interrupt()`` / ``Command(resume=...)`` IS
+        the answer-delivery mechanism on that path; *responder* is inert for
+        agents that never resolve to ``tool_strategy="mcp"``.
         Defaults to :class:`~bili.iris.tools.hitl.NullHitlResponder` when
-        omitted.
+        omitted, so an unconfigured CLI-path ``ask_user`` call degrades to
+        the no-response sentinel instead of raising.
     """
     if ASK_USER_TOOL_NAME in TOOL_REGISTRY:
         LOGGER.warning(
@@ -128,14 +213,10 @@ def register_ask_user_tool(responder: Optional[HitlResponder] = None) -> None:
             ASK_USER_TOOL_NAME,
         )
 
-    # Constructed for parity with the eventual CLI/MCP-path registration
-    # (which will actually call it) and to validate *responder* satisfies
-    # the HitlResponder protocol now rather than failing later, silently,
-    # the first time a CLI-path ask_user call needs it.
     effective_responder = responder if responder is not None else NullHitlResponder()
 
     tool = StructuredTool.from_function(
-        func=_build_ask_user_func(),
+        func=_build_ask_user_func(effective_responder),
         name=ASK_USER_TOOL_NAME,
         description=_ASK_USER_DESCRIPTION,
     )
@@ -146,8 +227,7 @@ def register_ask_user_tool(responder: Optional[HitlResponder] = None) -> None:
         lambda _n, _p, _params, _t=tool: _t  # noqa: E731
     )
     LOGGER.info(
-        "TOOL_REGISTRY: registered '%s' (responder=%s reserved for the "
-        "CLI/MCP tool-strategy path)",
+        "TOOL_REGISTRY: registered '%s' (responder=%s)",
         ASK_USER_TOOL_NAME,
         type(effective_responder).__name__,
     )

--- a/bili/iris/tools/hitl.py
+++ b/bili/iris/tools/hitl.py
@@ -15,6 +15,7 @@ its own :meth:`HitlResponder.ask` (see :class:`ScriptedHitlResponder` for the
 shape of a minimal implementation).
 """
 
+import threading
 from typing import List, Optional, Protocol, runtime_checkable
 
 from bili.utils.logging_utils import get_logger
@@ -37,13 +38,22 @@ NO_RESPONSE_PREFIX = "[no response:"
 class HitlResponder(Protocol):
     """Host-implemented callback that blocks until a human answers a question.
 
-    A single instance is registered once per process (or per run) via
+    A single instance is registered once per process (or run) via
     :func:`bili.iris.tools.ask_user.register_ask_user_tool` and is shared by
-    every ``ask_user`` tool call that instance's registration produced. An
-    implementation backing more than one concurrent agent run (e.g. several
-    MAS runs fanned out in parallel by a host) must be safe to call from
-    multiple threads at once, since each in-flight ``ask_user`` call blocks
-    the thread that made it.
+    every ``ask_user`` call that registration produced, across BOTH pause
+    mechanisms (the native ``interrupt()`` path calls :meth:`ask` indirectly
+    via a graph resume, the CLI/MCP path calls it directly and blocks on it).
+
+    Thread safety is a host-side contract this protocol does not enforce but
+    every implementation must honor: more than one ``ask_user`` call can be
+    in flight AT THE SAME TIME against the same responder instance whenever
+    a host runs multiple agent RUNS concurrently (e.g. a fan-out batch of N
+    MAS runs, each potentially raising its own question). Each in-flight
+    call blocks the thread that made it, so :meth:`ask` -- and any shared
+    state it reads or writes -- must be safe to call from multiple threads
+    at once. A responder that renders questions into a single-consumer UI
+    (one prompt at a time) must serialize or queue internally rather than
+    silently interleaving or corrupting concurrent calls.
     """
 
     def ask(self, question: str, options: Optional[List[str]] = None) -> str:
@@ -97,12 +107,18 @@ class ScriptedHitlResponder:
     Not a production responder. Used by bili-core's own tests, and usable by
     a host's tests, to exercise the ``ask_user`` pause/resume seam without a
     real human or a real event loop.
+
+    Thread-safe: a lock guards the append-then-index sequence in :meth:`ask`
+    so concurrent calls (e.g. a test that fans out several agent runs against
+    one shared responder) get distinct, correctly-ordered answers rather than
+    racing on the shared call count.
     """
 
     def __init__(self, answers: List[str]) -> None:
         """:param answers: Answers returned in order, one per :meth:`ask` call."""
         self._answers = list(answers)
         self._calls: List[dict] = []
+        self._lock = threading.Lock()
 
     def ask(self, question: str, options: Optional[List[str]] = None) -> str:
         """Record the call and return the next scripted answer.
@@ -111,13 +127,15 @@ class ScriptedHitlResponder:
             answers -- a test bug (the script under-provisioned answers),
             not a runtime condition to degrade gracefully from.
         """
-        self._calls.append({"question": question, "options": options})
-        return self._answers[len(self._calls) - 1]
+        with self._lock:
+            self._calls.append({"question": question, "options": options})
+            return self._answers[len(self._calls) - 1]
 
     @property
     def calls(self) -> List[dict]:
         """The ``{"question", "options"}`` dicts recorded for each :meth:`ask` call."""
-        return list(self._calls)
+        with self._lock:
+            return list(self._calls)
 
 
 __all__ = [

--- a/bili/iris/tools/tests/test_ask_user.py
+++ b/bili/iris/tools/tests/test_ask_user.py
@@ -1,14 +1,20 @@
-"""Unit tests for bili.iris.tools.ask_user registration/unregistration.
+"""Unit tests for bili.iris.tools.ask_user registration and dispatch.
 
-End-to-end pause/resume behavior is covered by the integration tests
-(test_ask_user_iris_integration.py, and AETHER's
-test_ask_user_aether_integration.py) -- this module covers the registration
-lifecycle and edge cases those don't exercise: double registration,
-unregister when absent, and the tool's shape (name/description/schema)
-independent of a running graph.
+End-to-end pause/resume behavior through a REAL compiled graph is covered by
+the integration tests (test_ask_user_iris_integration.py,
+test_ask_user_aether_integration.py) and the real MCP-server integration test
+(bili/iris/mcp/tests/test_ask_user_mcp_integration.py) -- this module covers
+the registration lifecycle and the dispatcher's own unit-level behavior:
+double registration, unregister when absent, the tool's shape
+(name/description/schema), and which of the two pause-path implementations
+gets called for a given calling context.
 """
 
-# pylint: disable=missing-function-docstring
+# pylint: disable=missing-function-docstring,import-outside-toplevel
+# Test-scoped imports (langgraph internals, IN_MCP_TOOL_CALL) are deferred to
+# inside individual test functions so each test's dependency is visible right
+# where it is used, and so importing this module never requires the [mcp]
+# extra just to collect the tests that do not exercise the MCP path.
 
 import logging
 
@@ -20,7 +26,7 @@ from bili.iris.tools.ask_user import (
     register_ask_user_tool,
     unregister_ask_user_tool,
 )
-from bili.iris.tools.hitl import ScriptedHitlResponder
+from bili.iris.tools.hitl import NO_RESPONSE_PREFIX, ScriptedHitlResponder
 
 
 class TestRegisterAskUserTool:
@@ -48,19 +54,106 @@ class TestRegisterAskUserTool:
         assert schema_fields["question"].is_required()
         assert not schema_fields["options"].is_required()
 
-    def test_tool_func_reaches_interrupt_outside_a_graph(self):
-        """Confirms the native tool's func calls langgraph.types.interrupt()
-        rather than silently returning a placeholder, by observing the
-        specific failure interrupt() itself raises when called with no
-        active LangGraph runnable context: RuntimeError from
-        langgraph.config.get_config(), not GraphInterrupt (GraphInterrupt
-        requires the runnable-context machinery interrupt() failed to find
-        here). The pause/resume-with-an-answer path is exercised for real
-        inside a compiled graph by the integration tests
+    def test_tool_func_reaches_interrupt_inside_a_graph(self):
+        """Confirms the dispatcher routes to the native (interrupt()) impl
+        when called from inside a LangGraph runnable context, by observing
+        the specific failure interrupt() itself raises when there is no
+        resume value available yet: RuntimeError from
+        langgraph.config.get_config() is what fires OUTSIDE a runnable
+        context (the MCP-path branch, covered separately below); INSIDE one
+        with no prior resume, interrupt() raises GraphInterrupt. The full
+        pause/resume-with-an-answer path is exercised for real inside a
+        compiled graph by the integration tests
         (test_ask_user_iris_integration.py, test_ask_user_aether_integration.py).
+        """
+        from langchain_core.messages import HumanMessage
+        from langgraph.checkpoint.memory import MemorySaver
+        from langgraph.errors import GraphBubbleUp
+        from langgraph.graph import END, START, StateGraph
+
+        from bili.utils.langgraph_utils import State
+
+        register_ask_user_tool()
+        tool = TOOL_REGISTRY[ASK_USER_TOOL_NAME](None, None, {})
+
+        raised = {}
+
+        def node(state):  # pylint: disable=unused-argument
+            try:
+                tool.func(question="Which environment?")
+            except GraphBubbleUp as exc:
+                raised["exc"] = exc
+            return {"messages": []}
+
+        graph = StateGraph(State)
+        graph.add_node("n", node)
+        graph.add_edge(START, "n")
+        graph.add_edge("n", END)
+        compiled = graph.compile(checkpointer=MemorySaver())
+        compiled.invoke(
+            {"messages": [HumanMessage(content="hi")]},
+            config={"configurable": {"thread_id": "t1"}},
+        )
+
+        assert "exc" in raised, "expected interrupt() to raise inside a graph node"
+
+    def test_tool_func_calls_responder_via_mcp_bridge(self):
+        """Confirms the dispatcher routes to the MCP (responder-calling)
+        impl when IN_MCP_TOOL_CALL is set -- the exact signal
+        bili.iris.mcp.server._build_mcp_fn sets around its own
+        tool.invoke(...) call. This is a real, distinguishing signal;
+        merely being "outside a graph" is NOT (a bare tool.invoke() call,
+        which the MCP bridge also makes, already populates LangChain's
+        ambient RunnableConfig, so langgraph.config.get_config() succeeds
+        in both contexts and cannot be used to tell them apart -- see the
+        ask_user module docstring's "Dispatch signal" section).
+        """
+        from bili.iris.mcp.server import IN_MCP_TOOL_CALL
+
+        responder = ScriptedHitlResponder(["staging"])
+        register_ask_user_tool(responder)
+        tool = TOOL_REGISTRY[ASK_USER_TOOL_NAME](None, None, {})
+
+        token = IN_MCP_TOOL_CALL.set(True)
+        try:
+            answer = tool.func(question="Which environment?")
+        finally:
+            IN_MCP_TOOL_CALL.reset(token)
+
+        assert answer == "staging"
+        assert responder.calls == [{"question": "Which environment?", "options": None}]
+
+    def test_tool_func_via_mcp_bridge_with_no_responder_returns_sentinel(self):
+        """Via the MCP bridge with no responder registered, the dispatcher's
+        MCP-path branch reaches NullHitlResponder's no-response sentinel
+        rather than raising -- an unconfigured CLI-path ask_user degrades
+        gracefully instead of crashing the calling CLI subprocess's turn.
+        """
+        from bili.iris.mcp.server import IN_MCP_TOOL_CALL
+
+        register_ask_user_tool()
+        tool = TOOL_REGISTRY[ASK_USER_TOOL_NAME](None, None, {})
+
+        token = IN_MCP_TOOL_CALL.set(True)
+        try:
+            answer = tool.func(question="Which environment?")
+        finally:
+            IN_MCP_TOOL_CALL.reset(token)
+
+        assert answer.startswith(NO_RESPONSE_PREFIX)
+
+    def test_tool_func_outside_a_graph_and_outside_mcp_bridge_raises(self):
+        """Called neither via a graph nor via the MCP bridge (e.g. a stray
+        direct call), the dispatcher falls through to the native path, which
+        calls langgraph.types.interrupt() and raises RuntimeError there --
+        proof that this fallback genuinely reaches interrupt() rather than
+        silently returning a placeholder. This is the correct default: an
+        untracked calling context is not silently assumed to be the MCP
+        bridge.
         """
         register_ask_user_tool()
         tool = TOOL_REGISTRY[ASK_USER_TOOL_NAME](None, None, {})
+
         with pytest.raises(RuntimeError, match="runnable context"):
             tool.func(question="Which environment?")
 
@@ -76,10 +169,6 @@ class TestRegisterAskUserTool:
         assert first_tool is not second_tool
 
     def test_accepts_explicit_responder_without_error(self):
-        # Chunk 1: the native tool does not call *responder* (see
-        # _build_ask_user_func's docstring) -- this test only verifies
-        # register_ask_user_tool() accepts one without raising, ahead of the
-        # CLI/MCP-path wiring that will consume it.
         responder = ScriptedHitlResponder(["staging"])
         register_ask_user_tool(responder)
         assert ASK_USER_TOOL_NAME in TOOL_REGISTRY

--- a/bili/iris/tools/tests/test_hitl.py
+++ b/bili/iris/tools/tests/test_hitl.py
@@ -5,11 +5,19 @@ Covers:
 - ScriptedHitlResponder cycles scripted answers and records calls.
 - ScriptedHitlResponder raises when the script is exhausted (a test-authoring
   bug, not a runtime condition to degrade from).
+- ScriptedHitlResponder is genuinely thread-safe under real concurrent
+  access (not just "has a lock") -- the documented contract every
+  HitlResponder implementation must honor, since a fan-out batch of agent
+  runs can have more than one ask_user call in flight against one
+  responder at once.
 - HitlResponder is runtime_checkable and isinstance-matches any object with
   a compatible ask() method (structural typing, not a required base class).
 """
 
 # pylint: disable=missing-function-docstring
+
+import threading
+import time
 
 import pytest
 
@@ -19,6 +27,22 @@ from bili.iris.tools.hitl import (
     NullHitlResponder,
     ScriptedHitlResponder,
 )
+
+
+class _NoOpLock:
+    """Context-manager stand-in for threading.Lock() that acquires nothing.
+
+    Swapped onto a ScriptedHitlResponder instance's _lock attribute in
+    test_lock_prevents_the_append_then_read_race to simulate "the lock was
+    never added" while running the exact same ask() method body -- proves
+    the real lock is what prevents the race, not a synthetic twin class.
+    """
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
 
 
 class TestNullHitlResponder:
@@ -68,3 +92,91 @@ class TestScriptedHitlResponder:
 
     def test_satisfies_hitl_responder_protocol(self):
         assert isinstance(ScriptedHitlResponder([]), HitlResponder)
+
+    def test_concurrent_calls_get_distinct_correctly_ordered_answers(self):
+        """N threads calling ask() at once against ONE responder each get a
+        distinct answer with no lost update or duplicate index.
+        """
+        n = 20
+        answers = [str(i) for i in range(n)]
+        responder = ScriptedHitlResponder(answers)
+        results = []
+        results_lock = threading.Lock()
+
+        def worker(i):
+            answer = responder.ask(f"question {i}")
+            with results_lock:
+                results.append(answer)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert len(results) == n
+        assert len(set(results)) == n, "expected all answers distinct, got a collision"
+        assert len(responder.calls) == n
+
+    def test_lock_prevents_the_append_then_read_race(self):
+        """Directly proves the lock in ScriptedHitlResponder.ask is load-bearing.
+
+        A bare append-then-read race is often NOT observable under CPython's
+        GIL without deliberately widening the window (individual list
+        operations are fast enough to rarely get preempted), so a plain
+        concurrent-calls test can pass by GIL-timing luck without the lock
+        actually doing anything -- a false sense of coverage. This test
+        widens the window INSIDE the real class's real critical section (a
+        slow-appending list stands in for self._calls, so the delay happens
+        between the append and the length-read the lock is meant to guard)
+        and shows the class collides with the lock removed but not with it
+        present, using the actual production code path both times -- not a
+        synthetic stand-in class.
+        """
+        n = 20
+        answers = [str(i) for i in range(n)]
+
+        class _SlowAppendList(list):
+            """A list whose append() sleeps, widening the race window that
+            follows it (the read of len(self)) for whichever code holds
+            (or fails to hold) the responder's lock across both operations.
+            """
+
+            def append(self, item):
+                super().append(item)
+                time.sleep(0.005)
+
+        def _run_concurrently(responder):
+            results = []
+            results_lock = threading.Lock()
+
+            def worker(i):
+                answer = responder.ask(f"question {i}")
+                with results_lock:
+                    results.append(answer)
+
+            threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+            return results
+
+        locked = ScriptedHitlResponder(answers)
+        locked._calls = _SlowAppendList()  # pylint: disable=protected-access
+        locked_results = _run_concurrently(locked)
+        assert len(set(locked_results)) == n, (
+            "the real, locked ScriptedHitlResponder must not collide even "
+            "with the append-then-read window deliberately widened"
+        )
+
+        unlocked = ScriptedHitlResponder(answers)
+        unlocked._calls = _SlowAppendList()  # pylint: disable=protected-access
+        unlocked._lock = _NoOpLock()  # pylint: disable=protected-access
+        unlocked_results = _run_concurrently(unlocked)
+        assert len(set(unlocked_results)) < n, (
+            "expected the lock-defeated instance to collide under the "
+            "widened race window -- if it did not, the race-window "
+            "widening stopped working and this test needs a wider delay, "
+            "not a passing grade"
+        )


### PR DESCRIPTION
## Summary

Extends `ask_user` (merged in #240: the native tool-calling human-in-the-loop
pause/resume seam) to the CLI/MCP tool-strategy path -- the flagship
no-API-key path, where an agentic CLI (Claude Code, Codex, Gemini CLI) is
served the tool over the ephemeral authenticated MCP server and
self-orchestrates. There is no LangGraph node to `interrupt()` there, so
`ask_user` instead blocks by calling a registered `HitlResponder` directly.

## The dispatch problem and its fix

`resolve_tools()` resolves an agent's tool list *before* `tool_strategy` is
known, so the exact same `TOOL_REGISTRY["ask_user"]` tool object is handed to
both the native (`create_agent`) and CLI/MCP (`EphemeralMcpServer`) paths.
The tool's `func` therefore has to dispatch at call time to one of two
separate, single-purpose implementations:

- `_ask_user_native_impl` (unchanged): calls `langgraph.types.interrupt()`.
- `_ask_user_mcp_impl` (new): blocks by calling `HitlResponder.ask(...)`
  directly.

The first (and wrong) approach tried was checking
`langgraph.config.get_config()` to detect "am I inside a LangGraph node."
A real MCP round trip showed this fails: calling *any* LangChain
`Runnable.invoke()` -- which both `ToolNode` (native) and
`bili.iris.mcp.server._build_mcp_fn` (MCP) do -- populates LangChain's own
ambient `RunnableConfig` propagation contextvar regardless of LangGraph
involvement, so `get_config()` succeeds in both contexts and cannot tell
them apart.

The fix is `bili.iris.mcp.server.IN_MCP_TOOL_CALL`, a `contextvars.ContextVar`
the ephemeral MCP bridge sets (token-scoped) around its own
`tool.invoke(...)` call. This is bili-core's own, narrower signal, true only
for the duration of a call the MCP bridge itself made. It is generic (any
tool can read it, not just `ask_user`), so `EphemeralMcpServer` still
registers whatever LangChain tool it is given without knowing anything about
`ask_user` -- no tool-specific server code was added.

## Other changes

- **Thread safety** (`bili/iris/tools/hitl.py`): `HitlResponder`'s docstring
  now states explicitly that more than one `ask_user` call can be in flight
  at once against the same responder instance (e.g. a host running several
  agent runs concurrently), so `ask()` must be safe to call from multiple
  threads. `ScriptedHitlResponder` gets a lock so it actually honors this --
  its prior append-then-index sequence was a real race.
- **Timeout validation warning** (`bili/aether/validation/validator.py`,
  `W14`): warns when an agent combines `ask_user` with a CLI
  `tool_strategy='mcp'` model and an explicit `cli_subprocess_timeout` below
  a 5-minute floor. That timeout is a blunt instrument: if it expires before
  a human answers, the *entire turn* is discarded, not just the pending
  question. Leaving the timeout unset (preset default 1800s) or explicitly 0
  (no timeout) is not flagged.

## Test plan

- [x] `bili/iris/mcp/tests/test_ask_user_mcp_integration.py` -- a REAL
  `EphemeralMcpServer` (real uvicorn thread, real FastMCP tool registration)
  driven by a real MCP streamable-HTTP client, matching the round trip a
  spawned CLI subprocess's own internal tool-calling loop makes. Covers: the
  blocking call returns the responder's answer, `options` forwards correctly,
  no-responder falls back to the sentinel, the call genuinely blocks for the
  responder's full duration (timing-based proof), and two concurrent calls
  against one shared responder do not cross answers.
- [x] `bili/iris/tools/tests/test_hitl.py` -- `ScriptedHitlResponder`'s lock
  is verified against the *real* class (not a synthetic stand-in): a
  slow-appending list plus a no-op lock swapped onto the real instance
  reproduce the race deterministically, confirming the shipped lock actually
  prevents it (not just "looks thread-safe").
- [x] `bili/iris/tools/tests/test_ask_user.py` -- dispatcher unit coverage
  for all three contexts (native graph, MCP bridge, neither).
- [x] `bili/aether/tests/test_validator.py` -- 7 new cases for `W14`
  (fires/doesn't fire across timeout value, model type, and tool presence).
- [x] Full `bili/iris/` (1866 tests) and `bili/aether/` (1269 of 1270; 1
  pre-existing worktree-only failure in `bili/aegis`, confirmed unrelated via
  `git stash`, same as #240) pass.
- [x] `pylint bili/ --fail-under=9`: 9.64/10 (new/touched production files
  10.00/10 or 100% pre-existing findings only).
- [x] Per-file coverage: `ask_user.py`, `hitl.py`, `mcp/server.py` all
  100%; `validator.py` 98%; all touched files clear the 90% gate.

## Explicitly out of scope

The prompted/facilitated ReAct loop still needs its own mechanism (its
hand-rolled tool-execution `except Exception` would currently swallow a
`GraphInterrupt`) and is not built here.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

https://claude.ai/code/session_01XpXRrbE4UhL22Usj6UdEVQ