### PR TITLE
fix: lazily import amazon_opensearch so sibling tool submodules import cleanly (closes #243)

### DIFF
--- a/bili/iris/tools/__init__.py
+++ b/bili/iris/tools/__init__.py
@@ -1,15 +1,15 @@
-from . import (
-    amazon_opensearch,
-    api_open_weather,
-    api_serp,
-    api_weather_gov,
-    ask_user,
-    faiss_memory_indexing,
-    hitl,
-    mock_tool,
-)
+"""bili.iris.tools: built-in LangChain tool implementations.
 
-__all__ = [
+Submodules are loaded lazily so that importing bili.iris.tools (or any one
+sibling submodule) does not eagerly pull in heavy optional backends:
+- ``amazon_opensearch`` requires ``opensearch-py`` / ``requests-aws4auth``
+  (OpenSearch extra)
+- ``faiss_memory_indexing`` requires ``faiss-cpu`` (FAISS extra)
+
+Only the modules the caller actually accesses are imported.
+"""
+
+_LAZY_SUBMODULES = {
     "amazon_opensearch",
     "api_open_weather",
     "api_serp",
@@ -18,4 +18,21 @@ __all__ = [
     "faiss_memory_indexing",
     "hitl",
     "mock_tool",
-]
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_SUBMODULES:
+        import importlib  # pylint: disable=import-outside-toplevel
+
+        module = importlib.import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return list(_LAZY_SUBMODULES)
+
+
+__all__ = sorted(_LAZY_SUBMODULES)

--- a/bili/tests/test_lean_core_imports.py
+++ b/bili/tests/test_lean_core_imports.py
@@ -289,6 +289,25 @@ class TestLeanCoreImports:
 
             assert QueryableMemorySaver is not None
 
+    def test_amazon_opensearch_not_imported_on_sibling_tool_access(self):
+        """Importing a sibling bili.iris.tools submodule does not pull in opensearch-py.
+
+        bili.iris.tools.__init__ lazily loads its submodules (PEP 562), so
+        importing bili.iris.tools.mock_tool must not trigger
+        bili.iris.tools.amazon_opensearch's own module-level opensearch-py
+        import as a side effect of the package __init__ running. Checking
+        for the absence of "bili.iris.tools.amazon_opensearch" in
+        sys.modules (rather than "opensearchpy" itself) sidesteps
+        _blocked_modules' own None-sentinel, which is always a key present
+        in sys.modules while active -- see
+        test_opensearch_utils_not_imported_on_utils_access for the same
+        pattern.
+        """
+        with _blocked_modules(["opensearchpy"]):
+            import bili.iris.tools.mock_tool  # pylint: disable=import-outside-toplevel,unused-import
+
+            assert "bili.iris.tools.amazon_opensearch" not in sys.modules
+
 
 # ---------------------------------------------------------------------------
 # PEP 562 lazy-loader __init__.py coverage
@@ -383,6 +402,44 @@ class TestLazyLoaderInits:
         assert "memory_checkpointer" in names
         assert "mongo_checkpointer" in names
         assert "pg_checkpointer" in names
+
+    # ------------------------------------------------------------------
+    # bili/iris/tools/__init__.py
+    # ------------------------------------------------------------------
+
+    def test_iris_tools_getattr_loads_known_submodule(self):
+        """Accessing a known submodule via bili.iris.tools.__getattr__ imports it."""
+        import importlib  # pylint: disable=import-outside-toplevel
+
+        saved = sys.modules.pop("bili.iris.tools", None)
+        try:
+            pkg = importlib.import_module("bili.iris.tools")
+            mod = pkg.__getattr__("mock_tool")
+            assert mod is not None
+            assert hasattr(mod, "init_mock_tool")
+        finally:
+            if saved is not None:
+                sys.modules["bili.iris.tools"] = saved
+
+    def test_iris_tools_getattr_raises_for_unknown_name(self):
+        """Accessing an unknown attribute via bili.iris.tools.__getattr__ raises."""
+        import importlib  # pylint: disable=import-outside-toplevel
+
+        import pytest as _pytest  # pylint: disable=import-outside-toplevel
+
+        pkg = importlib.import_module("bili.iris.tools")
+        with _pytest.raises(AttributeError, match="has no attribute"):
+            pkg.__getattr__("_nonexistent_xyz")
+
+    def test_iris_tools_dir_returns_submodule_names(self):
+        """bili.iris.tools.__dir__() returns the declared lazy submodule names."""
+        import importlib  # pylint: disable=import-outside-toplevel
+
+        pkg = importlib.import_module("bili.iris.tools")
+        names = pkg.__dir__()
+        assert "amazon_opensearch" in names
+        assert "faiss_memory_indexing" in names
+        assert "mock_tool" in names
 
     # ------------------------------------------------------------------
     # bili/iris/loaders/__init__.py


### PR DESCRIPTION
## Summary

`bili/iris/tools/__init__.py` eagerly imported every tool submodule,
including `amazon_opensearch`, which pulls in `opensearch-py` and
`requests-aws4auth` at package-init time. Because Python always runs a
package's `__init__.py` before resolving any of its submodules, this meant
`import bili.iris.tools.<anything>` failed in an install that has other
extras (e.g. `[mcp]`) but not the OpenSearch backend, even for a submodule
with no OpenSearch dependency of its own.

## Fix

Converts `bili/iris/tools/__init__.py` to the PEP 562 lazy-loader pattern
already used by `bili/iris/checkpointers/__init__.py` and
`bili/iris/loaders/__init__.py`: a module `__getattr__` resolves each
submodule name on first access and caches it in `globals()`, instead of
importing every submodule unconditionally at package-init time.

`from bili.iris.tools import amazon_opensearch` still works exactly as
before, lazily, once the real dependency is installed; only the eager
side effect on unrelated sibling imports is removed.

## Test plan

- [x] New regression test
  (`test_amazon_opensearch_not_imported_on_sibling_tool_access` in
  `bili/tests/test_lean_core_imports.py`) asserts
  `"bili.iris.tools.amazon_opensearch" not in sys.modules` after importing
  a sibling submodule with `opensearchpy` blocked from `sys.modules`.
  Verified the test fails against the pre-fix `__init__.py` with the exact
  reported `ModuleNotFoundError`, and passes against the fix.
- [x] Reproduced the original failure directly: a fresh venv with `[mcp,dev]`
  installed but not `opensearch-py` failed on
  `import bili.iris.tools.mock_tool` before the fix, succeeds after.
- [x] Added the standard three-branch `TestLazyLoaderInits` coverage for
  `bili.iris.tools` (`__getattr__` loads a known submodule,
  `__getattr__` raises for an unknown name, `__dir__` returns the
  declared submodule set), matching the existing coverage for the sibling
  lazy-loader packages.
- [x] Full `bili/iris/` (1866 tests) and `bili/tests/` (46 tests) pass with
  the OpenSearch extra installed; the sibling-tool test suite
  (91 tests, excluding the one file that legitimately tests
  `amazon_opensearch` itself) passes with the OpenSearch extra
  deliberately absent.
- [x] `pylint bili/ --fail-under=9`: 9.65/10, no new finding categories;
  the touched `__init__.py` is clean.
- [x] Coverage: `bili/iris/tools/__init__.py` at 100%.

Closes #243

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

https://claude.ai/code/session_01XpXRrbE4UhL22Usj6UdEVQ
